### PR TITLE
chore: update the release pipeline to not run MCP publish when it does not get published new one

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,49 @@
+name: MCP Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-mcp:
+    runs-on: linux-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Build MCP Publisher from source
+        run: |
+          # Build mcp-publisher from latest registry release
+          LATEST_TAG=$(curl -s https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ -z "$LATEST_TAG" ]; then
+            echo "Warning: Could not get latest tag, using main branch"
+            LATEST_TAG="main"
+          fi
+          echo "Building mcp-publisher from ${LATEST_TAG}"
+          cd ${{ runner.temp }}
+          git clone --depth 1 --branch "${LATEST_TAG}" https://github.com/modelcontextprotocol/registry.git
+          cd registry
+          go build -o mcp-publisher ./cmd/publisher
+          mv mcp-publisher ${{ github.workspace }}/mcp-publisher
+          cd ${{ github.workspace }}
+          chmod +x mcp-publisher
+
+      - name: Publish to MCP Registry
+        env:
+          # Ensure the workflow has access to OIDC tokens
+          GITHUB_ACTIONS: true
+        run: |
+          chmod +x mcp-publisher
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: linux-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -34,33 +34,4 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Release
-      # MCP publishing
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.25'
-
-      - name: Build MCP Publisher from source
-        run: |
-          # Always build from source (most reliable, matches Playwright approach)
-          # Get latest release tag
-          LATEST_TAG=$(curl -s https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-          if [ -z "$LATEST_TAG" ]; then
-            echo "Warning: Could not get latest tag, using main branch"
-            LATEST_TAG="main"
-          fi
-          echo "Building mcp-publisher from ${LATEST_TAG}"
-          cd ${{ runner.temp }}
-          git clone --depth 1 --branch "${LATEST_TAG}" https://github.com/modelcontextprotocol/registry.git
-          cd registry
-          go build -o mcp-publisher ./cmd/publisher
-          mv mcp-publisher ${{ github.workspace }}/mcp-publisher
-          cd ${{ github.workspace }}
-          chmod +x mcp-publisher
-
-      - name: Publish to MCP Registry
-        run: |
-          chmod +x mcp-publisher
-          ./mcp-publisher login github-oidc
-          ./mcp-publisher publish
+      # MCP publishing moved to a dedicated workflow triggered on GitHub release events


### PR DESCRIPTION
So, we should not run the MCP publish when no modules were published via npm