### PR TITLE
fix: remote server URL port handling for default ports

### DIFF
--- a/src/tests/tools/session/create-session.test.ts
+++ b/src/tests/tools/session/create-session.test.ts
@@ -74,3 +74,61 @@ describe('capability builders', () => {
     expect(caps).not.toHaveProperty('appium:udid');
   });
 });
+
+describe('remote server URL port handling', () => {
+  test('should use port 443 for https URLs without explicit port', () => {
+    const url = new URL('https://hub-cloud.browserstack.com/wd/hub');
+    const protocol = url.protocol.replace(':', '');
+    const port = url.port
+      ? parseInt(url.port, 10)
+      : protocol === 'https'
+        ? 443
+        : 80;
+    expect(port).toBe(443);
+  });
+
+  test('should use port 80 for http URLs without explicit port', () => {
+    const url = new URL('http://localhost/wd/hub');
+    const protocol = url.protocol.replace(':', '');
+    const port = url.port
+      ? parseInt(url.port, 10)
+      : protocol === 'https'
+        ? 443
+        : 80;
+    expect(port).toBe(80);
+  });
+
+  test('should use explicit port when provided', () => {
+    const url = new URL('http://localhost:4723/wd/hub');
+    const protocol = url.protocol.replace(':', '');
+    const port = url.port
+      ? parseInt(url.port, 10)
+      : protocol === 'https'
+        ? 443
+        : 80;
+    expect(port).toBe(4723);
+  });
+
+  test('should use explicit port 443 in https URL', () => {
+    // Note: URL.port returns empty string for default ports even when explicitly specified
+    const url = new URL('https://example.com:443/path');
+    const protocol = url.protocol.replace(':', '');
+    const port = url.port
+      ? parseInt(url.port, 10)
+      : protocol === 'https'
+        ? 443
+        : 80;
+    expect(port).toBe(443);
+  });
+
+  test('should handle non-default https port', () => {
+    const url = new URL('https://example.com:8443/path');
+    const protocol = url.protocol.replace(':', '');
+    const port = url.port
+      ? parseInt(url.port, 10)
+      : protocol === 'https'
+        ? 443
+        : 80;
+    expect(port).toBe(8443);
+  });
+});

--- a/src/tests/tools/session/create-session.test.ts
+++ b/src/tests/tools/session/create-session.test.ts
@@ -32,7 +32,8 @@ await jest.unstable_mockModule('webdriver', () => ({
 }));
 
 const module = await import('../../../tools/session/create-session.js');
-const { buildAndroidCapabilities, buildIOSCapabilities } = module;
+const { buildAndroidCapabilities, buildIOSCapabilities, getPortFromUrl } =
+  module;
 
 describe('capability builders', () => {
   test('buildAndroidCapabilities includes udid for local server and removes empty values', () => {
@@ -78,57 +79,27 @@ describe('capability builders', () => {
 describe('remote server URL port handling', () => {
   test('should use port 443 for https URLs without explicit port', () => {
     const url = new URL('https://hub-cloud.browserstack.com/wd/hub');
-    const protocol = url.protocol.replace(':', '');
-    const port = url.port
-      ? parseInt(url.port, 10)
-      : protocol === 'https'
-        ? 443
-        : 80;
-    expect(port).toBe(443);
+    expect(getPortFromUrl(url)).toBe(443);
   });
 
   test('should use port 80 for http URLs without explicit port', () => {
     const url = new URL('http://localhost/wd/hub');
-    const protocol = url.protocol.replace(':', '');
-    const port = url.port
-      ? parseInt(url.port, 10)
-      : protocol === 'https'
-        ? 443
-        : 80;
-    expect(port).toBe(80);
+    expect(getPortFromUrl(url)).toBe(80);
   });
 
   test('should use explicit port when provided', () => {
     const url = new URL('http://localhost:4723/wd/hub');
-    const protocol = url.protocol.replace(':', '');
-    const port = url.port
-      ? parseInt(url.port, 10)
-      : protocol === 'https'
-        ? 443
-        : 80;
-    expect(port).toBe(4723);
+    expect(getPortFromUrl(url)).toBe(4723);
   });
 
   test('should use explicit port 443 in https URL', () => {
     // Note: URL.port returns empty string for default ports even when explicitly specified
     const url = new URL('https://example.com:443/path');
-    const protocol = url.protocol.replace(':', '');
-    const port = url.port
-      ? parseInt(url.port, 10)
-      : protocol === 'https'
-        ? 443
-        : 80;
-    expect(port).toBe(443);
+    expect(getPortFromUrl(url)).toBe(443);
   });
 
   test('should handle non-default https port', () => {
     const url = new URL('https://example.com:8443/path');
-    const protocol = url.protocol.replace(':', '');
-    const port = url.port
-      ? parseInt(url.port, 10)
-      : protocol === 'https'
-        ? 443
-        : 80;
-    expect(port).toBe(8443);
+    expect(getPortFromUrl(url)).toBe(8443);
   });
 });

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -347,10 +347,18 @@ export default function createSession(server: any): void {
             `Sending the capabilities to the remote server: ${remoteServerUrl}`
           );
           const remoteUrl = new URL(remoteServerUrl);
+          const protocol = remoteUrl.protocol.replace(':', '');
+          // Use default port based on protocol when port is not specified
+          // URL.port returns empty string for default ports (443 for https, 80 for http)
+          const port = remoteUrl.port
+            ? parseInt(remoteUrl.port, 10)
+            : protocol === 'https'
+              ? 443
+              : 80;
           const client = await WebDriver.newSession({
-            protocol: remoteUrl.protocol.replace(':', ''),
+            protocol,
             hostname: remoteUrl.hostname,
-            port: parseInt(remoteUrl.port, 10),
+            port,
             path: remoteUrl.pathname,
             capabilities: finalCapabilities,
           });

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -196,6 +196,17 @@ export async function buildIOSCapabilities(
 }
 
 /**
+ * Extract port number from a URL object, using protocol defaults when not specified
+ */
+export function getPortFromUrl(url: URL): number {
+  if (url.port) {
+    return parseInt(url.port, 10);
+  }
+  const protocol = url.protocol.replace(':', '');
+  return protocol === 'https' ? 443 : 80;
+}
+
+/**
  * Create the appropriate driver instance for the given platform
  */
 function createDriverForPlatform(platform: 'android' | 'ios'): any {
@@ -348,13 +359,7 @@ export default function createSession(server: any): void {
           );
           const remoteUrl = new URL(remoteServerUrl);
           const protocol = remoteUrl.protocol.replace(':', '');
-          // Use default port based on protocol when port is not specified
-          // URL.port returns empty string for default ports (443 for https, 80 for http)
-          const port = remoteUrl.port
-            ? parseInt(remoteUrl.port, 10)
-            : protocol === 'https'
-              ? 443
-              : 80;
+          const port = getPortFromUrl(remoteUrl);
           const client = await WebDriver.newSession({
             protocol,
             hostname: remoteUrl.hostname,


### PR DESCRIPTION
## Summary

Fix "Invalid URL" error when connecting to remote Appium servers using standard URLs without explicit ports (e.g., `https://hub-cloud.browserstack.com/wd/hub`).

## Problem

When using `create_session` with a remote server URL that doesn't have an explicit port, the session creation fails with:

```
Error: Invalid URL
    at new URL (node:internal/url:828:25)
    at FetchRequest.createOptions
```

This affects all cloud providers that use standard HTTPS URLs:
- BrowserStack (`https://hub-cloud.browserstack.com/wd/hub`)
- Sauce Labs (`https://ondemand.saucelabs.com/wd/hub`)
- And others

## Root Cause

In JavaScript's `URL` API, `URL.port` returns an **empty string** for default ports:
- Port 443 for `https://`
- Port 80 for `http://`

The current code does:
```typescript
port: parseInt(remoteUrl.port, 10),  // parseInt('', 10) returns NaN
```

This causes the reconstructed URL to be `https://example.com:NaN/path` which is invalid.

## Solution

Add logic to detect empty port and use the appropriate default based on protocol:

```typescript
const protocol = remoteUrl.protocol.replace(':', '');
const port = remoteUrl.port
  ? parseInt(remoteUrl.port, 10)
  : protocol === 'https'
    ? 443
    : 80;
```

## Testing

- Added unit tests for port handling in `src/tests/tools/session/create-session.test.ts`
- Manually tested with BrowserStack iOS session - successfully connected and took screenshots

## Changes

- `src/tools/session/create-session.ts` - Fix port handling
- `src/tests/tools/session/create-session.test.ts` - Add tests for port handling
