### PR TITLE
fix: add appium_get_page_source tool

### DIFF
--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -25,6 +25,7 @@ This directory contains all MCP tools available in MCP Appium.
   - `double-tap.ts` - Double tap elements
   - `set-value.ts` - Enter text
   - `get-text.ts` - Get element text
+  - `get-page-source.ts` - Get page source (XML) from current screen
   - `screenshot.ts` - Capture screenshots
   - `activate-app.ts` - Activate apps
   - `terminate-app.ts` - Terminate apps

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -31,6 +31,7 @@ import clickElement from './interactions/click.js';
 import doubleTap from './interactions/double-tap.js';
 import setValue from './interactions/set-value.js';
 import getText from './interactions/get-text.js';
+import getPageSource from './interactions/get-page-source.js';
 import screenshot from './interactions/screenshot.js';
 import activateApp from './interactions/activate-app.js';
 import installApp from './interactions/install-app.js';
@@ -127,6 +128,7 @@ export default function registerTools(server: FastMCP): void {
   doubleTap(server);
   setValue(server);
   getText(server);
+  getPageSource(server);
   screenshot(server);
   generateTest(server);
   log.info('All tools registered');

--- a/src/tools/interactions/get-page-source.ts
+++ b/src/tools/interactions/get-page-source.ts
@@ -1,0 +1,52 @@
+import { FastMCP } from 'fastmcp/dist/FastMCP.js';
+import { z } from 'zod';
+import { getDriver } from '../session-store.js';
+
+export default function getPageSource(server: FastMCP): void {
+  server.addTool({
+    name: 'appium_get_page_source',
+    description: 'Get the page source (XML) from the current screen',
+    parameters: z.object({}),
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    execute: async (args: any, context: any): Promise<any> => {
+      const driver = getDriver();
+      if (!driver) {
+        throw new Error('No driver found. Please create a session first.');
+      }
+
+      try {
+        const pageSource = await driver.getPageSource();
+
+        if (!pageSource) {
+          throw new Error('Page source is empty or null');
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                'Page source retrieved successfully: \n' +
+                '```xml ' +
+                pageSource +
+                '```',
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to get page source. Error: ${err.toString()}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/appium/appium-mcp/issues/22

Currently, we don’t have an MCP tool to retrieve the application’s page source, so I’ve added support for it.

Attached the output from the cursor:
<img width="562" height="909" alt="Screenshot 2025-11-08 at 9 10 23 PM" src="https://github.com/user-attachments/assets/2b4c4bc6-360f-4c27-bac0-7fdb5b8e823f" />
