### PR TITLE
chore: run in version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "index-docs": "node dist/scripts/simple-index-documentation.js",
     "query-docs": "node dist/scripts/simple-query-documentation.js",
     "sync-version": "node scripts/sync-version.mjs",
-    "prepare": "npm run sync-version && npm run build"
+    "version": "npm run sync-version"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Another shot. the version hook works just after bumping version in package.json, so this should be good.

reference: https://github.com/appium/appium-espresso-driver/blob/master/package.json#L106C5-L106C14 