### PR TITLE
feat(session): implement get device time

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ The default regex pattern allows any URL that starts with `http://` or `https://
 | `appium_stop_recording_screen` | Stop the active screen recording and save the video to disk as an MP4 file. Returns the path to the saved file. |
 | `appium_mobile_get_device_info` | Get device information (model, OS version, locale, timezone, screen density, etc.). On iOS real devices, includes detailed lockdown info (hardware model, product type, CPU architecture, etc.). |
 | `appium_mobile_get_battery_info` | Get the current battery level (as a percentage) and charging state of the device. Works on both iOS and Android. |
+| `appium_mobile_get_device_time` | Get the current time on the device. Accepts an optional `format` parameter (moment.js format string); defaults to ISO 8601. Works on both iOS and Android. |
 
 ### App Management
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,6 +33,7 @@ import {
 import deviceInfo from './session/device-info.js';
 import batteryInfo from './session/battery-info.js';
 import { pushFile, pullFile } from './session/file-transfer.js';
+import deviceTime from './session/device-time.js';
 import bootSimulator from './ios/boot-simulator.js';
 import setupWDA from './ios/setup-wda.js';
 import installWDA from './ios/install-wda.js';
@@ -157,6 +158,7 @@ export default function registerTools(server: FastMCP): void {
   batteryInfo(server);
   pushFile(server);
   pullFile(server);
+  deviceTime(server);
 
   // iOS Setup
   bootSimulator(server);

--- a/src/tools/session/device-time.ts
+++ b/src/tools/session/device-time.ts
@@ -1,0 +1,59 @@
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver } from '../../session-store.js';
+import { execute } from '../../command.js';
+
+export default function deviceTime(server: FastMCP): void {
+  const schema = z.object({
+    format: z
+      .string()
+      .optional()
+      .describe(
+        'moment.js format string for the returned time. Defaults to ISO 8601 (YYYY-MM-DDTHH:mm:ssZ).'
+      ),
+  });
+
+  server.addTool({
+    name: 'appium_mobile_get_device_time',
+    description:
+      'Get the current time on the device. Works on both iOS and Android.',
+    parameters: schema,
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    execute: async (args: z.infer<typeof schema>): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver) {
+        throw new Error('No driver found');
+      }
+
+      try {
+        const params: Record<string, unknown> = {};
+        if (args.format != null) {
+          params.format = args.format;
+        }
+        const time = await execute(driver, 'mobile: getDeviceTime', params);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: String(time),
+            },
+          ],
+        };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to get device time. Error: ${message}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}


### PR DESCRIPTION
PR implements the functionality to get the current time on the connected device. It uses `mobile: getDeviceTime` underneath. Tested on iOS and Android.

## Demonstration

### without format 

<img width="1435" height="122" alt="image" src="https://github.com/user-attachments/assets/0886ca83-1cf4-4f4a-a8d7-b05bb9824ff2" />

### with format

<img width="1435" height="122" alt="image" src="https://github.com/user-attachments/assets/b38fac4f-8a1a-4785-a534-f937e0ec271f" />
 