### PR TITLE
feat: add appium_get_settings and appium_update_settings tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ MCP Appium provides a comprehensive set of tools organized into the following ca
 | `create_session` | Create a new mobile automation session for Android, iOS, or `general` capabilities (see 'general' mode above). If a remote Appium server is referenced, `create_session` forwards the final capabilities to that server via the WebDriver `newSession` API - include device selection (e.g., `appium:udid`) in `capabilities` when targeting a remote server. |
 | `delete_session` | Delete the current mobile session and clean up resources                                                    |
 | `appium_mobile_shake` | Shake gesture (`mobile: shake`) on **iOS Simulator only** (XCUITest). Not supported on Android or physical iOS devices. |
+| `appium_get_settings` | Read current Appium driver session settings (idle timeouts, animation-related flags, selector waits, etc.). Helps diagnose and tune flaky automation. |
+| `appium_update_settings` | Merge key-value updates into driver session settings (driver-specific keys; use `appium_get_settings` to inspect). |
 
 The remote server URL in `create_session` can be set via the `remoteServerUrl` parameter.
 If `REMOTE_SERVER_URL_ALLOW_REGEX` is set, the URL must match the provided regex pattern for security reasons.

--- a/src/command.ts
+++ b/src/command.ts
@@ -37,6 +37,40 @@ export async function execute(
 }
 
 /**
+ * Read current Appium driver session settings (embedded drivers or remote
+ * WebDriver `GET /session/:id/appium/settings`).
+ */
+export async function getSessionDriverSettings(
+  driver: DriverInstance
+): Promise<Record<string, unknown>> {
+  if (isAndroidUiautomator2DriverSession(driver)) {
+    return (await driver.getSettings()) as Record<string, unknown>;
+  } else if (isXCUITestDriverSession(driver)) {
+    return (await driver.getSettings()) as Record<string, unknown>;
+  } else {
+    const raw = await (driver as Client).getSettings();
+    return raw as Record<string, unknown>;
+  }
+}
+
+/**
+ * Update Appium driver session settings (embedded drivers or remote WebDriver
+ * `POST /session/:id/appium/settings`).
+ */
+export async function updateSessionDriverSettings(
+  driver: DriverInstance,
+  settings: Record<string, unknown>
+): Promise<void> {
+  if (isAndroidUiautomator2DriverSession(driver)) {
+    await driver.updateSettings(settings as never);
+  } else if (isXCUITestDriverSession(driver)) {
+    await driver.updateSettings(settings as never);
+  } else {
+    await (driver as Client).updateSettings(settings);
+  }
+}
+
+/**
  * Activate an application by its bundle/package id on the device.
  *
  * Works across Android and iOS driver implementations as well as remote

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -15,6 +15,7 @@ This directory contains all MCP tools available in MCP Appium.
 - `select-platform.ts` - Choose Android or iOS
 - `select-device.ts` - Choose specific device
 - `file-transfer.ts` - Push/pull files on device (`appium_mobile_push_file`, `appium_mobile_pull_file`)
+- `driver-settings.ts` - Read/update Appium driver session settings (`appium_get_settings`, `appium_update_settings`)
 
 ### iOS Setup (`ios/`)
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -34,6 +34,7 @@ import deviceInfo from './session/device-info.js';
 import batteryInfo from './session/battery-info.js';
 import { pushFile, pullFile } from './session/file-transfer.js';
 import deviceTime from './session/device-time.js';
+import driverSettings from './session/driver-settings.js';
 import bootSimulator from './ios/boot-simulator.js';
 import setupWDA from './ios/setup-wda.js';
 import installWDA from './ios/install-wda.js';
@@ -160,6 +161,7 @@ export default function registerTools(server: FastMCP): void {
   pushFile(server);
   pullFile(server);
   deviceTime(server);
+  driverSettings(server);
 
   // iOS Setup
   bootSimulator(server);

--- a/src/tools/session/driver-settings.ts
+++ b/src/tools/session/driver-settings.ts
@@ -1,0 +1,109 @@
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { z } from 'zod';
+import { getDriver } from '../../session-store.js';
+import {
+  getSessionDriverSettings,
+  updateSessionDriverSettings,
+} from '../../command.js';
+
+const updateSettingsSchema = z.object({
+  settings: z
+    .record(z.string(), z.any())
+    .describe(
+      'Key-value map of Appium driver settings to merge into the current session. ' +
+        'Valid keys depend on the driver (e.g. Android UiAutomator2: waitForIdleTimeout, ' +
+        'waitForSelectorTimeout, ignoreUnimportantViews; iOS XCUITest has its own set). ' +
+        'Call appium_get_settings first to inspect current values.'
+    ),
+});
+
+export default function driverSettings(server: FastMCP): void {
+  server.addTool({
+    name: 'appium_get_settings',
+    description:
+      'Read current Appium driver session settings (e.g. idle timeouts, animation flags, ' +
+      'selector waits). Use this to tune stability for agent-driven flows. Works for embedded ' +
+      'UiAutomator2/XCUITest sessions and remote WebDriver clients that support Appium settings.',
+    parameters: z.object({}),
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    execute: async (
+      _args: Record<string, never>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver) {
+        throw new Error('No driver found');
+      }
+
+      try {
+        const settings = await getSessionDriverSettings(driver);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(settings, null, 2),
+            },
+          ],
+        };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to get driver settings. Error: ${message}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+
+  server.addTool({
+    name: 'appium_update_settings',
+    description:
+      'Update Appium driver session settings by merging the provided map into the current ' +
+      'configuration. Useful to reduce flakiness (e.g. adjust waitForIdleTimeout) or toggle ' +
+      'driver-specific behavior. Keys are driver-specific; use appium_get_settings to see ' +
+      'what is supported.',
+    parameters: updateSettingsSchema,
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    execute: async (
+      args: z.infer<typeof updateSettingsSchema>,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const driver = getDriver();
+      if (!driver) {
+        throw new Error('No driver found');
+      }
+
+      try {
+        await updateSessionDriverSettings(driver, args.settings);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Successfully updated driver settings.',
+            },
+          ],
+        };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to update driver settings. Error: ${message}`,
+            },
+          ],
+        };
+      }
+    },
+  });
+}


### PR DESCRIPTION
Adds appium_get_settings and appium_update_settings so you can read/update Appium driver session settings mid-session (timeouts, UIA2/XCUITest flags, etc.). Works for embedded drivers and remote clients that support /appium/settings.