### PR TITLE
chore(tools): unify tool text results and driver resolution helpers

### DIFF
--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -136,23 +136,6 @@ export function getDriver(sessionId?: string): NullableDriverInstance {
   return sessions.get(id)?.driver ?? null;
 }
 
-/**
- * Get a driver instance or throw if none is available.
- * Accepts an optional sessionId to target a specific session
- * instead of the currently active one.
- */
-export function getDriverOrThrow(sessionId?: string): DriverInstance {
-  const driver = getDriver(sessionId);
-  if (!driver) {
-    throw new Error(
-      sessionId
-        ? `No driver found for session ${sessionId}`
-        : 'No active session. Call create_session first.'
-    );
-  }
-  return driver;
-}
-
 export function getSessionId() {
   return activeSessionId;
 }

--- a/src/tools/app-management/install-app.ts
+++ b/src/tools/app-management/install-app.ts
@@ -1,28 +1,31 @@
 import type { ContentResult } from 'fastmcp';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { execute } from '../../command.js';
 import { invalidateAppListCache } from './resolve-app-id.js';
+import {
+  errorResult,
+  resolveDriver,
+  textResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export async function install(
   path: string,
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
   try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
     const platform = getPlatformName(driver);
     const params =
       platform === PLATFORM.android ? { appPath: path } : { app: path };
     await execute(driver, 'mobile: installApp', params);
     invalidateAppListCache(sessionId);
-    return { content: [{ type: 'text', text: 'App installed successfully' }] };
-  } catch (err: any) {
-    return {
-      content: [
-        { type: 'text', text: `Failed to install app. err: ${err.toString()}` },
-      ],
-    };
+    return textResult('App installed successfully');
+  } catch (err: unknown) {
+    return errorResult(`Failed to install app. err: ${toolErrorMessage(err)}`);
   }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,7 +12,7 @@
  * See src/tools/README.md for tool organization.
  * See src/tools/metadata/README.md for YAML metadata approach.
  */
-import { FastMCP } from 'fastmcp';
+import type { FastMCP } from 'fastmcp';
 import log from '../logger.js';
 import answerAppium from './documentation/answer-appium.js';
 import appiumSkills from './documentation/appium-skills.js';
@@ -55,10 +55,12 @@ import screenRecording from './interactions/screen-recording.js';
 import app from './app-management/app.js';
 import context from './context/context.js';
 
+type RegisteredTool = Parameters<FastMCP['addTool']>[0];
+
 export default function registerTools(server: FastMCP): void {
   // Wrap addTool to inject logging around tool execution
-  const originalAddTool = (server as any).addTool.bind(server);
-  (server as any).addTool = (toolDef: any) => {
+  const originalAddTool = server.addTool.bind(server);
+  server.addTool = (toolDef: RegisteredTool): void => {
     const toolName = toolDef?.name ?? 'unknown_tool';
     const originalExecute = toolDef?.execute;
     if (typeof originalExecute !== 'function') {
@@ -74,7 +76,10 @@ export default function registerTools(server: FastMCP): void {
       'secret',
       'clientSecret',
     ];
-    const redactArgs = (obj: any) => {
+    const redactArgs = (obj: unknown): unknown => {
+      if (obj === undefined || obj === null) {
+        return obj;
+      }
       try {
         return JSON.parse(
           JSON.stringify(obj, (key, value) => {
@@ -104,7 +109,7 @@ export default function registerTools(server: FastMCP): void {
     };
     return originalAddTool({
       ...toolDef,
-      execute: async (args: any, context: any) => {
+      execute: async (args, context) => {
         const start = Date.now();
         log.info(`[TOOL START] ${toolName}`, redactArgs(args));
         try {
@@ -112,9 +117,10 @@ export default function registerTools(server: FastMCP): void {
           const duration = Date.now() - start;
           log.info(`[TOOL END] ${toolName} (${duration}ms)`);
           return result;
-        } catch (err: any) {
+        } catch (err: unknown) {
           const duration = Date.now() - start;
-          const msg = err?.stack || err?.message || String(err);
+          const msg =
+            err instanceof Error ? err.stack || err.message : String(err);
           log.error(`[TOOL ERROR] ${toolName} (${duration}ms): ${msg}`);
           throw err;
         }

--- a/src/tools/session/device-control.ts
+++ b/src/tools/session/device-control.ts
@@ -2,7 +2,6 @@ import type { ContentResult, FastMCP } from 'fastmcp';
 import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { z } from 'zod';
 import {
-  getDriver,
   getPlatformName,
   isAndroidUiautomator2DriverSession,
   isRemoteDriverSession,
@@ -11,6 +10,13 @@ import {
   type DriverInstance,
 } from '../../session-store.js';
 import { execute } from '../../command.js';
+import {
+  errorResult,
+  platformMismatch,
+  resolveDriver,
+  textResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const deviceControlSchema = z.object({
   action: z
@@ -49,20 +55,20 @@ async function handleLock(
     seconds !== undefined
       ? `Device locked for ${seconds} second(s).`
       : 'Device locked.';
-  return { content: [{ type: 'text', text: msg }] };
+  return textResult(msg);
 }
 
 async function handleUnlock(driver: DriverInstance): Promise<ContentResult> {
   await execute(driver, 'mobile: unlock', {});
-  return { content: [{ type: 'text', text: 'Device unlocked.' }] };
+  return textResult('Device unlocked.');
 }
 
 async function handleShake(driver: DriverInstance): Promise<ContentResult> {
   if (!isXCUITestDriverSession(driver)) {
-    throw new Error('Shake is supported only with XCUITest driver sessions.');
+    return platformMismatch('shake', 'iOS', getPlatformName(driver));
   }
   await (driver as any).mobileShake();
-  return { content: [{ type: 'text', text: 'Shake action performed.' }] };
+  return textResult('Shake action performed.');
 }
 
 async function handleOpenNotifications(
@@ -70,9 +76,7 @@ async function handleOpenNotifications(
 ): Promise<ContentResult> {
   const platform = getPlatformName(driver);
   if (platform !== PLATFORM.android) {
-    throw new Error(
-      `Unsupported platform: ${platform}. Open notifications is supported on Android only.`
-    );
+    return platformMismatch('open_notifications', 'Android', platform);
   }
 
   if (isAndroidUiautomator2DriverSession(driver)) {
@@ -83,11 +87,7 @@ async function handleOpenNotifications(
     throw new Error('Unsupported Android driver for open notifications');
   }
 
-  return {
-    content: [
-      { type: 'text', text: 'Successfully opened notifications panel.' },
-    ],
-  };
+  return textResult('Successfully opened notifications panel.');
 }
 
 export default function mobileDeviceControl(server: FastMCP): void {
@@ -104,16 +104,17 @@ export default function mobileDeviceControl(server: FastMCP): void {
       args: z.infer<typeof deviceControlSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
+      }
+      const { driver } = resolved;
+
+      if (args.action !== 'lock' && args.seconds !== undefined) {
+        return errorResult('seconds is only valid when action is lock');
+      }
+
       try {
-        const driver = getDriver(args.sessionId);
-        if (!driver) {
-          throw new Error('No driver found');
-        }
-
-        if (args.action !== 'lock' && args.seconds !== undefined) {
-          throw new Error('seconds is only valid when action is lock');
-        }
-
         switch (args.action) {
           case 'lock':
             return await handleLock(driver, args.seconds);
@@ -125,16 +126,9 @@ export default function mobileDeviceControl(server: FastMCP): void {
             return await handleOpenNotifications(driver);
         }
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed device control action ${args.action}. err: ${message}`,
-            },
-          ],
-          isError: true,
-        };
+        return errorResult(
+          `Failed device control action ${args.action}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/session/driver-settings.ts
+++ b/src/tools/session/driver-settings.ts
@@ -1,10 +1,15 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import {
   getSessionDriverSettings,
   updateSessionDriverSettings,
 } from '../../command.js';
+import {
+  errorResult,
+  resolveDriver,
+  textResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const updateSettingsSchema = z.object({
   settings: z
@@ -33,31 +38,19 @@ export default function driverSettings(server: FastMCP): void {
       _args: Record<string, never>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver();
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver();
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const settings = await getSessionDriverSettings(driver);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(settings, null, 2),
-            },
-          ],
-        };
+        return textResult(JSON.stringify(settings, null, 2));
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to get driver settings. Error: ${message}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed to get driver settings. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });
@@ -78,31 +71,19 @@ export default function driverSettings(server: FastMCP): void {
       args: z.infer<typeof updateSettingsSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver();
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver();
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         await updateSessionDriverSettings(driver, args.settings);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: 'Successfully updated driver settings.',
-            },
-          ],
-        };
+        return textResult('Successfully updated driver settings.');
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to update driver settings. Error: ${message}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed to update driver settings. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -1,0 +1,62 @@
+import type { ContentResult } from 'fastmcp';
+import type { DriverInstance } from '../session-store.js';
+import { getDriver } from '../session-store.js';
+
+/**
+ * Normalizes unknown errors into a message string for tool responses.
+ */
+export function toolErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Standard success ContentResult.
+ */
+export function textResult(text: string): ContentResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+/**
+ * Standard error ContentResult. Sets isError so MCP clients can handle
+ * failures consistently without throwing (which adds an unhelpful prefix).
+ */
+export function errorResult(text: string): ContentResult {
+  return { content: [{ type: 'text', text }], isError: true };
+}
+
+export type DriverOrError =
+  | { ok: true; driver: DriverInstance }
+  | { ok: false; result: ContentResult };
+
+/**
+ * Resolves the driver for a tool call or returns a standardised error result.
+ * Named resolveDriver (not requireDriver / getDriverOrThrow) to make clear
+ * it never throws.
+ */
+export function resolveDriver(sessionId?: string): DriverOrError {
+  const driver = getDriver(sessionId);
+  if (!driver) {
+    const ctx = sessionId ? ` for session '${sessionId}'` : '';
+    return {
+      ok: false,
+      result: errorResult(
+        `No active driver session${ctx}. Call create_session first or pass a valid sessionId.`
+      ),
+    };
+  }
+  return { ok: true, driver };
+}
+
+/**
+ * Returns a standard error result for platform-mismatch cases
+ * (e.g. shake is iOS-only, open-notifications is Android-only).
+ */
+export function platformMismatch(
+  action: string,
+  expected: string,
+  actual: string
+): ContentResult {
+  return errorResult(
+    `action=${action} is ${expected}-only. Current session platform is '${actual}'.`
+  );
+}


### PR DESCRIPTION
Adds shared helpers (textToolResult, requireDriver, toolErrorMessage) and migrates a first set of tools for consistent isError handling. Types the addTool logging wrapper via FastMCP.

Related: enhancement proposal for MCP tool error/response contract (issue link in PR).
