### PR TITLE
chore: publish only necessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "typescript": "^5.8.3"
   },
   "files": [
-    "src",
     "scripts",
     "dist",
     "CHANGELOG.md",


### PR DESCRIPTION
The current npm published module has unnecessary files as npm published mosules. This PR aims to push minimal files to reduce the amount of package size.
https://www.npmjs.com/package/appium-mcp?activeTab=code

This will maybe reduce the amount of npm published file size from 17MB to in 2 MB or so.