### PR TITLE
chore: Update Appium MCP configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,14 @@ To integrate MCP Appium with your MCP client, add the following to your configur
 ```json
 {
   "mcpServers": {
-    "mcp-appium": {
+    "appium-mcp": {
       "disabled": false,
       "timeout": 100,
       "type": "stdio",
       "command": "npx",
-      "args": ["appium-mcp"],
+      "args": [
+        "appium-mcp@latest"
+      ],
       "env": {
         "ANDROID_HOME": "/path/to/android/sdk",
         "CAPABILITIES_CONFIG": "/path/to/your/capabilities.json"


### PR DESCRIPTION
This pull request updates the configuration instructions in the `README.md` for integrating MCP Appium with your MCP client. The changes clarify the server naming and ensure the latest version of `appium-mcp` is used.

Configuration update:

* Renamed the server key from `mcp-appium` to `appium-mcp` for consistency.
* Updated the `args` array to specify `"appium-mcp@latest"` instead of just `"appium-mcp"`, ensuring that the latest version is used when running the command.