### PR TITLE
feat(interations): implement get alert text

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ The default regex pattern allows any URL that starts with `http://` or `https://
 | `appium_get_clipboard` | Get the current clipboard content as plain text from the device            |
 | `appium_set_clipboard` | Set the device clipboard to the provided plain text                        |
 | `appium_handle_alert` | Accept or dismiss system/permission alerts, or click a dialog button by label |
+| `appium_get_alert_text` | Get the text content of the currently displayed alert or dialog |
 
 ### Screen & Navigation
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -55,7 +55,7 @@ import getActiveElement from './interactions/active-element.js';
 import getPageSource from './interactions/get-page-source.js';
 import { getOrientation, setOrientation } from './interactions/orientation.js';
 import clipboard from './interactions/clipboard.js';
-import handleAlert from './interactions/handle-alert.js';
+import handleAlert, { getAlertText } from './interactions/handle-alert.js';
 import { screenshot, elementScreenshot } from './interactions/screenshot.js';
 import {
   startRecordingScreen,
@@ -190,6 +190,7 @@ export default function registerTools(server: FastMCP): void {
   getOrientation(server);
   setOrientation(server);
   handleAlert(server);
+  getAlertText(server);
   screenshot(server);
   elementScreenshot(server);
   startRecordingScreen(server);

--- a/src/tools/interactions/handle-alert.ts
+++ b/src/tools/interactions/handle-alert.ts
@@ -110,6 +110,52 @@ async function handleiOSAlert(
   await execute(driver, 'mobile: alert', params);
 }
 
+export function getAlertText(server: FastMCP): void {
+  server.addTool({
+    name: 'appium_get_alert_text',
+    description:
+      'Get the text content of the currently displayed alert or dialog. Use this to read what an alert says before deciding how to handle it with appium_handle_alert. Works on both iOS and Android.',
+    parameters: z.object({}),
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    execute: async (
+      _args: Record<string, never>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver) {
+        throw new Error('No driver found');
+      }
+
+      try {
+        const text = await (driver as any).getAlertText();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: text
+                ? `Alert text: "${text}"`
+                : 'Alert is present but has no text.',
+            },
+          ],
+        };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to get alert text. Error: ${message}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}
+
 export default function handleAlert(server: FastMCP): void {
   server.addTool({
     name: 'appium_handle_alert',


### PR DESCRIPTION
This PR implements get alert text for both Android and iOS. Tested both on both platforms


### iOS

<img width="2870" height="590" alt="image" src="https://github.com/user-attachments/assets/127a53a8-06b2-460f-85ef-c013ceaa9eaa" />


### Android 

<img width="2870" height="590" alt="image" src="https://github.com/user-attachments/assets/57fc72a5-b6ca-499e-8704-8fd3d31e8baf" />
