### PR TITLE
fix: fix the scheme version for modelcontextprotocol

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -29,7 +29,7 @@
     }],
     "@semantic-release/npm",
     ["@semantic-release/git", {
-      "assets": ["docs", "package.json", "CHANGELOG.md"],
+      "assets": ["docs", "package.json", "package-lock.json", "CHANGELOG.md", "server.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     "@semantic-release/github"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "check": "npm run lint && npm run format:check",
     "index-docs": "node dist/scripts/simple-index-documentation.js",
     "query-docs": "node dist/scripts/simple-query-documentation.js",
-    "prepublish": "npm run build"
+    "sync-version":  "node scripts/sync-version.mjs",
+    "prepublish": "npm run sync-version && npm run build"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'fs';
+
+const packageJson = JSON.parse(readFileSync('package.json', 'utf8'));
+const serverJson = JSON.parse(readFileSync('server.json', 'utf8'));
+
+const version = packageJson.version;
+
+// Update server.json version
+serverJson.version = version;
+serverJson.packages[0].version = version;
+
+writeFileSync('server.json', JSON.stringify(serverJson, null, 2) + '\n');
+
+console.log(`✓ Synced version to ${version}`);

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.appium/appium-mcp",
   "title": "MCP Appium - Mobile Development and Automation Server",
   "description": "MCP server for Appium mobile automation on iOS and Android devices with test creation tools.",
-  "version": "1.1.11",
+  "version": "1.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "appium-mcp",
-      "version": "1.1.11",
+      "version": "1.7.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Fixes https://github.com/appium/appium-mcp/actions/runs/20707249816/job/59440095150
Also, this PR adds a script to sync the version in `server.json` as well