### PR TITLE
chore: exclude src/tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   "files": [
     "scripts",
     "src",
+    "!src/tests",
     "dist",
     "CHANGELOG.md",
     "README.md",


### PR DESCRIPTION
I assume... we don't need src/tests since no references from other files. The tests dir has 30MB+ so it should reduce the amount of package size

https://www.npmjs.com/package/appium-mcp?activeTab=code