### PR TITLE
fix: prioritize explicit capabilities over auto-detected platformVersion

### DIFF
--- a/src/tools/create-session.ts
+++ b/src/tools/create-session.ts
@@ -148,9 +148,10 @@ async function buildIOSCapabilities(
 
   const capabilities = {
     ...defaultCaps,
+    // Auto-detected platform version as fallback (before config)
+    ...(platformVersion && { 'appium:platformVersion': platformVersion }),
     ...configCaps,
     ...(selectedDeviceUdid && { 'appium:udid': selectedDeviceUdid }),
-    ...(platformVersion && { 'appium:platformVersion': platformVersion }),
     ...(deviceType === 'simulator' && {
       'appium:usePrebuiltWDA': true,
       'appium:wdaStartupRetries': 4,


### PR DESCRIPTION
## Problem

When creating iOS sessions with explicit `platformVersion` in capabilities, the auto-detected platform version from `node-simctl` was overwriting the explicit value. This caused the error:

```
'' cannot be coerced to a valid version number
```

This occurred because the capability merge order in `buildIOSCapabilities()` placed auto-detected `platformVersion` **after** `configCaps`, causing explicit values to be overwritten.

## Solution

Reordered the capability merge in `src/tools/create-session.ts:149-161` to place auto-detected `platformVersion` **before** `configCaps` and `customCaps`:

**Before:**
```typescript
const capabilities = {
  ...defaultCaps,
  ...configCaps,              // Explicit config
  ...(platformVersion && { 'appium:platformVersion': platformVersion }), // OVERWRITES explicit!
  ...customCaps,
};
```

**After:**
```typescript
const capabilities = {
  ...defaultCaps,
  ...(platformVersion && { 'appium:platformVersion': platformVersion }), // Fallback
  ...configCaps,              // Explicit config overrides
  ...customCaps,              // Custom overrides everything
};
```

## Impact

- ✅ Explicit `platformVersion` from `capabilities` parameter now properly overrides auto-detection
- ✅ Explicit `platformVersion` from `CAPABILITIES_CONFIG` file properly overrides auto-detection
- ✅ Auto-detected `platformVersion` still works as fallback when not explicitly provided
- ✅ Eliminates need for `CAPABILITIES_CONFIG` env var workaround in many cases

## Testing

Tested with iOS simulator session creation:
1. **Without fix**: Error when `node-simctl` returns empty runtime string
2. **With fix**: Session creates successfully using explicit `platformVersion` from capabilities