### PR TITLE
feat: add Playwright web browser automation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "langchain": "^1.1.6",
     "lodash": "^4.17.21",
     "node-simctl": "^8.0.4",
+    "playwright": "^1.58.2",
     "rimraf": "^6.0.1",
     "webdriver": "^9.23.0",
     "xpath": "^0.0.34",

--- a/src/command.ts
+++ b/src/command.ts
@@ -2,6 +2,7 @@ import type { Client } from 'webdriver';
 import {
   isAndroidUiautomator2DriverSession,
   isXCUITestDriverSession,
+  isPlaywrightDriverSession,
 } from './session-store.js';
 import type { DriverInstance } from './session-store.js';
 import type { StringRecord, Element as AppiumElement } from '@appium/types';
@@ -23,6 +24,10 @@ export async function execute(
   cmd: string,
   params: any
 ): Promise<any> {
+  if (isPlaywrightDriverSession(driver)) {
+    // For Playwright, execute JavaScript in the page context
+    return await driver.page.evaluate(cmd);
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.execute(cmd, params);
   } else if (isXCUITestDriverSession(driver)) {
@@ -45,6 +50,9 @@ export async function activateApp(
   driver: DriverInstance,
   appId: string
 ): Promise<void> {
+  if (isPlaywrightDriverSession(driver)) {
+    throw new Error('activateApp is not supported for Playwright web sessions');
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.activateApp(appId);
   } else if (isXCUITestDriverSession(driver)) {
@@ -62,6 +70,9 @@ export async function activateApp(
 export async function getCurrentContext(
   driver: DriverInstance
 ): Promise<string> {
+  if (isPlaywrightDriverSession(driver)) {
+    return 'WEB';
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getCurrentContext();
   } else if (isXCUITestDriverSession(driver)) {
@@ -77,6 +88,9 @@ export async function getCurrentContext(
  * @returns Array of context names.
  */
 export async function getContexts(driver: DriverInstance): Promise<string[]> {
+  if (isPlaywrightDriverSession(driver)) {
+    return ['WEB'];
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getContexts();
   } else if (isXCUITestDriverSession(driver)) {
@@ -95,6 +109,11 @@ export async function setContext(
   driver: DriverInstance,
   name?: string
 ): Promise<void> {
+  if (isPlaywrightDriverSession(driver)) {
+    throw new Error(
+      'setContext is not supported for Playwright web sessions (already in web context)'
+    );
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.setContext(name);
   } else if (isXCUITestDriverSession(driver)) {
@@ -116,6 +135,11 @@ export async function setValue(
   elementUUID: string,
   text: string
 ) {
+  if (isPlaywrightDriverSession(driver)) {
+    const el = driver.requireElement(elementUUID);
+    await el.fill(text);
+    return;
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.setValue(text, elementUUID);
   } else if (isXCUITestDriverSession(driver)) {
@@ -134,6 +158,11 @@ export async function elementClick(
   driver: DriverInstance,
   elementUUID: string
 ): Promise<void> {
+  if (isPlaywrightDriverSession(driver)) {
+    const el = driver.requireElement(elementUUID);
+    await el.click();
+    return;
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.click(elementUUID);
   } else if (isXCUITestDriverSession(driver)) {
@@ -153,6 +182,19 @@ export async function getElementRect(
   driver: DriverInstance,
   elementUUID: string
 ): Promise<import('@appium/types').Rect> {
+  if (isPlaywrightDriverSession(driver)) {
+    const el = driver.requireElement(elementUUID);
+    const box = await el.boundingBox();
+    if (!box) {
+      throw new Error('Element is not visible or has no bounding box');
+    }
+    return {
+      x: Math.floor(box.x),
+      y: Math.floor(box.y),
+      width: Math.floor(box.width),
+      height: Math.floor(box.height),
+    };
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getElementRect(elementUUID);
   } else if (isXCUITestDriverSession(driver)) {
@@ -170,6 +212,15 @@ export async function getElementRect(
 export async function getWindowRect(
   driver: DriverInstance
 ): Promise<import('@appium/types').Rect> {
+  if (isPlaywrightDriverSession(driver)) {
+    const viewport = driver.page.viewportSize();
+    return {
+      x: 0,
+      y: 0,
+      width: viewport?.width ?? 1920,
+      height: viewport?.height ?? 1080,
+    };
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getWindowRect();
   } else if (isXCUITestDriverSession(driver)) {
@@ -188,6 +239,11 @@ export async function performActions(
   driver: DriverInstance,
   operation: StringRecord<any>[] | import('@appium/types').ActionSequence[]
 ): Promise<void> {
+  if (isPlaywrightDriverSession(driver)) {
+    throw new Error(
+      'performActions (W3C Actions API) is not supported for Playwright web sessions. Use Playwright-specific interaction tools instead.'
+    );
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.performActions(operation);
   } else if (isXCUITestDriverSession(driver)) {
@@ -205,6 +261,9 @@ export async function performActions(
  * @returns Page source as a string.
  */
 export async function getPageSource(driver: DriverInstance): Promise<string> {
+  if (isPlaywrightDriverSession(driver)) {
+    return await driver.page.content();
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getPageSource();
   } else if (isXCUITestDriverSession(driver)) {
@@ -223,6 +282,16 @@ export async function getScreenshot(
   driver: DriverInstance,
   elementId?: string
 ): Promise<string> {
+  if (isPlaywrightDriverSession(driver)) {
+    if (elementId) {
+      const el = driver.requireElement(elementId);
+      const buffer = await el.screenshot();
+      return buffer.toString('base64');
+    }
+    const buffer = await driver.page.screenshot({ type: 'png' });
+    return buffer.toString('base64');
+  }
+
   if (elementId) {
     if (isAndroidUiautomator2DriverSession(driver)) {
       return await driver.getElementScreenshot(elementId);
@@ -251,6 +320,10 @@ export async function getElementText(
   driver: DriverInstance,
   elementUUID: string
 ): Promise<string> {
+  if (isPlaywrightDriverSession(driver)) {
+    const el = driver.requireElement(elementUUID);
+    return (await el.textContent()) ?? '';
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getText(elementUUID);
   } else if (isXCUITestDriverSession(driver)) {
@@ -262,6 +335,20 @@ export async function getElementText(
 export async function getActiveElement(
   driver: DriverInstance
 ): Promise<AppiumElement> {
+  if (isPlaywrightDriverSession(driver)) {
+    // In Playwright, get the focused element via page.evaluate
+    const handle = await driver.page.evaluateHandle(
+      () => document.activeElement
+    );
+    const el = handle.asElement();
+    if (!el) {
+      throw new Error('No active element found');
+    }
+    const uuid = driver.registerElement(el);
+    return {
+      'element-6066-11e4-a52e-4f735466cecf': uuid,
+    } as unknown as AppiumElement;
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.active();
   } else if (isXCUITestDriverSession(driver)) {
@@ -280,6 +367,13 @@ export async function getActiveElement(
 export async function getOrientation(
   driver: DriverInstance
 ): Promise<'LANDSCAPE' | 'PORTRAIT'> {
+  if (isPlaywrightDriverSession(driver)) {
+    const viewport = driver.page.viewportSize();
+    if (viewport && viewport.width > viewport.height) {
+      return 'LANDSCAPE';
+    }
+    return 'PORTRAIT';
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getOrientation();
   } else if (isXCUITestDriverSession(driver)) {
@@ -300,6 +394,17 @@ export async function setOrientation(
   driver: DriverInstance,
   orientation: 'LANDSCAPE' | 'PORTRAIT'
 ): Promise<void> {
+  if (isPlaywrightDriverSession(driver)) {
+    const viewport = driver.page.viewportSize();
+    const w = viewport?.width ?? 1280;
+    const h = viewport?.height ?? 720;
+    if (orientation === 'LANDSCAPE' && h > w) {
+      await driver.page.setViewportSize({ width: h, height: w });
+    } else if (orientation === 'PORTRAIT' && w > h) {
+      await driver.page.setViewportSize({ width: h, height: w });
+    }
+    return;
+  }
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.setOrientation(orientation);
   } else if (isXCUITestDriverSession(driver)) {

--- a/src/playwright-adapter.ts
+++ b/src/playwright-adapter.ts
@@ -1,0 +1,136 @@
+/**
+ * Playwright Adapter
+ *
+ * Bridges Playwright's Locator/ElementHandle-based API to the UUID-based
+ * element model used by the existing tool infrastructure.
+ */
+import type {
+  Browser,
+  BrowserContext,
+  Page,
+  ElementHandle,
+} from 'playwright';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Wraps a Playwright Browser + BrowserContext + Page into a single object
+ * that can be stored in the session store alongside Appium drivers.
+ *
+ * Maintains an element registry that maps generated UUIDs to Playwright
+ * ElementHandles so that downstream tools can reference elements the
+ * same way they do with Appium's W3C element IDs.
+ */
+export class PlaywrightDriver {
+  readonly browser: Browser;
+  readonly context: BrowserContext;
+  private _page: Page;
+  private readonly elements = new Map<string, ElementHandle>();
+
+  constructor(browser: Browser, context: BrowserContext, page: Page) {
+    this.browser = browser;
+    this.context = context;
+    this._page = page;
+  }
+
+  get page(): Page {
+    return this._page;
+  }
+
+  /** Switch the active page (tab). */
+  setPage(page: Page): void {
+    this._page = page;
+  }
+
+  // ── Element Registry ────────────────────────────────────────────
+
+  /** Register an ElementHandle and return a UUID for it. */
+  registerElement(handle: ElementHandle): string {
+    const uuid = randomUUID();
+    this.elements.set(uuid, handle);
+    return uuid;
+  }
+
+  /** Look up a previously registered ElementHandle by UUID. */
+  getElement(uuid: string): ElementHandle | undefined {
+    return this.elements.get(uuid);
+  }
+
+  /** Require an element handle or throw. */
+  requireElement(uuid: string): ElementHandle {
+    const el = this.elements.get(uuid);
+    if (!el) {
+      throw new Error(
+        `Element with UUID "${uuid}" not found. It may have been removed from the DOM or the page navigated away.`
+      );
+    }
+    return el;
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────────
+
+  /** Clean up: close context and browser. */
+  async deleteSession(): Promise<void> {
+    this.elements.clear();
+    await this.context.close();
+    await this.browser.close();
+  }
+
+  // ── Element Operations (Appium-compatible surface) ──────────────
+
+  async findElement(
+    strategy: string,
+    selector: string
+  ): Promise<Record<string, string>> {
+    let pwSelector: string;
+
+    switch (strategy) {
+      case 'css selector':
+        pwSelector = selector;
+        break;
+      case 'xpath':
+        pwSelector = `xpath=${selector}`;
+        break;
+      case 'id':
+        pwSelector = `#${selector}`;
+        break;
+      case 'name':
+        pwSelector = `[name="${selector}"]`;
+        break;
+      case 'class name':
+        pwSelector = `.${selector}`;
+        break;
+      case 'tag name':
+        pwSelector = selector;
+        break;
+      case 'text':
+        pwSelector = `text=${selector}`;
+        break;
+      case 'accessibility id':
+      case 'role':
+        pwSelector = `[aria-label="${selector}"]`;
+        break;
+      case 'data-testid':
+      case 'test id':
+        pwSelector = `[data-testid="${selector}"]`;
+        break;
+      case 'placeholder':
+        pwSelector = `[placeholder="${selector}"]`;
+        break;
+      default:
+        // Treat unknown strategies as CSS selectors
+        pwSelector = selector;
+    }
+
+    const handle = await this._page.waitForSelector(pwSelector, {
+      timeout: 10000,
+    });
+    if (!handle) {
+      throw new Error(
+        `Element not found with strategy "${strategy}" and selector "${selector}"`
+      );
+    }
+
+    const uuid = this.registerElement(handle);
+    return { 'element-6066-11e4-a52e-4f735466cecf': uuid };
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ const server = new FastMCP({
   name: 'MCP Appium',
   version: '1.0.0',
   instructions:
-    'Intelligent MCP server providing AI assistants with powerful tools and resources for Appium mobile automation',
+    'Intelligent MCP server providing AI assistants with powerful tools and resources for Appium mobile automation and Playwright web browser automation',
 });
 
 registerResources(server);

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -1,13 +1,15 @@
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { XCUITestDriver } from 'appium-xcuitest-driver';
 import type { Client } from 'webdriver';
+import { PlaywrightDriver } from './playwright-adapter.js';
 import log from './logger.js';
 
 // Type aliases for driver variants used throughout the project.
 export type DriverInstance =
   | Client
   | AndroidUiautomator2Driver
-  | XCUITestDriver;
+  | XCUITestDriver
+  | PlaywrightDriver;
 export type NullableDriverInstance = DriverInstance | null;
 export type SessionCapabilities = Record<string, any>;
 
@@ -38,6 +40,7 @@ let activeSessionId: string | null = null;
 export const PLATFORM = {
   android: 'Android',
   ios: 'iOS',
+  web: 'Web',
 };
 
 /**
@@ -49,11 +52,18 @@ export const PLATFORM = {
  * @param driver - The driver instance to inspect (may be a Client, AndroidUiautomator2Driver, XCUITestDriver, or null).
  * @returns `true` if `driver` is non-null and has a string `sessionId`; otherwise `false`.
  */
+export function isPlaywrightDriverSession(
+  driver: NullableDriverInstance
+): driver is PlaywrightDriver {
+  return driver instanceof PlaywrightDriver;
+}
+
 export function isRemoteDriverSession(driver: NullableDriverInstance): boolean {
   if (driver) {
     return (
       !(driver instanceof AndroidUiautomator2Driver) &&
-      !(driver instanceof XCUITestDriver)
+      !(driver instanceof XCUITestDriver) &&
+      !(driver instanceof PlaywrightDriver)
     );
   }
   return false;
@@ -287,6 +297,9 @@ export async function safeDeleteAllSessions(): Promise<number> {
 }
 
 export const getPlatformName = (driver: any): string => {
+  if (driver instanceof PlaywrightDriver) {
+    return PLATFORM.web;
+  }
   if (driver instanceof AndroidUiautomator2Driver) {
     return PLATFORM.android;
   }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -59,6 +59,14 @@ import isAppInstalled from './app-management/is-app-installed.js';
 import deepLink from './app-management/deep-link.js';
 import getContexts from './context/get-contexts.js';
 import switchContext from './context/switch-context.js';
+import navigate from './web/navigate.js';
+import { goBack, goForward, reload } from './web/browser-navigation.js';
+import evaluate from './web/evaluate.js';
+import selectOption from './web/select-option.js';
+import hover from './web/hover.js';
+import { newTab, switchTab, listTabs, closeTab } from './web/tabs.js';
+import { type as playwrightType, pressKey as playwrightPressKey } from './web/keyboard.js';
+import getUrl from './web/get-url.js';
 
 export default function registerTools(server: FastMCP): void {
   // Wrap addTool to inject logging around tool execution
@@ -189,6 +197,22 @@ export default function registerTools(server: FastMCP): void {
   // Test Generation
   generateLocators(server);
   generateTest(server);
+
+  // Web (Playwright) Tools
+  navigate(server);
+  goBack(server);
+  goForward(server);
+  reload(server);
+  evaluate(server);
+  selectOption(server);
+  hover(server);
+  newTab(server);
+  switchTab(server);
+  listTabs(server);
+  closeTab(server);
+  playwrightType(server);
+  playwrightPressKey(server);
+  getUrl(server);
 
   // Documentation
   answerAppium(server);

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -13,6 +13,12 @@ export const findElementSchema = z.object({
     '-android uiautomator',
     '-ios predicate string',
     '-ios class chain',
+    'tag name',
+    'text',
+    'data-testid',
+    'test id',
+    'placeholder',
+    'role',
   ]),
   selector: z.string().describe('The selector to find the element'),
 });
@@ -21,7 +27,7 @@ export default function findElement(server: FastMCP): void {
   server.addTool({
     name: 'appium_find_element',
     description:
-      'Find a specific element by strategy and selector which will return a uuid that can be used for interactions. [PRIORITY 2: Use this to search for a target element by xpath, id, accessibility id, etc.]',
+      'Find a specific element by strategy and selector which will return a uuid that can be used for interactions. [PRIORITY 2: Use this to search for a target element by xpath, id, accessibility id, css selector, text, data-testid, etc.] Works with both Appium mobile sessions and Playwright web sessions.',
     parameters: findElementSchema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -1,5 +1,5 @@
 /**
- * Tool to create a new mobile session (Android or iOS)
+ * Tool to create a new session (Android, iOS, or Web via Playwright)
  */
 import { z } from 'zod';
 import { access, readFile } from 'node:fs/promises';
@@ -15,6 +15,7 @@ import {
   clearSelectedDevice,
 } from './select-device.js';
 import { IOSManager } from '../../devicemanager/ios-manager.js';
+import { PlaywrightDriver } from '../../playwright-adapter.js';
 import log from '../../logger.js';
 import {
   createUIResource,
@@ -272,12 +273,17 @@ async function createDriverSession(
 export default function createSession(server: any): void {
   server.addTool({
     name: 'create_session',
-    description: `Create a new Appium session with Android, iOS or any device/driver Appium supports.
+    description: `Create a new session with Android, iOS, Web (Playwright), or any device/driver Appium supports.
       WORKFLOW FOR LOCAL SERVERS (no remoteServerUrl):
       - Use select_platform tool FIRST to ask the user which platform they want
       - Then optionally use select_device tool if multiple devices are available
       - Finally call create_session with the selected platform and device
       - DO NOT assume or default to any platform
+      WORKFLOW FOR WEB (Playwright):
+      - Use select_platform with platform='web' first
+      - Then call create_session with platform='web'
+      - Optionally specify browser (chromium, firefox, webkit) and headless mode
+      - No remoteServerUrl needed - Playwright launches the browser directly
       WORKFLOW FOR REMOTE SERVERS (remoteServerUrl provided):
       - SKIP select_platform tool entirely
       - Infer the platform from the user's request (e.g., 'ios', 'android', or 'general')
@@ -287,9 +293,10 @@ export default function createSession(server: any): void {
       - Example: User says 'start session with http://localhost:4723 for ios with iphone 17' → infer platform='ios' and call create_session with remoteServerUrl and platform parameters
       `,
     parameters: z.object({
-      platform: z.enum(['ios', 'android', 'general']).describe(
+      platform: z.enum(['ios', 'android', 'general', 'web']).describe(
         `REQUIRED: Platform to use.
-          - For local servers, this must match the platform the user explicitly selected via the select_platform tool ('ios' or 'android').
+          - For local servers, this must match the platform the user explicitly selected via the select_platform tool ('ios', 'android', or 'web').
+          - Use 'web' for browser automation using Playwright (supports chromium, firefox, webkit).
           - Use 'general' when you want the tool to treat capabilities as a pass-through Appium/W3C capability set (recommended for non-Android/iOS drivers such as Windows, macOS, or other custom Appium servers). 'general' will not apply any platform-specific defaults.
           - If remoteServerUrl is provided, the assistant should confirm or infer the platform from the conversation; do not assume a default.`
       ),
@@ -297,13 +304,40 @@ export default function createSession(server: any): void {
         .record(z.string(), z.any())
         .optional()
         .describe(
-          'Optional custom W3C format capabilities for the session. These are applied on top of defaults for ios/android or used as-is for platform="general". Common options include appium:app (app path), appium:deviceName, appium:platformVersion, appium:bundleId, appium:autoGrantPermissions, etc. Custom capabilities override default and config file settings.'
+          'Optional custom W3C format capabilities for the session. These are applied on top of defaults for ios/android or used as-is for platform="general". For web sessions, use browser, headless, and url parameters instead. Custom capabilities override default and config file settings.'
         ),
       remoteServerUrl: z
         .string()
         .optional()
         .describe(
-          'Remote Appium server URL (e.g., http://localhost:4723 or http://192.168.1.100:4723). If not provided, uses local Appium server.'
+          'Remote Appium server URL (e.g., http://localhost:4723 or http://192.168.1.100:4723). If not provided, uses local Appium server. Not used for web/Playwright sessions.'
+        ),
+      browser: z
+        .enum(['chromium', 'firefox', 'webkit'])
+        .optional()
+        .describe(
+          "For web platform only: Browser engine to use. Default is 'chromium'. Options: 'chromium', 'firefox', 'webkit' (Safari engine)."
+        ),
+      headless: z
+        .boolean()
+        .optional()
+        .describe(
+          'For web platform only: Whether to run the browser in headless mode. Default is true.'
+        ),
+      url: z
+        .string()
+        .optional()
+        .describe(
+          'For web platform only: Initial URL to navigate to after launching the browser.'
+        ),
+      viewport: z
+        .object({
+          width: z.number().int().min(1).describe('Viewport width in pixels'),
+          height: z.number().int().min(1).describe('Viewport height in pixels'),
+        })
+        .optional()
+        .describe(
+          'For web platform only: Browser viewport size. Default is 1280x720.'
         ),
     }),
     annotations: {
@@ -317,6 +351,76 @@ export default function createSession(server: any): void {
           capabilities: customCapabilities,
           remoteServerUrl,
         } = args;
+
+        // Handle Playwright web sessions
+        if (platform === 'web') {
+          const browserType = args.browser || 'chromium';
+          const headless = args.headless !== false; // default true
+          const initialUrl = args.url;
+          const viewport = args.viewport || { width: 1920, height: 1080 };
+
+          log.info(
+            `Creating new WEB session with Playwright (${browserType}, headless=${headless})`
+          );
+
+          const { chromium, firefox, webkit } = await import('playwright');
+          const engines = { chromium, firefox, webkit };
+          const engine = engines[browserType as keyof typeof engines];
+          if (!engine) {
+            throw new Error(
+              `Unsupported browser: ${browserType}. Use chromium, firefox, or webkit.`
+            );
+          }
+
+          const browser = await engine.launch({ headless });
+          const context = await browser.newContext({
+            viewport,
+            userAgent:
+              'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36',
+          });
+          const page = await context.newPage();
+
+          if (initialUrl) {
+            await page.goto(initialUrl);
+          }
+
+          const pwDriver = new PlaywrightDriver(browser, context, page);
+          const sessionId = `pw-${Date.now()}`;
+          const webCapabilities = {
+            platformName: 'Web',
+            browserName: browserType,
+            headless,
+            viewport,
+          };
+          setSession(pwDriver, sessionId, webCapabilities);
+
+          log.info(
+            `WEB session created successfully with ID: ${sessionId}`
+          );
+
+          const totalSessions = listSessions().length;
+
+          const textResponse = {
+            content: [
+              {
+                type: 'text',
+                text: `WEB session created successfully with ID: ${sessionId}\nPlatform: Web (Playwright)\nBrowser: ${browserType}\nHeadless: ${headless}\nViewport: ${viewport.width}x${viewport.height}${initialUrl ? `\nURL: ${initialUrl}` : ''}\nActive sessions: ${totalSessions}`,
+              },
+            ],
+          };
+
+          const uiResource = createUIResource(
+            `ui://appium-mcp/session-dashboard/${sessionId}`,
+            createSessionDashboardUI({
+              sessionId,
+              platform: 'Web',
+              automationName: 'Playwright',
+              deviceName: `${browserType}${headless ? ' (headless)' : ''}`,
+            })
+          );
+
+          return addUIResourceToResponse(textResponse, uiResource);
+        }
 
         const configCapabilities = await loadCapabilitiesConfig();
         let finalCapabilities;

--- a/src/tools/session/select-platform.ts
+++ b/src/tools/session/select-platform.ts
@@ -195,23 +195,24 @@ async function handleIOSPlatformSelection(
 export default function selectPlatform(server: any): void {
   server.addTool({
     name: 'select_platform',
-    description: `Select the mobile platform for LOCAL Appium servers ONLY.
+    description: `Select the platform for LOCAL servers ONLY.
       DO NOT use this tool if the user mentions a REMOTE Appium server URL (e.g., http://localhost:4723, http://192.168.1.100:4723, or any other server address).
       WORKFLOW FOR LOCAL SERVERS:
-      1. First, ASK THE USER which mobile platform they want to use (Android or iOS)
-      2. You MUST explicitly prompt the user to choose between Android or iOS
+      1. First, ASK THE USER which platform they want to use (Android, iOS, or Web)
+      2. You MUST explicitly prompt the user to choose between Android, iOS, or Web
       3. DO NOT assume or default to any platform
-      4. After platform selection, available devices will be listed
+      4. For Android/iOS: After platform selection, available devices will be listed
       5. If multiple devices are available, use select_device to let the user choose
       6. After device selection, proceed to create_session
+      7. For Web: No device selection needed, proceed directly to create_session
       WORKFLOW FOR REMOTE SERVERS:
       If user provides a remote server URL, SKIP this tool entirely. Instead, infer the platform and device type from the user's request (e.g., 'ios xcuitest driver with iphone 17 simulator' means platform='ios') and call create_session directly with the remoteServerUrl parameter.
       `,
     parameters: z.object({
       platform: z
-        .enum(['ios', 'android'])
+        .enum(['ios', 'android', 'web'])
         .describe(
-          "REQUIRED: The platform chosen by the user - 'android' for Android devices/emulators or 'ios' for iOS devices/simulators. This must be based on the user's explicit choice, NOT a default assumption."
+          "REQUIRED: The platform chosen by the user - 'android' for Android devices/emulators, 'ios' for iOS devices/simulators, or 'web' for browser automation with Playwright. This must be based on the user's explicit choice, NOT a default assumption."
         ),
       iosDeviceType: z
         .enum(['simulator', 'real'])
@@ -234,9 +235,19 @@ export default function selectPlatform(server: any): void {
         } else if (platform === 'ios') {
           log.info('Platform selected: IOS');
           return await handleIOSPlatformSelection(iosDeviceType);
+        } else if (platform === 'web') {
+          log.info('Platform selected: WEB (Playwright)');
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Web (Playwright) platform selected.\n\nYou can now create a browser session using the create_session tool with platform='web'.\n\nSupported browsers: chromium, firefox, webkit\nDefault: chromium (headless)\n\nReady to create a session? Use the create_session tool with platform='web' and optionally specify browser and headless options.`,
+              },
+            ],
+          };
         } else {
           throw new Error(
-            `Invalid platform: ${platform}. Please choose 'android' or 'ios'.`
+            `Invalid platform: ${platform}. Please choose 'android', 'ios', or 'web'.`
           );
         }
       } catch (error: any) {

--- a/src/tools/test-generation/locators.ts
+++ b/src/tools/test-generation/locators.ts
@@ -14,6 +14,7 @@ import {
   getDriver,
   isAndroidUiautomator2DriverSession,
   isXCUITestDriverSession,
+  isPlaywrightDriverSession,
 } from '../../session-store.js';
 import { generateAllElementLocators } from '../../locators/generate-all-locators.js';
 import {
@@ -48,7 +49,9 @@ export default function generateLocators(server: any): void {
           // Get the page source from the driver
           const pageSource = await getPageSource(driver);
           let driverName;
-          if (isAndroidUiautomator2DriverSession(driver)) {
+          if (isPlaywrightDriverSession(driver)) {
+            driverName = 'playwright';
+          } else if (isAndroidUiautomator2DriverSession(driver)) {
             driverName = await driver.caps.automationName?.toLowerCase();
           } else if (isXCUITestDriverSession(driver)) {
             driverName = await driver.caps.automationName?.toLowerCase();

--- a/src/tools/web/browser-navigation.ts
+++ b/src/tools/web/browser-navigation.ts
@@ -1,0 +1,138 @@
+/**
+ * Tools for browser back/forward/reload navigation in Playwright sessions
+ */
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver, isPlaywrightDriverSession } from '../../session-store.js';
+
+export function goBack(server: FastMCP): void {
+  server.addTool({
+    name: 'playwright_go_back',
+    description:
+      'Go back to the previous page in browser history. Only works with Playwright web sessions.',
+    parameters: z.object({}),
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        await driver.page.goBack();
+        const title = await driver.page.title();
+        const url = driver.page.url();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Navigated back.\nURL: ${url}\nTitle: ${title}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to go back. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}
+
+export function goForward(server: FastMCP): void {
+  server.addTool({
+    name: 'playwright_go_forward',
+    description:
+      'Go forward to the next page in browser history. Only works with Playwright web sessions.',
+    parameters: z.object({}),
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        await driver.page.goForward();
+        const title = await driver.page.title();
+        const url = driver.page.url();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Navigated forward.\nURL: ${url}\nTitle: ${title}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to go forward. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}
+
+export function reload(server: FastMCP): void {
+  server.addTool({
+    name: 'playwright_reload',
+    description:
+      'Reload the current page. Only works with Playwright web sessions.',
+    parameters: z.object({}),
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        await driver.page.reload();
+        const title = await driver.page.title();
+        const url = driver.page.url();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Page reloaded.\nURL: ${url}\nTitle: ${title}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to reload page. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}

--- a/src/tools/web/evaluate.ts
+++ b/src/tools/web/evaluate.ts
@@ -1,0 +1,62 @@
+/**
+ * Tool to evaluate JavaScript in a Playwright web session
+ */
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver, isPlaywrightDriverSession } from '../../session-store.js';
+
+export default function evaluate(server: FastMCP): void {
+  const evaluateSchema = z.object({
+    script: z
+      .string()
+      .describe(
+        'JavaScript code to evaluate in the browser page context. The result will be serialized and returned.'
+      ),
+  });
+
+  server.addTool({
+    name: 'playwright_evaluate',
+    description:
+      'Execute JavaScript code in the browser page context and return the result. Only works with Playwright web sessions.',
+    parameters: evaluateSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (
+      args: z.infer<typeof evaluateSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const result = await driver.page.evaluate(args.script);
+        const resultStr =
+          typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Script executed successfully.\nResult: ${resultStr ?? 'undefined'}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to evaluate script. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}

--- a/src/tools/web/get-url.ts
+++ b/src/tools/web/get-url.ts
@@ -1,0 +1,49 @@
+/**
+ * Tool to get the current page URL in Playwright sessions
+ */
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver, isPlaywrightDriverSession } from '../../session-store.js';
+
+export default function getUrl(server: FastMCP): void {
+  server.addTool({
+    name: 'playwright_get_url',
+    description:
+      'Get the current page URL and title. Only works with Playwright web sessions.',
+    parameters: z.object({}),
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    execute: async (): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const url = driver.page.url();
+        const title = await driver.page.title();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `URL: ${url}\nTitle: ${title}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to get URL. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}

--- a/src/tools/web/hover.ts
+++ b/src/tools/web/hover.ts
@@ -1,0 +1,58 @@
+/**
+ * Tool to hover over an element in Playwright sessions
+ */
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver, isPlaywrightDriverSession } from '../../session-store.js';
+import { elementUUIDScheme } from '../../schema.js';
+
+export default function hover(server: FastMCP): void {
+  const hoverSchema = z.object({
+    elementUUID: elementUUIDScheme,
+  });
+
+  server.addTool({
+    name: 'playwright_hover',
+    description:
+      'Hover over an element to trigger hover states, tooltips, or dropdown menus. Only works with Playwright web sessions.',
+    parameters: hoverSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (
+      args: z.infer<typeof hoverSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const el = driver.requireElement(args.elementUUID);
+        await el.hover();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Successfully hovered over element ${args.elementUUID}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to hover over element ${args.elementUUID}. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}

--- a/src/tools/web/keyboard.ts
+++ b/src/tools/web/keyboard.ts
@@ -1,0 +1,126 @@
+/**
+ * Tools for keyboard interactions in Playwright sessions
+ */
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver, isPlaywrightDriverSession } from '../../session-store.js';
+import { elementUUIDScheme } from '../../schema.js';
+
+export function type(server: FastMCP): void {
+  const typeSchema = z.object({
+    elementUUID: elementUUIDScheme.optional().describe(
+      'Optional UUID of the element to type into. If not provided, types into the currently focused element.'
+    ),
+    text: z.string().describe('The text to type character by character'),
+    delay: z
+      .number()
+      .min(0)
+      .max(1000)
+      .optional()
+      .describe(
+        'Delay between keystrokes in milliseconds. Default is 0 (instant).'
+      ),
+  });
+
+  server.addTool({
+    name: 'playwright_type',
+    description:
+      'Type text character by character (simulating real keyboard input). Unlike set_value/fill which replaces the entire value, this types each character individually. Useful for contenteditable elements, search-as-you-type, and autocomplete fields. Only works with Playwright web sessions.',
+    parameters: typeSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (
+      args: z.infer<typeof typeSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        if (args.elementUUID) {
+          const el = driver.requireElement(args.elementUUID);
+          await el.type(args.text, { delay: args.delay });
+        } else {
+          await driver.page.keyboard.type(args.text, { delay: args.delay });
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Successfully typed "${args.text}"${args.elementUUID ? ` into element ${args.elementUUID}` : ''}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to type text. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}
+
+export function pressKey(server: FastMCP): void {
+  const pressKeySchema = z.object({
+    key: z
+      .string()
+      .describe(
+        'Key to press. Examples: "Enter", "Tab", "Escape", "ArrowDown", "Control+a", "Meta+c", "Shift+Tab"'
+      ),
+  });
+
+  server.addTool({
+    name: 'playwright_press_key',
+    description:
+      'Press a keyboard key or key combination. Supports modifiers (Control, Shift, Alt, Meta). Only works with Playwright web sessions.',
+    parameters: pressKeySchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (
+      args: z.infer<typeof pressKeySchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        await driver.page.keyboard.press(args.key);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Successfully pressed key "${args.key}"`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to press key "${args.key}". Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}

--- a/src/tools/web/navigate.ts
+++ b/src/tools/web/navigate.ts
@@ -1,0 +1,67 @@
+/**
+ * Tool to navigate to a URL in a Playwright web session
+ */
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver, isPlaywrightDriverSession } from '../../session-store.js';
+
+export default function navigate(server: FastMCP): void {
+  const navigateSchema = z.object({
+    url: z.string().describe('The URL to navigate to'),
+    waitUntil: z
+      .enum(['load', 'domcontentloaded', 'networkidle', 'commit'])
+      .optional()
+      .describe(
+        "When to consider navigation complete. Default is 'load'. Use 'networkidle' to wait until no network requests for 500ms."
+      ),
+  });
+
+  server.addTool({
+    name: 'playwright_navigate',
+    description:
+      'Navigate to a URL in the browser. Only works with Playwright web sessions.',
+    parameters: navigateSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: true,
+    },
+    execute: async (
+      args: z.infer<typeof navigateSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const response = await driver.page.goto(args.url, {
+          waitUntil: args.waitUntil || 'load',
+        });
+
+        const status = response?.status() ?? 'unknown';
+        const title = await driver.page.title();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Navigated to ${args.url}\nStatus: ${status}\nTitle: ${title}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to navigate to ${args.url}. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}

--- a/src/tools/web/select-option.ts
+++ b/src/tools/web/select-option.ts
@@ -1,0 +1,88 @@
+/**
+ * Tool to select an option from a <select> dropdown in Playwright sessions
+ */
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver, isPlaywrightDriverSession } from '../../session-store.js';
+import { elementUUIDScheme } from '../../schema.js';
+
+export default function selectOption(server: FastMCP): void {
+  const selectOptionSchema = z.object({
+    elementUUID: elementUUIDScheme.describe(
+      'The UUID of the <select> element returned by appium_find_element'
+    ),
+    value: z
+      .string()
+      .optional()
+      .describe('Select option by its value attribute'),
+    label: z
+      .string()
+      .optional()
+      .describe('Select option by its visible text label'),
+    index: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Select option by its zero-based index'),
+  });
+
+  server.addTool({
+    name: 'playwright_select_option',
+    description:
+      'Select an option from a <select> dropdown element. Provide value, label, or index. Only works with Playwright web sessions.',
+    parameters: selectOptionSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (
+      args: z.infer<typeof selectOptionSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const el = driver.requireElement(args.elementUUID);
+
+        let option: Record<string, string | number> = {};
+        if (args.value !== undefined) {
+          option = { value: args.value };
+        } else if (args.label !== undefined) {
+          option = { label: args.label };
+        } else if (args.index !== undefined) {
+          option = { index: args.index };
+        } else {
+          throw new Error(
+            'At least one of value, label, or index must be provided'
+          );
+        }
+
+        const selected = await el.selectOption(option);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Successfully selected option. Selected values: ${JSON.stringify(selected)}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to select option. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}

--- a/src/tools/web/tabs.ts
+++ b/src/tools/web/tabs.ts
@@ -1,0 +1,259 @@
+/**
+ * Tools for managing browser tabs in Playwright sessions
+ */
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver, isPlaywrightDriverSession } from '../../session-store.js';
+
+export function newTab(server: FastMCP): void {
+  const newTabSchema = z.object({
+    url: z
+      .string()
+      .optional()
+      .describe('Optional URL to navigate to in the new tab'),
+  });
+
+  server.addTool({
+    name: 'playwright_new_tab',
+    description:
+      'Open a new browser tab, optionally navigating to a URL. The new tab becomes the active page. Only works with Playwright web sessions.',
+    parameters: newTabSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: true,
+    },
+    execute: async (
+      args: z.infer<typeof newTabSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const page = await driver.context.newPage();
+        if (args.url) {
+          await page.goto(args.url);
+        }
+        driver.setPage(page);
+
+        const title = await page.title();
+        const url = page.url();
+        const totalTabs = driver.context.pages().length;
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `New tab opened (tab ${totalTabs}).\nURL: ${url}\nTitle: ${title}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to open new tab. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}
+
+export function switchTab(server: FastMCP): void {
+  const switchTabSchema = z.object({
+    index: z
+      .number()
+      .int()
+      .min(0)
+      .describe('Zero-based index of the tab to switch to'),
+  });
+
+  server.addTool({
+    name: 'playwright_switch_tab',
+    description:
+      'Switch to a different browser tab by index. Only works with Playwright web sessions.',
+    parameters: switchTabSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (
+      args: z.infer<typeof switchTabSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const pages = driver.context.pages();
+        if (args.index >= pages.length) {
+          throw new Error(
+            `Tab index ${args.index} is out of range. There are ${pages.length} tab(s) (0-${pages.length - 1}).`
+          );
+        }
+
+        const page = pages[args.index];
+        driver.setPage(page);
+        await page.bringToFront();
+
+        const title = await page.title();
+        const url = page.url();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Switched to tab ${args.index}.\nURL: ${url}\nTitle: ${title}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to switch tab. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}
+
+export function listTabs(server: FastMCP): void {
+  server.addTool({
+    name: 'playwright_list_tabs',
+    description:
+      'List all open browser tabs with their URLs and titles. Only works with Playwright web sessions.',
+    parameters: z.object({}),
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    execute: async (): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const pages = driver.context.pages();
+        const currentPage = driver.page;
+
+        const tabInfo = await Promise.all(
+          pages.map(async (page, index) => {
+            const title = await page.title();
+            const url = page.url();
+            const isActive = page === currentPage ? ' (active)' : '';
+            return `  ${index}. ${title || '(no title)'} - ${url}${isActive}`;
+          })
+        );
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Open tabs (${pages.length}):\n${tabInfo.join('\n')}`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to list tabs. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}
+
+export function closeTab(server: FastMCP): void {
+  const closeTabSchema = z.object({
+    index: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        'Zero-based index of the tab to close. Defaults to the current active tab.'
+      ),
+  });
+
+  server.addTool({
+    name: 'playwright_close_tab',
+    description:
+      'Close a browser tab by index, or close the current active tab if no index is provided. Only works with Playwright web sessions.',
+    parameters: closeTabSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (
+      args: z.infer<typeof closeTabSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver || !isPlaywrightDriverSession(driver)) {
+        throw new Error(
+          'No Playwright web session found. Create a session with platform="web" first.'
+        );
+      }
+
+      try {
+        const pages = driver.context.pages();
+        const targetIndex = args.index ?? pages.indexOf(driver.page);
+
+        if (targetIndex < 0 || targetIndex >= pages.length) {
+          throw new Error(
+            `Tab index ${targetIndex} is out of range. There are ${pages.length} tab(s).`
+          );
+        }
+
+        const pageToClose = pages[targetIndex];
+        await pageToClose.close();
+
+        // Switch to the last remaining tab if we closed the active one
+        const remaining = driver.context.pages();
+        if (remaining.length > 0 && pageToClose === driver.page) {
+          driver.setPage(remaining[remaining.length - 1]);
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Tab ${targetIndex} closed. ${remaining.length} tab(s) remaining.`,
+            },
+          ],
+        };
+      } catch (err: any) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to close tab. Error: ${err.toString()}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Adds **Playwright** as a new platform alongside Android and iOS, enabling web browser automation (chromium, firefox, webkit) through the same MCP tool interface
- Introduces a `PlaywrightDriver` adapter that bridges Playwright's API to the existing UUID-based element model, so all existing interaction tools (click, find, setText, getText, screenshot, etc.) work seamlessly with web sessions
- Adds **14 new Playwright-specific tools** for web-only operations: navigation, JS evaluation, tab management, hover, select option, keyboard input

## Details

### Core Infrastructure
- `src/playwright-adapter.ts` — `PlaywrightDriver` class wrapping Browser/BrowserContext/Page with an element UUID registry
- `src/session-store.ts` — Added `PlaywrightDriver` to `DriverInstance` union, `isPlaywrightDriverSession()` type guard, `'Web'` platform constant
- `src/command.ts` — Added Playwright branches to all 15 command abstraction functions

### Session Management
- `select_platform` — Added `'web'` platform option
- `create_session` — Added `'web'` platform with `browser` (chromium/firefox/webkit), `headless`, `url`, and `viewport` parameters. Uses realistic 1920x1080 viewport and real browser user-agent by default

### New Playwright Tools (`src/tools/web/`)
| Tool | Description |
|------|-------------|
| `playwright_navigate` | Navigate to a URL |
| `playwright_go_back` / `go_forward` / `reload` | Browser history navigation |
| `playwright_get_url` | Get current URL and title |
| `playwright_evaluate` | Execute JavaScript in page context |
| `playwright_type` | Type text character-by-character |
| `playwright_press_key` | Press keyboard key/combo |
| `playwright_hover` | Hover over element |
| `playwright_select_option` | Select from `<select>` dropdown |
| `playwright_new_tab` / `switch_tab` / `list_tabs` / `close_tab` | Tab management |

### Existing Tools Extended for Web
- `appium_find_element` — Added new strategies: `text`, `data-testid`, `tag name`, `placeholder`, `role`
- `appium_click`, `appium_set_value`, `appium_get_text`, `appium_screenshot`, `appium_element_screenshot`, `appium_get_page_source`, `appium_get_active_element`, `generate_locators` — All work with Playwright sessions

### Mobile-Only Tools (unchanged)
App management, device managers, iOS tools, geolocation, context switching, scroll/swipe/pinch gestures, orientation, lock/unlock — these correctly throw descriptive errors if called on a Playwright session.

## Test plan

- [x] All 84 existing tests pass — no regressions
- [x] TypeScript builds cleanly with no errors
- [x] Smoke tested: PlaywrightDriver creation, findElement (by id, placeholder, css, text), fill, click, textContent, screenshot, page.content(), deleteSession
- [x] End-to-end tested: created web session, navigated to a live website, interacted with UI elements, extracted page data, managed tabs
- [ ] Reviewers may want to verify with `npm test` and `npm run build`
- [ ] Test with firefox and webkit browsers