### PR TITLE
fix: await `getElementText` to return actual text instead of [object Promise]

### DIFF
--- a/src/tools/interactions/get-text.ts
+++ b/src/tools/interactions/get-text.ts
@@ -27,7 +27,7 @@ export default function getText(server: FastMCP): void {
       }
 
       try {
-        const text = getElementText(driver, args.elementUUID);
+        const text = await getElementText(driver, args.elementUUID);
         return {
           content: [
             {


### PR DESCRIPTION
We should await before getting the text, earlier I was getting `[object Promise]` instead of the actual text