### PR TITLE
chore: remove ts jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
-export default {
-  preset: 'ts-jest/presets/js-with-ts-esm',
+import ts from 'typescript';
+
+const config = {
   testEnvironment: 'node',
   // Restrict Jest to the source tree to avoid discovering compiled tests under dist/
   roots: ['<rootDir>/src'],
@@ -14,10 +15,7 @@ export default {
   testPathIgnorePatterns: ['/dist/', '/node_modules/', '/src/resources/submodules'],
   transform: {
     '^.+\\.tsx?$': [
-      'ts-jest',
-      {
-        useESM: true,
-      },
+      '<rootDir>/jest.config.js',
     ],
   },
   // Add this to ensure Jest can handle ESM
@@ -26,3 +24,26 @@ export default {
     'node_modules/(?!(@xmldom|fast-xml-parser|xpath|uuid)/)',
   ],
 };
+
+Object.defineProperty(config, 'process', {
+  enumerable: false,
+  value(sourceText, sourcePath) {
+    const { outputText } = ts.transpileModule(sourceText, {
+      fileName: sourcePath,
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        target: ts.ScriptTarget.ES2022,
+        inlineSourceMap: true,
+        inlineSources: true,
+        esModuleInterop: true,
+      },
+    });
+
+    return {
+      code: outputText,
+    };
+  },
+});
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "lint-staged": "^16.2.7",
     "prettier": "^3.5.3",
     "semantic-release": "^25.0.2",
-    "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.2"
   },


### PR DESCRIPTION
Closes https://github.com/appium/appium-mcp/issues/267

I wondered if we could remove the ts-jest simply