### PR TITLE
fix: extract session ID from array returned by `createSession`

### DIFF
--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -230,11 +230,12 @@ async function createDriverSession(
   capabilities: Capabilities
 ): Promise<string> {
   // @ts-ignore
-  const sessionId = await driver.createSession(null, {
+  const result = await driver.createSession(null, {
     alwaysMatch: capabilities,
     firstMatch: [{}],
   });
-  return sessionId;
+  // Appium drivers return [sessionId, caps], extract just the session ID
+  return Array.isArray(result) ? result[0] : result;
 }
 
 /**


### PR DESCRIPTION
Currently, in the create session tool we are getting an object as session ID, the `createSession` method in appium returns - `[sessionId: string, capabilities: DriverCaps<C>]` 
so we need to extract and pass the session id array[0] so the next logs print correctly.