### PR TITLE
fix: setContext missing return statements

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -98,8 +98,10 @@ export async function setContext(
 ): Promise<void> {
   if (isAndroidUiautomator2DriverSession(driver)) {
     await driver.setContext(name);
+    return;
   } else if (isXCUITestDriverSession(driver)) {
     await driver.setContext(name || null);
+    return;
   }
   throw new Error('setContext is not supported');
 }


### PR DESCRIPTION
## Summary

- `setContext` in `src/command.ts` is missing `return` statements after the `await` calls in both the Android (`isAndroidUiautomator2DriverSession`) and iOS (`isXCUITestDriverSession`) branches
- This causes execution to always fall through to `throw new Error('setContext is not supported')`, even when the context switch succeeds on the driver
- Added `return` after each `await driver.setContext(...)` call so the function exits before reaching the throw

Note that the sibling functions `getCurrentContext` and `getContexts` don't have this issue because they use `return await`, which exits the function. `setContext` returns `void`, so the `await` alone doesn't prevent fall-through.

Fixes #153