### PR TITLE
fix(ios): use selected device name instead of hardcoded 'iPhone Simulator'

### DIFF
--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -137,18 +137,19 @@ async function buildIOSCapabilities(
   const deviceType = isRemoteServer ? null : getSelectedDeviceType();
   await validateIOSDeviceSelection(deviceType);
 
-  const defaultCaps: Capabilities = {
-    platformName: 'iOS',
-    'appium:automationName': 'XCUITest',
-    'appium:deviceName': 'iPhone Simulator',
-  };
-
+  // Get selected device info BEFORE constructing defaultCaps so we can use the actual device name
   const selectedDeviceUdid = isRemoteServer ? undefined : getSelectedDevice();
   const selectedDeviceInfo = isRemoteServer
     ? undefined
     : getSelectedDeviceInfo();
 
   log.debug('Selected device info:', selectedDeviceInfo);
+
+  const defaultCaps: Capabilities = {
+    platformName: 'iOS',
+    'appium:automationName': 'XCUITest',
+    'appium:deviceName': selectedDeviceInfo?.name || 'iPhone Simulator',
+  };
 
   const platformVersion =
     selectedDeviceInfo?.platform && selectedDeviceInfo.platform.trim() !== ''


### PR DESCRIPTION
## Problem

When creating an iOS session after selecting a device via `select_device`, the session creation would fail with:

```
Failed to create session: Could not create simulator with name 'appiumTest-...-iPhone Simulator', 
device type id 'iPhone Simulator', with runtime ids 'com.apple.CoreSimulator.SimRuntime.iOS-26-1'
```

This happened because `appium:deviceName` was always hardcoded to `'iPhone Simulator'` in the default capabilities, even when a specific device was selected.

## Root Cause

In `buildIOSCapabilities()`, the `defaultCaps` object was constructed **before** retrieving the selected device info:

```typescript
const defaultCaps: Capabilities = {
  platformName: 'iOS',
  'appium:automationName': 'XCUITest',
  'appium:deviceName': 'iPhone Simulator',  // Always hardcoded!
};

const selectedDeviceUdid = getSelectedDevice();
const selectedDeviceInfo = getSelectedDeviceInfo();
```

While `appium:udid` was correctly set later, Appium still used the generic `deviceName` to try creating a new simulator.

## Solution

Move the device info retrieval **before** constructing `defaultCaps`, and use the selected device's actual name:

```typescript
const selectedDeviceUdid = getSelectedDevice();
const selectedDeviceInfo = getSelectedDeviceInfo();

const defaultCaps: Capabilities = {
  platformName: 'iOS',
  'appium:automationName': 'XCUITest',
  'appium:deviceName': selectedDeviceInfo?.name || 'iPhone Simulator',
};
```

## Testing

Tested with iPhone 17 simulator on iOS 26.0:
1. `select_platform` → iOS simulator
2. `select_device` → iPhone 17 (UDID: 3AD0D226-...)
3. `create_session` → ✅ Successfully creates session on the selected device

Before fix: Session creation failed trying to create new simulator
After fix: Session connects to existing booted simulator correctly