### PR TITLE
feat: support remote sessions for context management and app listing

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,6 +1,7 @@
 import type { Client } from 'webdriver';
 import {
   isAndroidUiautomator2DriverSession,
+  isRemoteDriverSession,
   isXCUITestDriverSession,
 } from './session-store.js';
 import type { DriverInstance } from './session-store.js';
@@ -129,6 +130,8 @@ export async function getCurrentContext(
     return await driver.getCurrentContext();
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.getCurrentContext();
+  } else if (isRemoteDriverSession(driver)) {
+    return String(await (driver as Client).getAppiumContext());
   }
   throw new Error('getCurrentContext is not supported');
 }
@@ -144,6 +147,9 @@ export async function getContexts(driver: DriverInstance): Promise<string[]> {
     return await driver.getContexts();
   } else if (isXCUITestDriverSession(driver)) {
     return (await driver.getContexts()) as string[];
+  } else if (isRemoteDriverSession(driver)) {
+    const contexts = await (driver as Client).getAppiumContexts();
+    return contexts.map((c) => (typeof c === 'string' ? c : String(c)));
   }
   throw new Error('getContexts is not supported');
 }
@@ -162,6 +168,11 @@ export async function setContext(
     return await driver.setContext(name);
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.setContext(name || null);
+  } else if (isRemoteDriverSession(driver)) {
+    if (name == null || name === '') {
+      throw new Error('Context name is required');
+    }
+    return await (driver as Client).switchAppiumContext(name);
   }
   throw new Error('setContext is not supported');
 }

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -318,9 +318,7 @@ export const getPlatformName = (driver: any): string => {
     return PLATFORM.ios;
   }
 
-  const session = listSessions().find(
-    (s) => s.sessionId === client.sessionId
-  );
+  const session = listSessions().find((s) => s.sessionId === client.sessionId);
   if (session && session.platform) {
     return session.platform;
   }

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -41,13 +41,12 @@ export const PLATFORM = {
 };
 
 /**
- * Determine whether the provided driver represents a remote driver session.
+ * Determine whether the provided driver represents a remote Appium session
+ * (i.e. a `Client` obtained via `WebDriver.newSession`) rather than an
+ * in-process `AndroidUiautomator2Driver` or `XCUITestDriver`.
  *
- * This checks for the presence of a string-valued `sessionId` property on the
- * driver object, which indicates a remote/WebDriver session.
- *
- * @param driver - The driver instance to inspect (may be a Client, AndroidUiautomator2Driver, XCUITestDriver, or null).
- * @returns `true` if `driver` is non-null and has a string `sessionId`; otherwise `false`.
+ * @param driver - The driver instance to inspect.
+ * @returns `true` if `driver` is non-null and not an embedded Appium driver.
  */
 export function isRemoteDriverSession(driver: NullableDriverInstance): boolean {
   if (driver) {
@@ -303,6 +302,32 @@ export async function safeDeleteAllSessions(): Promise<number> {
   return deletedCount;
 }
 
+function findSessionByDriver(driver: DriverInstance): SessionInfo | undefined {
+  for (const session of sessions.values()) {
+    if (session.driver === driver) {
+      return session;
+    }
+  }
+  return undefined;
+}
+
+/** Resolve a capability platform string to the corresponding `PLATFORM` constant. */
+function platformFromCapabilityString(
+  raw: string | null | undefined
+): string | null {
+  if (raw == null || raw === '') {
+    return null;
+  }
+  const p = raw.trim().toLowerCase();
+  if (p === 'android') {
+    return PLATFORM.android;
+  }
+  if (p === 'ios' || p === 'tvos') {
+    return PLATFORM.ios;
+  }
+  return null;
+}
+
 export const getPlatformName = (driver: any): string => {
   if (driver instanceof AndroidUiautomator2Driver) {
     return PLATFORM.android;
@@ -311,10 +336,26 @@ export const getPlatformName = (driver: any): string => {
     return PLATFORM.ios;
   }
 
-  if ((driver as Client).isAndroid) {
+  const client = driver as Client;
+  if (client.isAndroid) {
     return PLATFORM.android;
-  } else if ((driver as Client).isIOS) {
+  }
+  if (client.isIOS) {
     return PLATFORM.ios;
+  }
+
+  const session = findSessionByDriver(driver);
+  if (session) {
+    let resolved = platformFromCapabilityString(session.metadata.platform);
+    if (!resolved) {
+      const caps = session.metadata.capabilities;
+      resolved =
+        platformFromCapabilityString(caps?.platformName) ??
+        platformFromCapabilityString(caps?.['appium:platformName']);
+    }
+    if (resolved) {
+      return resolved;
+    }
   }
 
   throw new Error('Unknown driver type');

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -302,32 +302,6 @@ export async function safeDeleteAllSessions(): Promise<number> {
   return deletedCount;
 }
 
-function findSessionByDriver(driver: DriverInstance): SessionInfo | undefined {
-  for (const session of sessions.values()) {
-    if (session.driver === driver) {
-      return session;
-    }
-  }
-  return undefined;
-}
-
-/** Resolve a capability platform string to the corresponding `PLATFORM` constant. */
-function platformFromCapabilityString(
-  raw: string | null | undefined
-): string | null {
-  if (raw == null || raw === '') {
-    return null;
-  }
-  const p = raw.trim().toLowerCase();
-  if (p === 'android') {
-    return PLATFORM.android;
-  }
-  if (p === 'ios' || p === 'tvos') {
-    return PLATFORM.ios;
-  }
-  return null;
-}
-
 export const getPlatformName = (driver: any): string => {
   if (driver instanceof AndroidUiautomator2Driver) {
     return PLATFORM.android;
@@ -344,18 +318,11 @@ export const getPlatformName = (driver: any): string => {
     return PLATFORM.ios;
   }
 
-  const session = findSessionByDriver(driver);
-  if (session) {
-    let resolved = platformFromCapabilityString(session.metadata.platform);
-    if (!resolved) {
-      const caps = session.metadata.capabilities;
-      resolved =
-        platformFromCapabilityString(caps?.platformName) ??
-        platformFromCapabilityString(caps?.['appium:platformName']);
-    }
-    if (resolved) {
-      return resolved;
-    }
+  const session = listSessions().find(
+    (s) => s.sessionId === client.sessionId
+  );
+  if (session && session.platform) {
+    return session.platform;
   }
 
   throw new Error('Unknown driver type');

--- a/src/tests/session-store.test.ts
+++ b/src/tests/session-store.test.ts
@@ -497,7 +497,11 @@ describe('getPlatformName', () => {
   });
 
   test('falls back to session platformName for remote sessions', () => {
-    const client = { isAndroid: false, isIOS: false } as any;
+    const client = {
+      isAndroid: false,
+      isIOS: false,
+      sessionId: 'session-remote-android',
+    } as any;
     setSession(client, 'session-remote-android', {
       platformName: 'Android',
     });
@@ -505,17 +509,13 @@ describe('getPlatformName', () => {
   });
 
   test('falls back to appium:platformName when platformName is absent', () => {
-    const client = { isAndroid: false, isIOS: false } as any;
+    const client = {
+      isAndroid: false,
+      isIOS: false,
+      sessionId: 'session-remote-ios-cap',
+    } as any;
     setSession(client, 'session-remote-ios-cap', {
       'appium:platformName': 'iOS',
-    });
-    expect(getPlatformName(client)).toBe(PLATFORM.ios);
-  });
-
-  test('resolves tvOS capabilities to iOS platform', () => {
-    const client = { isAndroid: false, isIOS: false } as any;
-    setSession(client, 'session-tvos', {
-      platformName: 'tvOS',
     });
     expect(getPlatformName(client)).toBe(PLATFORM.ios);
   });

--- a/src/tests/session-store.test.ts
+++ b/src/tests/session-store.test.ts
@@ -495,4 +495,28 @@ describe('getPlatformName', () => {
     const unknown = { isAndroid: false, isIOS: false } as any;
     expect(() => getPlatformName(unknown)).toThrow('Unknown driver type');
   });
+
+  test('falls back to session platformName for remote sessions', () => {
+    const client = { isAndroid: false, isIOS: false } as any;
+    setSession(client, 'session-remote-android', {
+      platformName: 'Android',
+    });
+    expect(getPlatformName(client)).toBe(PLATFORM.android);
+  });
+
+  test('falls back to appium:platformName when platformName is absent', () => {
+    const client = { isAndroid: false, isIOS: false } as any;
+    setSession(client, 'session-remote-ios-cap', {
+      'appium:platformName': 'iOS',
+    });
+    expect(getPlatformName(client)).toBe(PLATFORM.ios);
+  });
+
+  test('resolves tvOS capabilities to iOS platform', () => {
+    const client = { isAndroid: false, isIOS: false } as any;
+    setSession(client, 'session-tvos', {
+      platformName: 'tvOS',
+    });
+    expect(getPlatformName(client)).toBe(PLATFORM.ios);
+  });
 });

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -16,8 +16,22 @@ import {
 } from '../../ui/mcp-ui-utils.js';
 import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
+import { execute } from '../../command.js';
 
 const execAsync = promisify(exec);
+
+/** Extract package ids from the `mobile: listApps` result (map or legacy array). */
+function androidListAppsPackageIds(
+  result: Record<string, unknown> | string[] | null | undefined
+): string[] {
+  if (result == null) {
+    return [];
+  }
+  if (Array.isArray(result)) {
+    return result;
+  }
+  return Object.keys(result);
+}
 
 function normalizeListAppsResult(
   result: Record<string, Record<string, unknown> | undefined>
@@ -40,11 +54,24 @@ export async function listAppsFromDevice(
     throw new Error('No driver found');
   }
 
-  if (isRemoteDriverSession(driver)) {
-    throw new Error('listApps is not yet implemented for the remote driver');
-  }
-
   const platform = getPlatformName(driver);
+
+  if (isRemoteDriverSession(driver)) {
+    if (platform === PLATFORM.android) {
+      const result = await execute(driver, 'mobile: listApps', {});
+      const ids = androidListAppsPackageIds(result);
+      return ids.map((packageName) => ({ packageName, appName: packageName }));
+    }
+    if (platform === PLATFORM.ios) {
+      const result = await execute(driver, 'mobile: listApps', {
+        applicationType,
+      });
+      return normalizeListAppsResult(
+        (result as Record<string, Record<string, unknown> | undefined>) || {}
+      );
+    }
+    throw new Error(`listApps is not implemented for platform: ${platform}`);
+  }
 
   if (platform === PLATFORM.ios && isXCUITestDriverSession(driver)) {
     const xcuiDriver = driver as XCUITestDriver;

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -22,11 +22,8 @@ const execAsync = promisify(exec);
 
 /** Extract package ids from the `mobile: listApps` result (map or legacy array). */
 function androidListAppsPackageIds(
-  result: Record<string, unknown> | string[] | null | undefined
+  result: Record<string, unknown> | string[]
 ): string[] {
-  if (result == null) {
-    return [];
-  }
   if (Array.isArray(result)) {
     return result;
   }

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -1,10 +1,6 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import {
-  getDriver,
-  isRemoteDriverSession,
-  setCurrentContext,
-} from '../../session-store.js';
+import { getDriver, setCurrentContext } from '../../session-store.js';
 import { getContexts, getCurrentContext, setContext } from '../../command.js';
 import {
   createUIResource,
@@ -46,12 +42,6 @@ export default function context(server: FastMCP): void {
         const driver = getDriver(args.sessionId);
         if (!driver) {
           throw new Error('No driver found. Please create a session first.');
-        }
-
-        if (isRemoteDriverSession(driver)) {
-          throw new Error(
-            'Context management is not yet implemented for the remote driver'
-          );
         }
 
         const [currentContext, availableContexts] = await Promise.all([


### PR DESCRIPTION
Previously, appium_context and appium_app (action=list) threw errors for remote Appium sessions. This adds proper remote support:

- Add remote context handling in command.ts (getAppiumContext, getAppiumContexts, switchAppiumContext)
- Remove the remote-blocking guard in context.ts
- Implement remote listApps via execute('mobile: listApps') for both Android and iOS
- Add getPlatformName fallback using stored session capabilities when Client flags are unset
- Document iOS Simulator limitation for remote list in README