### PR TITLE
chore(tools): complete migration of all tools to textResult/errorResult/resolveDriver

### DIFF
--- a/src/tests/tools/session/device-info.test.ts
+++ b/src/tests/tools/session/device-info.test.ts
@@ -42,7 +42,9 @@ describe('appium_mobile_device_info tool', () => {
       mockGetDriver.mockReturnValue(null as any);
       const result = await tool.execute({ action: 'battery' }, undefined);
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toBe('No driver found');
+      expect(result.content[0].text).toBe(
+        'No active driver session. Call create_session first or pass a valid sessionId.'
+      );
     });
 
     test('returns formatted iOS battery info', async () => {
@@ -97,7 +99,9 @@ describe('appium_mobile_device_info tool', () => {
       mockGetDriver.mockReturnValue(null as any);
       const result = await tool.execute({ action: 'info' }, undefined);
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toBe('No driver found');
+      expect(result.content[0].text).toBe(
+        'No active driver session. Call create_session first or pass a valid sessionId.'
+      );
     });
 
     test('returns device info as formatted JSON', async () => {
@@ -136,7 +140,9 @@ describe('appium_mobile_device_info tool', () => {
       mockGetDriver.mockReturnValue(null as any);
       const result = await tool.execute({ action: 'time' }, undefined);
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toBe('No driver found');
+      expect(result.content[0].text).toBe(
+        'No active driver session. Call create_session first or pass a valid sessionId.'
+      );
     });
 
     test('returns device time as string', async () => {

--- a/src/tests/tools/session/file-transfer.test.ts
+++ b/src/tests/tools/session/file-transfer.test.ts
@@ -41,16 +41,18 @@ describe('appium_mobile_file', () => {
     )?.[0];
   }
 
-  test('throws when no driver is active', async () => {
+  test('returns error when no driver is active', async () => {
     const tool = await registerTool();
     mockGetDriver.mockReturnValue(null as any);
 
-    await expect(
-      tool.execute(
-        { action: 'push', remotePath: '/sdcard/x.txt', payloadBase64: 'YQ==' },
-        undefined
-      )
-    ).rejects.toThrow('No driver found');
+    const result = await tool.execute(
+      { action: 'push', remotePath: '/sdcard/x.txt', payloadBase64: 'YQ==' },
+      undefined
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      'No active driver session. Call create_session first or pass a valid sessionId.'
+    );
   });
 
   test('push: Android uses path and data', async () => {

--- a/src/tools/app-management/activate-app.ts
+++ b/src/tools/app-management/activate-app.ts
@@ -1,28 +1,28 @@
 import type { ContentResult } from 'fastmcp';
-import { getDriver } from '../../session-store.js';
 import { activateApp as _activateApp } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export async function activate(
   id: string,
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
   try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
     await _activateApp(driver, id);
-    return {
-      content: [{ type: 'text', text: `App ${id} activated correctly.` }],
-    };
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Error activating the app ${id}: ${err.toString()}`,
-        },
-      ],
-    };
+    return textResult(`App ${id} activated correctly.`);
+  } catch (err: unknown) {
+    return errorResult(
+      `Error activating the app ${id}: ${toolErrorMessage(err)}`
+    );
   }
 }

--- a/src/tools/app-management/background-app.ts
+++ b/src/tools/app-management/background-app.ts
@@ -1,6 +1,11 @@
 import type { ContentResult } from 'fastmcp';
-import { getDriver } from '../../session-store.js';
 import { execute } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export const DEFAULT_BACKGROUND_SECONDS = 5;
 
@@ -8,36 +13,27 @@ export async function background(
   seconds: number,
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
   try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
     await execute(driver, 'mobile: backgroundApp', { seconds });
     const resumeHint =
       seconds < 0
         ? 'The app should stay in the background until you bring it back (e.g. action=activate).'
         : 'The app is sent to the background, then brought back automatically after the wait.';
-    return {
-      content: [
-        {
-          type: 'text',
-          text:
-            `Background completed (${seconds}s). ${resumeHint}\n\n` +
-            `Tips if you saw little or no change: (1) Short positive durations (e.g. 2s) are easy to miss—try 8–15 seconds to see the home/recents screen clearly. ` +
-            `(2) The foreground app must be the one you expect—use action=activate with the package/bundle id first if needed. ` +
-            `(3) Some OEMs minimize animation; use appium_screenshot before and after to verify.`,
-        },
-      ],
-    };
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Failed to background app. Error: ${err.toString()}`,
-        },
-      ],
-    };
+    return textResult(
+      `Background completed (${seconds}s). ${resumeHint}\n\n` +
+        `Tips if you saw little or no change: (1) Short positive durations (e.g. 2s) are easy to miss—try 8–15 seconds to see the home/recents screen clearly. ` +
+        `(2) The foreground app must be the one you expect—use action=activate with the package/bundle id first if needed. ` +
+        `(3) Some OEMs minimize animation; use appium_screenshot before and after to verify.`
+    );
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to background app. Error: ${toolErrorMessage(err)}`
+    );
   }
 }

--- a/src/tools/app-management/clear-app.ts
+++ b/src/tools/app-management/clear-app.ts
@@ -1,31 +1,32 @@
 import type { ContentResult } from 'fastmcp';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { execute } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export async function clear(
   id: string,
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
   try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
     const platform = getPlatformName(driver);
     const params =
       platform === PLATFORM.android ? { appId: id } : { bundleId: id };
     await execute(driver, 'mobile: clearApp', params);
-    return {
-      content: [{ type: 'text', text: 'App data cleared successfully' }],
-    };
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Failed to clear app data. err: ${err.toString()}`,
-        },
-      ],
-    };
+    return textResult('App data cleared successfully');
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to clear app data. err: ${toolErrorMessage(err)}`
+    );
   }
 }

--- a/src/tools/app-management/deep-link.ts
+++ b/src/tools/app-management/deep-link.ts
@@ -1,6 +1,5 @@
 import type { ContentResult } from 'fastmcp';
 import {
-  getDriver,
   getPlatformName,
   isRemoteDriverSession,
   isAndroidUiautomator2DriverSession,
@@ -10,6 +9,12 @@ import {
 import { execute } from '../../command.js';
 import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export async function deepLink(
   url: string,
@@ -17,12 +22,13 @@ export async function deepLink(
   waitForLaunch?: boolean,
   sessionId?: string
 ): Promise<ContentResult> {
-  try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
 
+  try {
     if (isRemoteDriverSession(driver)) {
       const platform = getPlatformName(driver);
       if (platform === PLATFORM.android) {
@@ -57,22 +63,12 @@ export async function deepLink(
       throw new Error('Unsupported driver for deep link');
     }
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Successfully opened deep link "${url}"${appId ? ` with app ${appId}` : ''}`,
-        },
-      ],
-    };
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Failed to open deep link "${url}". err: ${err.toString()}`,
-        },
-      ],
-    };
+    return textResult(
+      `Successfully opened deep link "${url}"${appId ? ` with app ${appId}` : ''}`
+    );
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to open deep link "${url}". err: ${toolErrorMessage(err)}`
+    );
   }
 }

--- a/src/tools/app-management/is-app-installed.ts
+++ b/src/tools/app-management/is-app-installed.ts
@@ -1,6 +1,5 @@
 import type { ContentResult } from 'fastmcp';
 import {
-  getDriver,
   getPlatformName,
   isRemoteDriverSession,
   isAndroidUiautomator2DriverSession,
@@ -10,17 +9,24 @@ import {
 import { execute } from '../../command.js';
 import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export async function isInstalled(
   id: string,
   sessionId?: string
 ): Promise<ContentResult> {
-  try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
 
+  try {
     let result: boolean;
     if (isRemoteDriverSession(driver)) {
       const platform = getPlatformName(driver);
@@ -38,24 +44,12 @@ export async function isInstalled(
       throw new Error('Unsupported driver for is_installed');
     }
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: result
-            ? `App "${id}" is installed.`
-            : `App "${id}" is not installed.`,
-        },
-      ],
-    };
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Failed to check if app is installed. err: ${err.toString()}`,
-        },
-      ],
-    };
+    return textResult(
+      result ? `App "${id}" is installed.` : `App "${id}" is not installed.`
+    );
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to check if app is installed. err: ${toolErrorMessage(err)}`
+    );
   }
 }

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -17,6 +17,7 @@ import {
 import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
 import { execute } from '../../command.js';
+import { textResult, errorResult, toolErrorMessage } from '../tool-response.js';
 
 const execAsync = promisify(exec);
 
@@ -109,24 +110,15 @@ export async function list(
 ): Promise<ContentResult> {
   try {
     const apps = await listAppsFromDevice(applicationType, sessionId);
-    const textResponse = {
-      content: [
-        {
-          type: 'text' as const,
-          text: `Installed apps: ${JSON.stringify(apps, null, 2)}`,
-        },
-      ],
-    };
+    const textResponse = textResult(
+      `Installed apps: ${JSON.stringify(apps, null, 2)}`
+    );
     const uiResource = createUIResource(
       `ui://appium-mcp/app-list/${Date.now()}`,
       createAppListUI(apps)
     );
     return addUIResourceToResponse(textResponse, uiResource);
-  } catch (err: any) {
-    return {
-      content: [
-        { type: 'text', text: `Failed to list apps. err: ${err.toString()}` },
-      ],
-    };
+  } catch (err: unknown) {
+    return errorResult(`Failed to list apps. err: ${toolErrorMessage(err)}`);
   }
 }

--- a/src/tools/app-management/permissions.ts
+++ b/src/tools/app-management/permissions.ts
@@ -1,7 +1,13 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { execute } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const iosPermissionStateSchema = z.enum(['yes', 'no', 'unset', 'limited']);
 
@@ -80,10 +86,11 @@ export default function mobilePermissions(server: FastMCP): void {
       args: z.infer<typeof schema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const platform = getPlatformName(driver);
@@ -98,9 +105,7 @@ export default function mobilePermissions(server: FastMCP): void {
               params.appPackage = args.appPackage;
             }
             const raw = await execute(driver, 'mobile: getPermissions', params);
-            return {
-              content: [{ type: 'text', text: JSON.stringify(raw, null, 2) }],
-            };
+            return textResult(JSON.stringify(raw, null, 2));
           }
           if (platform === PLATFORM.ios) {
             if (!args.bundleId) {
@@ -120,9 +125,7 @@ export default function mobilePermissions(server: FastMCP): void {
               bundleId: args.bundleId,
               service: args.service,
             });
-            return {
-              content: [{ type: 'text', text: String(raw) }],
-            };
+            return textResult(String(raw));
           }
           throw new Error(
             `Unsupported platform: ${platform}. Only Android and iOS are supported.`
@@ -147,11 +150,7 @@ export default function mobilePermissions(server: FastMCP): void {
               params.target = args.target;
             }
             await execute(driver, 'mobile: changePermissions', params);
-            return {
-              content: [
-                { type: 'text', text: 'Permissions updated successfully.' },
-              ],
-            };
+            return textResult('Permissions updated successfully.');
           }
           if (platform === PLATFORM.ios) {
             if (!args.bundleId || !args.access) {
@@ -161,14 +160,7 @@ export default function mobilePermissions(server: FastMCP): void {
               bundleId: args.bundleId,
               access: args.access,
             });
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'Permission settings updated successfully.',
-                },
-              ],
-            };
+            return textResult('Permission settings updated successfully.');
           }
           throw new Error(
             `Unsupported platform: ${platform}. Only Android and iOS are supported.`
@@ -186,19 +178,11 @@ export default function mobilePermissions(server: FastMCP): void {
         await execute(driver, 'mobile: resetPermission', {
           service: args.service,
         });
-        return {
-          content: [{ type: 'text', text: 'Permission reset successfully.' }],
-        };
+        return textResult('Permission reset successfully.');
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed permissions action ${args.action}. err: ${message}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed permissions action ${args.action}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/app-management/query-app-state.ts
+++ b/src/tools/app-management/query-app-state.ts
@@ -1,6 +1,11 @@
 import type { ContentResult } from 'fastmcp';
-import { getDriver } from '../../session-store.js';
 import { queryAppState as _queryAppState } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const APP_STATE_LABELS: Record<number, string> = {
   0: 'not installed',
@@ -14,26 +19,19 @@ export async function queryState(
   id: string,
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
   try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
     const state = await _queryAppState(driver, id);
     const label = APP_STATE_LABELS[state] ?? 'unknown';
-    return {
-      content: [
-        { type: 'text', text: `App "${id}" state: ${state} (${label})` },
-      ],
-    };
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Failed to query app state for "${id}": ${err.toString()}`,
-        },
-      ],
-    };
+    return textResult(`App "${id}" state: ${state} (${label})`);
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to query app state for "${id}": ${toolErrorMessage(err)}`
+    );
   }
 }

--- a/src/tools/app-management/terminate-app.ts
+++ b/src/tools/app-management/terminate-app.ts
@@ -1,29 +1,32 @@
 import type { ContentResult } from 'fastmcp';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { execute } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export async function terminate(
   id: string,
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
   try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
     const platform = getPlatformName(driver);
     const params =
       platform === PLATFORM.android ? { appId: id } : { bundleId: id };
     await execute(driver, 'mobile: terminateApp', params);
-    return { content: [{ type: 'text', text: 'App terminated successfully' }] };
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Failed to terminate app. err: ${err.toString()}`,
-        },
-      ],
-    };
+    return textResult('App terminated successfully');
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to terminate app. err: ${toolErrorMessage(err)}`
+    );
   }
 }

--- a/src/tools/app-management/uninstall-app.ts
+++ b/src/tools/app-management/uninstall-app.ts
@@ -1,18 +1,26 @@
 import type { ContentResult } from 'fastmcp';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { execute } from '../../command.js';
 import { invalidateAppListCache } from './resolve-app-id.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export async function uninstall(
   id: string,
   keepData?: boolean,
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
   try {
-    const driver = getDriver(sessionId);
-    if (!driver) {
-      return { content: [{ type: 'text', text: 'No driver found' }] };
-    }
     const platform = getPlatformName(driver);
     const params =
       platform === PLATFORM.android
@@ -22,24 +30,14 @@ export async function uninstall(
     if (removed) {
       invalidateAppListCache(sessionId);
     }
-    return {
-      content: [
-        {
-          type: 'text',
-          text: removed
-            ? 'App uninstalled successfully'
-            : `App "${id}" was not installed, nothing to uninstall.`,
-        },
-      ],
-    };
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Failed to uninstall app. err: ${err.toString()}`,
-        },
-      ],
-    };
+    return textResult(
+      removed
+        ? 'App uninstalled successfully'
+        : `App "${id}" was not installed, nothing to uninstall.`
+    );
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to uninstall app. err: ${toolErrorMessage(err)}`
+    );
   }
 }

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -1,12 +1,18 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, setCurrentContext } from '../../session-store.js';
+import { setCurrentContext } from '../../session-store.js';
 import { getContexts, getCurrentContext, setContext } from '../../command.js';
 import {
   createUIResource,
   createContextSwitcherUI,
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const contextSchema = z.object({
   action: z
@@ -38,12 +44,13 @@ export default function context(server: FastMCP): void {
       args: z.infer<typeof contextSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      try {
-        const driver = getDriver(args.sessionId);
-        if (!driver) {
-          throw new Error('No driver found. Please create a session first.');
-        }
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
+      }
+      const { driver } = resolved;
 
+      try {
         const [currentContext, availableContexts] = await Promise.all([
           getCurrentContext(driver).catch(() => null),
           getContexts(driver).catch(() => [] as string[]),
@@ -55,24 +62,12 @@ export default function context(server: FastMCP): void {
 
         if (args.action === 'list') {
           if (!availableContexts || availableContexts.length === 0) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: 'No contexts available.',
-                },
-              ],
-            };
+            return textResult('No contexts available.');
           }
 
-          const textResponse = {
-            content: [
-              {
-                type: 'text',
-                text: `Available contexts: ${JSON.stringify(availableContexts, null, 2)}\nCurrent context: ${currentContext}`,
-              },
-            ],
-          };
+          const textResponse = textResult(
+            `Available contexts: ${JSON.stringify(availableContexts, null, 2)}\nCurrent context: ${currentContext}`
+          );
 
           const uiResource = createUIResource(
             `ui://appium-mcp/context-switcher/${Date.now()}`,
@@ -87,63 +82,30 @@ export default function context(server: FastMCP): void {
         }
 
         if (currentContext === args.context) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Already on context "${args.context}".`,
-              },
-            ],
-          };
+          return textResult(`Already on context "${args.context}".`);
         }
 
         if (!availableContexts || availableContexts.length === 0) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: 'No contexts available. Cannot switch context.',
-              },
-            ],
-            isError: true,
-          };
+          return errorResult('No contexts available. Cannot switch context.');
         }
 
         if (!availableContexts.includes(args.context)) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Context "${args.context}" not found. Available contexts: ${JSON.stringify(availableContexts, null, 2)}`,
-              },
-            ],
-            isError: true,
-          };
+          return errorResult(
+            `Context "${args.context}" not found. Available contexts: ${JSON.stringify(availableContexts, null, 2)}`
+          );
         }
 
         await setContext(driver, args.context);
         const newContext = await getCurrentContext(driver);
         setCurrentContext(newContext);
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully switched context from "${currentContext}" to "${newContext}".`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully switched context from "${currentContext}" to "${newContext}".`
+        );
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed context action ${args.action}. err: ${message}`,
-            },
-          ],
-          isError: true,
-        };
+        return errorResult(
+          `Failed context action ${args.action}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/active-element.ts
+++ b/src/tools/interactions/active-element.ts
@@ -1,7 +1,12 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { getActiveElement as _getActiveElement } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function getActiveElement(server: FastMCP): void {
   const schema = z.object({
@@ -21,10 +26,11 @@ export default function getActiveElement(server: FastMCP): void {
       openWorldHint: false,
     },
     execute: async (args: z.infer<typeof schema>): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const element = await _getActiveElement(driver);
@@ -38,23 +44,13 @@ export default function getActiveElement(server: FastMCP): void {
           );
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully found an active element. Element id: ${elementId}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to find an active element. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully found an active element. Element id: ${elementId}`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to find an active element. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/click.ts
+++ b/src/tools/interactions/click.ts
@@ -1,12 +1,17 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import {
   elementClick as _elementClick,
   performActions,
 } from '../../command.js';
 import log from '../../logger.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function generateTest(server: FastMCP): void {
   const clickActionSchema = z.object({
@@ -30,10 +35,11 @@ export default function generateTest(server: FastMCP): void {
       args: z.infer<typeof clickActionSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         // Check if this is an AI-generated coordinate-based UUID
@@ -76,37 +82,22 @@ export default function generateTest(server: FastMCP): void {
 
           await performActions(driver, operation);
 
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Successfully clicked at coordinates (${x}, ${y}) using AI-found element`,
-              },
-            ],
-          };
+          return textResult(
+            `Successfully clicked at coordinates (${x}, ${y}) using AI-found element`
+          );
         }
 
         // Traditional element click
         await _elementClick(driver, args.elementUUID);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully clicked on element ${args.elementUUID}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        const errorMessage = err.message || err.toString();
+        return textResult(
+          `Successfully clicked on element ${args.elementUUID}`
+        );
+      } catch (err: unknown) {
+        const errorMessage = toolErrorMessage(err);
         log.error('Failed to click element:', errorMessage);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to click on element ${args.elementUUID}. err: ${errorMessage}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed to click on element ${args.elementUUID}. err: ${errorMessage}`
+        );
       }
     },
   });

--- a/src/tools/interactions/clipboard.ts
+++ b/src/tools/interactions/clipboard.ts
@@ -1,7 +1,12 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { getClipboard, setClipboard } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 /**
  * Register clipboard read/write tools.
@@ -36,35 +41,22 @@ export default function clipboard(server: FastMCP): void {
       args: { sessionId?: string },
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const content = await getClipboard(driver);
         if (!content) {
-          return {
-            content: [{ type: 'text', text: 'Clipboard is empty.' }],
-          };
+          return textResult('Clipboard is empty.');
         }
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Clipboard content: ${content}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to get clipboard content. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(`Clipboard content: ${content}`);
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to get clipboard content. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });
@@ -97,30 +89,21 @@ export default function clipboard(server: FastMCP): void {
       args: z.infer<typeof setClipboardSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         await setClipboard(driver, args.content);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully set clipboard content to: ${args.content}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to set clipboard content. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully set clipboard content to: ${args.content}`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to set clipboard content. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/double-tap.ts
+++ b/src/tools/interactions/double-tap.ts
@@ -1,8 +1,14 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import { execute, getElementRect, performActions } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function doubleTap(server: FastMCP): void {
   const doubleTapActionSchema = z.object({
@@ -25,10 +31,11 @@ export default function doubleTap(server: FastMCP): void {
       args: z.infer<typeof doubleTapActionSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const platform = getPlatformName(driver);
@@ -74,23 +81,13 @@ export default function doubleTap(server: FastMCP): void {
           );
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully performed double tap on element ${args.elementUUID}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to perform double tap on element ${args.elementUUID}. Error: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully performed double tap on element ${args.elementUUID}`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to perform double tap on element ${args.elementUUID}. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/double-tap.ts
+++ b/src/tools/interactions/double-tap.ts
@@ -41,11 +41,7 @@ export default function doubleTap(server: FastMCP): void {
         const platform = getPlatformName(driver);
         if (platform === PLATFORM.android) {
           // Get element location for Android double tap
-          const element = await driver.findElement('id', args.elementUUID);
-          const elementRect = await getElementRect(
-            driver,
-            element['element-6066-11e4-a52e-4f735466cecf']
-          );
+          const elementRect = await getElementRect(driver, args.elementUUID);
 
           // Calculate center coordinates
           const x = elementRect.x + elementRect.width / 2;

--- a/src/tools/interactions/drag-and-drop.ts
+++ b/src/tools/interactions/drag-and-drop.ts
@@ -1,8 +1,14 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, getPlatformName } from '../../session-store.js';
+import { getPlatformName } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import { getElementRect, getWindowRect } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const DROP_PAUSE_DURATION_MS = 150;
 
@@ -130,10 +136,11 @@ export default function dragAndDrop(server: FastMCP): void {
       args: z.infer<typeof dragAndDropSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const platform = getPlatformName(driver);
@@ -213,23 +220,13 @@ export default function dragAndDrop(server: FastMCP): void {
           ? `element ${args.targetElementUUID}`
           : `coordinates (${endX}, ${endY})`;
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully performed drag and drop from ${sourceDesc} to ${targetDesc}.`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to perform drag and drop. Error: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully performed drag and drop from ${sourceDesc} to ${targetDesc}.`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to perform drag and drop. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -1,10 +1,15 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { getScreenshot } from '../../command.js';
 import { imageUtil } from '@appium/support';
 import { AIVisionFinder } from '../../ai-finder/vision-finder.js';
 import log from '../../logger.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 // Module-level singleton: ensures the LRU cache persists across tool calls.
 // Creating a new AIVisionFinder() on every call would reset the cache each time.
@@ -78,10 +83,11 @@ export default function findElement(server: FastMCP): void {
       args: z.infer<typeof findElementSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         // Route 1: Traditional locator strategy
@@ -95,14 +101,9 @@ export default function findElement(server: FastMCP): void {
             args.strategy,
             args.selector
           );
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${element['element-6066-11e4-a52e-4f735466cecf']}`,
-              },
-            ],
-          };
+          return textResult(
+            `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${element['element-6066-11e4-a52e-4f735466cecf']}`
+          );
         }
 
         // Route 2: AI vision-based finding
@@ -151,25 +152,11 @@ export default function findElement(server: FastMCP): void {
           responseText += `; vision image: ${result.annotatedImagePath}`;
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: responseText,
-            },
-          ],
-        };
-      } catch (err: any) {
-        const errorMessage = err.message || err.toString();
+        return textResult(responseText);
+      } catch (err: unknown) {
+        const errorMessage = toolErrorMessage(err);
         log.error('Failed to find element:', errorMessage);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to find element. Error: ${errorMessage}`,
-            },
-          ],
-        };
+        return errorResult(`Failed to find element. Error: ${errorMessage}`);
       }
     },
   });

--- a/src/tools/interactions/get-element-attribute.ts
+++ b/src/tools/interactions/get-element-attribute.ts
@@ -1,8 +1,13 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import { getElementAttribute } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function getElementAttributeTool(server: FastMCP): void {
   const schema = z.object({
@@ -31,10 +36,11 @@ export default function getElementAttributeTool(server: FastMCP): void {
       args: z.infer<typeof schema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const value = await getElementAttribute(
@@ -42,26 +48,15 @@ export default function getElementAttributeTool(server: FastMCP): void {
           args.elementUUID,
           args.attribute
         );
-        return {
-          content: [
-            {
-              type: 'text',
-              text:
-                value !== null
-                  ? `Attribute "${args.attribute}" of element ${args.elementUUID}: ${value}`
-                  : `Attribute "${args.attribute}" is not set on element ${args.elementUUID}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to get attribute "${args.attribute}" from element ${args.elementUUID}. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          value !== null
+            ? `Attribute "${args.attribute}" of element ${args.elementUUID}: ${value}`
+            : `Attribute "${args.attribute}" is not set on element ${args.elementUUID}`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to get attribute "${args.attribute}" from element ${args.elementUUID}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/get-page-source.ts
+++ b/src/tools/interactions/get-page-source.ts
@@ -1,12 +1,17 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import {
   createUIResource,
   createPageSourceInspectorUI,
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
 import { getPageSource as _getPageSource } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function getPageSource(server: FastMCP): void {
   const pageSourceSchema = z.object({
@@ -27,10 +32,11 @@ export default function getPageSource(server: FastMCP): void {
       args: z.infer<typeof pageSourceSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found. Please create a session first.');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const pageSource = await _getPageSource(driver);
@@ -38,18 +44,12 @@ export default function getPageSource(server: FastMCP): void {
           throw new Error('Page source is empty or null');
         }
 
-        const textResponse = {
-          content: [
-            {
-              type: 'text',
-              text:
-                'Page source retrieved successfully: \n' +
-                '```xml ' +
-                pageSource +
-                '```',
-            },
-          ],
-        };
+        const textResponse = textResult(
+          'Page source retrieved successfully: \n' +
+            '```xml ' +
+            pageSource +
+            '```'
+        );
 
         // Add interactive page source inspector UI
         const uiResource = createUIResource(
@@ -58,16 +58,10 @@ export default function getPageSource(server: FastMCP): void {
         );
 
         return addUIResourceToResponse(textResponse, uiResource);
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to get page source. Error: ${err.toString()}`,
-            },
-          ],
-          isError: true,
-        };
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to get page source. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/get-text.ts
+++ b/src/tools/interactions/get-text.ts
@@ -1,8 +1,13 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import { getElementText } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function getText(server: FastMCP): void {
   const getTextSchema = z.object({
@@ -25,30 +30,21 @@ export default function getText(server: FastMCP): void {
       args: z.infer<typeof getTextSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const text = await getElementText(driver, args.elementUUID);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully got text ${text} from element ${args.elementUUID}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to get text from element ${args.elementUUID}. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully got text ${text} from element ${args.elementUUID}`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to get text from element ${args.elementUUID}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/handle-alert.ts
+++ b/src/tools/interactions/handle-alert.ts
@@ -3,11 +3,16 @@ import { z } from 'zod';
 import { generateAllElementLocators } from '../../locators/generate-all-locators.js';
 import {
   DriverInstance,
-  getDriver,
   getPlatformName,
   PLATFORM,
 } from '../../session-store.js';
 import { elementClick, execute, getPageSource } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const ANDROID_LOCATOR_STRATEGY_ORDER = [
   'id',
@@ -121,24 +126,18 @@ export default function alert(server: FastMCP): void {
       args: z.infer<typeof appiumAlertSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         if (args.action === 'get_text') {
           const text = await (driver as any).getAlertText();
-          return {
-            content: [
-              {
-                type: 'text',
-                text: text
-                  ? `Alert text: "${text}"`
-                  : 'Alert is present but has no text.',
-              },
-            ],
-          };
+          return textResult(
+            text ? `Alert text: "${text}"` : 'Alert is present but has no text.'
+          );
         }
 
         const platform = getPlatformName(driver);
@@ -152,31 +151,21 @@ export default function alert(server: FastMCP): void {
           );
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully ${args.action}ed alert${
-                args.buttonLabel ? ` with button "${args.buttonLabel}"` : ''
-              }`,
-            },
-          ],
-        };
-      } catch (err: any) {
+        return textResult(
+          `Successfully ${args.action}ed alert${
+            args.buttonLabel ? ` with button "${args.buttonLabel}"` : ''
+          }`
+        );
+      } catch (err: unknown) {
         const contextStr =
           args.action === 'get_text'
             ? 'action=get_text'
             : args.buttonLabel
               ? `action=${args.action}, buttonLabel="${args.buttonLabel}"`
               : `action=${args.action}`;
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed alert action (${contextStr}). err: ${err.toString()}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed alert action (${contextStr}). err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/keyboard.ts
+++ b/src/tools/interactions/keyboard.ts
@@ -1,7 +1,12 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { execute } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function keyboard(server: FastMCP): void {
   const hideKeyboardSchema = z.object({
@@ -33,33 +38,21 @@ export default function keyboard(server: FastMCP): void {
       args: z.infer<typeof hideKeyboardSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const params =
           args.keys && args.keys.length > 0 ? { keys: args.keys } : {};
         await execute(driver, 'mobile: hideKeyboard', params);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: 'Keyboard dismissed successfully.',
-            },
-          ],
-        };
+        return textResult('Keyboard dismissed successfully.');
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to hide keyboard. Error: ${message}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed to hide keyboard. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });
@@ -83,10 +76,11 @@ export default function keyboard(server: FastMCP): void {
       args: { sessionId?: string },
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const raw = await execute(driver, 'mobile: isKeyboardShown', {});
@@ -95,24 +89,11 @@ export default function keyboard(server: FastMCP): void {
             `Unexpected isKeyboardShown result type: ${typeof raw}`
           );
         }
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({ keyboardShown: raw }, null, 2),
-            },
-          ],
-        };
+        return textResult(JSON.stringify({ keyboardShown: raw }, null, 2));
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to query keyboard visibility. Error: ${message}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed to query keyboard visibility. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/long-press.ts
+++ b/src/tools/interactions/long-press.ts
@@ -1,8 +1,14 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import { execute, getElementRect, performActions } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function longPress(server: FastMCP): void {
   const longPressSchema = z.object({
@@ -35,10 +41,11 @@ export default function longPress(server: FastMCP): void {
       args: z.infer<typeof longPressSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const platform = getPlatformName(driver);
@@ -95,23 +102,13 @@ export default function longPress(server: FastMCP): void {
           );
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully performed long press on element ${args.elementUUID}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to perform long press on element ${args.elementUUID}. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully performed long press on element ${args.elementUUID}`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to perform long press on element ${args.elementUUID}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/orientation.ts
+++ b/src/tools/interactions/orientation.ts
@@ -1,10 +1,15 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import {
   getOrientation as _getOrientation,
   setOrientation as _setOrientation,
 } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const orientationSchema = z.object({
   action: z
@@ -36,22 +41,18 @@ export default function orientation(server: FastMCP): void {
       args: z.infer<typeof orientationSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         if (args.action === 'get') {
           const currentOrientation = await _getOrientation(driver);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Successfully got orientation: ${currentOrientation}`,
-              },
-            ],
-          };
+          return textResult(
+            `Successfully got orientation: ${currentOrientation}`
+          );
         }
 
         if (!args.orientation) {
@@ -59,23 +60,13 @@ export default function orientation(server: FastMCP): void {
         }
 
         await _setOrientation(driver, args.orientation);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully set orientation to ${args.orientation}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to ${args.action} orientation. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully set orientation to ${args.orientation}`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to ${args.action} orientation. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/pinch.ts
+++ b/src/tools/interactions/pinch.ts
@@ -1,6 +1,6 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import {
   execute,
@@ -8,6 +8,12 @@ import {
   getWindowRect,
   performActions,
 } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function pinch(server: FastMCP): void {
   const pinchSchema = z.object({
@@ -53,10 +59,11 @@ export default function pinch(server: FastMCP): void {
       args: z.infer<typeof pinchSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const platform = getPlatformName(driver);
@@ -153,23 +160,13 @@ export default function pinch(server: FastMCP): void {
         }
 
         const target = elementUUID ? `element ${elementUUID}` : 'screen';
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully performed pinch ${direction} (scale=${scale}) on ${target}.`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to perform pinch gesture. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully performed pinch ${direction} (scale=${scale}) on ${target}.`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to perform pinch gesture. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/press-key.ts
+++ b/src/tools/interactions/press-key.ts
@@ -1,7 +1,6 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
 import {
-  getDriver,
   getPlatformName,
   isAndroidUiautomator2DriverSession,
   isXCUITestDriverSession,
@@ -11,6 +10,12 @@ import {
 import { execute } from '../../command.js';
 import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const ANDROID_KEYCODE_MAP: Record<string, number> = {
   BACK: 4,
@@ -91,10 +96,11 @@ export default function pressKey(server: FastMCP): void {
       args: z.infer<typeof pressKeySchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       const platform = getPlatformName(driver);
       const { key, keyCode, isLongPress } = args;
@@ -152,32 +158,15 @@ export default function pressKey(server: FastMCP): void {
           );
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text:
-                platform === PLATFORM.android
-                  ? `Successfully pressed key${
-                      key ? ` "${key}"` : ''
-                    } on Android.`
-                  : `Successfully pressed key${
-                      key ? ` "${key}"` : ''
-                    } on iOS/tvOS.`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to press key${
-                key ? ` "${key}"` : ''
-              }. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          platform === PLATFORM.android
+            ? `Successfully pressed key${key ? ` "${key}"` : ''} on Android.`
+            : `Successfully pressed key${key ? ` "${key}"` : ''} on iOS/tvOS.`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to press key${key ? ` "${key}"` : ''}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/screen-recording.ts
+++ b/src/tools/interactions/screen-recording.ts
@@ -2,13 +2,19 @@ import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import {
   startRecordingScreen as cmdStartRecording,
   stopRecordingScreen as cmdStopRecording,
 } from '../../command.js';
 import { resolveScreenshotDir } from '../../utils/paths.js';
 import crypto from 'node:crypto';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 /**
  * iOS-specific options for startRecordingScreen.
@@ -151,28 +157,21 @@ export default function screenRecording(server: FastMCP): void {
       args: z.infer<typeof screenRecordingSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         if (args.action === 'stop') {
           const base64Video = await cmdStopRecording(driver);
           if (!base64Video) {
-            return {
-              content: [
-                { type: 'text', text: 'No active screen recording to stop.' },
-              ],
-            };
+            return textResult('No active screen recording to stop.');
           }
 
           const filepath = await saveRecording(base64Video);
-          return {
-            content: [
-              { type: 'text', text: `Screen recording saved to: ${filepath}` },
-            ],
-          };
+          return textResult(`Screen recording saved to: ${filepath}`);
         }
 
         const platform = getPlatformName(driver);
@@ -231,19 +230,11 @@ export default function screenRecording(server: FastMCP): void {
         }
 
         await cmdStartRecording(driver, options);
-        return {
-          content: [{ type: 'text', text: 'Screen recording started.' }],
-        };
+        return textResult('Screen recording started.');
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed screen recording action ${args.action}. Error: ${message}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed screen recording action ${args.action}. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/screenshot.ts
+++ b/src/tools/interactions/screenshot.ts
@@ -13,6 +13,7 @@ import { getScreenshot } from '../../command.js';
 import z from 'zod';
 import { imageUtil } from '@appium/support';
 import { resolveScreenshotDir } from '../../utils/paths.js';
+import { textResult, errorResult, toolErrorMessage } from '../tool-response.js';
 
 export { resolveScreenshotDir };
 
@@ -42,7 +43,9 @@ export async function executeScreenshot(opts: {
 
   const driver = deps.getDriver(sessionId);
   if (!driver) {
-    throw new Error('No driver found');
+    return errorResult(
+      `No active driver session. Call create_session first or pass a valid sessionId.`
+    );
   }
 
   try {
@@ -80,14 +83,9 @@ export async function executeScreenshot(opts: {
     // Save screenshot to disk
     await deps.writeFile(filepath, screenshotBuffer);
 
-    const textResponse = {
-      content: [
-        {
-          type: 'text',
-          text: `Screenshot saved successfully to: ${filepath}`,
-        },
-      ],
-    };
+    const textResponse = textResult(
+      `Screenshot saved successfully to: ${filepath}`
+    );
 
     // Add interactive screenshot viewer UI
     const uiResource = createUIResource(
@@ -96,15 +94,10 @@ export async function executeScreenshot(opts: {
     );
 
     return addUIResourceToResponse(textResponse, uiResource);
-  } catch (err: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Failed to take screenshot. err: ${err.toString()}`,
-        },
-      ],
-    };
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to take screenshot. err: ${toolErrorMessage(err)}`
+    );
   }
 }
 

--- a/src/tools/interactions/set-value.ts
+++ b/src/tools/interactions/set-value.ts
@@ -1,8 +1,13 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import { setValue as _setValue } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function setValue(server: FastMCP): void {
   const setValueSchema = z
@@ -38,10 +43,11 @@ export default function setValue(server: FastMCP): void {
       args: z.infer<typeof setValueSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         await _setValue(
@@ -50,23 +56,13 @@ export default function setValue(server: FastMCP): void {
           args.text,
           args.w3cActions
         );
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully set value ${args.text} into element ${args.elementUUID}`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to set value ${args.text} into element ${args.elementUUID}. err: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(
+          `Successfully set value ${args.text} into element ${args.elementUUID}`
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to set value ${args.text} into element ${args.elementUUID}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/tap.ts
+++ b/src/tools/interactions/tap.ts
@@ -1,7 +1,12 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { performActions } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function tap(server: FastMCP): void {
   const tapSchema = z.object({
@@ -26,10 +31,11 @@ export default function tap(server: FastMCP): void {
       args: z.infer<typeof tapSchema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       const { x, y } = args;
 
@@ -49,23 +55,11 @@ export default function tap(server: FastMCP): void {
         ];
         await performActions(driver, operation);
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Successfully tapped at coordinates (${x}, ${y})`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to tap at coordinates (${x}, ${y}). Error: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(`Successfully tapped at coordinates (${x}, ${y})`);
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to tap at coordinates (${x}, ${y}). Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/interactions/window-size.ts
+++ b/src/tools/interactions/window-size.ts
@@ -1,7 +1,12 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver } from '../../session-store.js';
 import { getWindowSize as cmdGetWindowSize } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function getWindowSize(server: FastMCP): void {
   server.addTool({
@@ -22,28 +27,19 @@ export default function getWindowSize(server: FastMCP): void {
       args: { sessionId?: string },
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const { width, height } = await cmdGetWindowSize(driver);
-        return {
-          content: [
-            { type: 'text', text: `Width: ${width}, Height: ${height}` },
-          ],
-        };
+        return textResult(`Width: ${width}, Height: ${height}`);
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to get window size. Error: ${message}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed to get window size. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/ios/prepare-ios-simulator.ts
+++ b/src/tools/ios/prepare-ios-simulator.ts
@@ -18,6 +18,7 @@ import { zip } from '@appium/support';
 import { Simctl } from 'node-simctl';
 import { IOSManager } from '../../devicemanager/ios-manager.js';
 import log from '../../logger.js';
+import { textResult } from '../tool-response.js';
 
 const execAsync = promisify(exec);
 
@@ -478,14 +479,7 @@ export default function prepareIosSimulator(server: FastMCP): void {
         platform
       );
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(result),
-          },
-        ],
-      };
+      return textResult(JSON.stringify(result));
     },
   });
 }

--- a/src/tools/navigations/scroll-to-element.ts
+++ b/src/tools/navigations/scroll-to-element.ts
@@ -179,7 +179,7 @@ export default function scrollToElement(server: any): void {
             args.selector
           );
           return textResult(
-            `Successfully scrolled found element ${args.selector} after initial scroll.`
+            `Successfully scrolled and found element ${args.selector}.`
           );
         }
       } catch (err: unknown) {

--- a/src/tools/navigations/scroll-to-element.ts
+++ b/src/tools/navigations/scroll-to-element.ts
@@ -1,5 +1,11 @@
-import { getDriver, getPlatformName } from '../../session-store.js';
+import { getPlatformName } from '../../session-store.js';
 import { z } from 'zod';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const scrollToElementSchema = z.object({
   sessionId: z
@@ -135,12 +141,11 @@ export default function scrollToElement(server: any): void {
       openWorldHint: false,
     },
     execute: async (args: any, _context: any): Promise<any> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error(
-          'No active driver session. Please create a session first.'
-        );
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const platform = getPlatformName(driver);
@@ -151,14 +156,9 @@ export default function scrollToElement(server: any): void {
             args.strategy,
             args.selector
           );
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Element ${args.selector} is already visible on screen.`,
-              },
-            ],
-          };
+          return textResult(
+            `Element ${args.selector} is already visible on screen.`
+          );
         } catch (_error) {
           const direction = args.direction || 'down';
           switch (platform) {
@@ -178,24 +178,14 @@ export default function scrollToElement(server: any): void {
             args.strategy,
             args.selector
           );
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Successfully scrolled found element ${args.selector} after initial scroll.`,
-              },
-            ],
-          };
+          return textResult(
+            `Successfully scrolled found element ${args.selector} after initial scroll.`
+          );
         }
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to scroll and find element. Error: ${err.toString()}`,
-            },
-          ],
-        };
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to scroll and find element. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/navigations/scroll.ts
+++ b/src/tools/navigations/scroll.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import log from '../../logger.js';
 import { execute, getWindowRect, performActions } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function scroll(server: any): void {
   server.addTool({
@@ -22,12 +28,11 @@ export default function scroll(server: any): void {
       openWorldHint: false,
     },
     execute: async (args: any, _context: any): Promise<any> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error(
-          'No active driver session. Please create a session first.'
-        );
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const rect = await getWindowRect(driver);
@@ -82,23 +87,11 @@ export default function scroll(server: any): void {
             `Unsupported platform: ${getPlatformName(driver)}. Only Android and iOS are supported.`
           );
         }
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Scrolled ${args.direction} successfully.`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to scroll ${args.direction}. Error: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(`Scrolled ${args.direction} successfully.`);
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to scroll ${args.direction}. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/navigations/swipe.ts
+++ b/src/tools/navigations/swipe.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import log from '../../logger.js';
 import { elementUUIDScheme } from '../../schema.js';
 import {
@@ -8,6 +8,12 @@ import {
   getWindowRect,
   performActions,
 } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 function calculateSwipeCoordinates(
   direction: 'left' | 'right' | 'up' | 'down',
@@ -184,12 +190,11 @@ export default function swipe(server: any): void {
       openWorldHint: false,
     },
     execute: async (args: any, _context: any): Promise<any> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error(
-          'No active driver session. Please create a session first.'
-        );
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const platform = getPlatformName(driver);
@@ -345,23 +350,11 @@ export default function swipe(server: any): void {
           ? ` ${args.direction}`
           : ` from (${startX}, ${startY}) to (${endX}, ${endY})`;
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Swiped${directionText} successfully.`,
-            },
-          ],
-        };
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to perform swipe. Error: ${err.toString()}`,
-            },
-          ],
-        };
+        return textResult(`Swiped${directionText} successfully.`);
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to perform swipe. Error: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -21,6 +21,7 @@ import {
   createSessionDashboardUI,
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
+import { textResult } from '../tool-response.js';
 import WebDriver from 'webdriver';
 
 // Define capabilities type
@@ -409,14 +410,9 @@ export default function createSession(server: any): void {
 
         const totalSessions = listSessions().length;
 
-        const textResponse = {
-          content: [
-            {
-              type: 'text',
-              text: `${platform.toUpperCase()} session created successfully with ID: ${sessionIdStr}\nPlatform: ${finalCapabilities.platformName}\nAutomation: ${finalCapabilities['appium:automationName']}\nDevice: ${finalCapabilities['appium:deviceName']}\nActive sessions: ${totalSessions}`,
-            },
-          ],
-        };
+        const textResponse = textResult(
+          `${platform.toUpperCase()} session created successfully with ID: ${sessionIdStr}\nPlatform: ${finalCapabilities.platformName}\nAutomation: ${finalCapabilities['appium:automationName']}\nDevice: ${finalCapabilities['appium:deviceName']}\nActive sessions: ${totalSessions}`
+        );
 
         // Add interactive session dashboard UI
         const uiResource = createUIResource(

--- a/src/tools/session/delete-session.ts
+++ b/src/tools/session/delete-session.ts
@@ -4,6 +4,7 @@
 import { z } from 'zod';
 import { safeDeleteSession } from '../../session-store.js';
 import log from '../../logger.js';
+import { textResult, errorResult } from '../tool-response.js';
 
 export default function deleteSession(server: any): void {
   server.addTool({
@@ -28,40 +29,22 @@ export default function deleteSession(server: any): void {
         const deleted = await safeDeleteSession(args.sessionId);
 
         if (deleted) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: args.sessionId
-                  ? `Session ${args.sessionId} deleted successfully.`
-                  : 'Active session deleted successfully.',
-              },
-            ],
-          };
+          return textResult(
+            args.sessionId
+              ? `Session ${args.sessionId} deleted successfully.`
+              : 'Active session deleted successfully.'
+          );
         } else {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: args.sessionId
-                  ? `Session ${args.sessionId} not found or deletion already in progress.`
-                  : 'No active session found or deletion already in progress.',
-              },
-            ],
-          };
+          return textResult(
+            args.sessionId
+              ? `Session ${args.sessionId} not found or deletion already in progress.`
+              : 'No active session found or deletion already in progress.'
+          );
         }
       } catch (error: any) {
         log.error(`Error deleting session`, error);
-        // don't need to raise an error since session end means anyway we should create a new session
-        // to proceed further requests.
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Session delete might fail as error ${error}`,
-            },
-          ],
-        };
+        // don't raise an error — a failed deletion still means a new session is needed
+        return errorResult(`Session delete might fail as error ${error}`);
       }
     },
   });

--- a/src/tools/session/delete-session.ts
+++ b/src/tools/session/delete-session.ts
@@ -4,7 +4,7 @@
 import { z } from 'zod';
 import { safeDeleteSession } from '../../session-store.js';
 import log from '../../logger.js';
-import { textResult, errorResult } from '../tool-response.js';
+import { textResult, toolErrorMessage } from '../tool-response.js';
 
 export default function deleteSession(server: any): void {
   server.addTool({
@@ -41,10 +41,13 @@ export default function deleteSession(server: any): void {
               : 'No active session found or deletion already in progress.'
           );
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         log.error(`Error deleting session`, error);
-        // don't raise an error — a failed deletion still means a new session is needed
-        return errorResult(`Session delete might fail as error ${error}`);
+        // return a non-fatal success-shaped result — a failed deletion still means
+        // a new session is needed, so we don't want isError:true blocking the LLM
+        return textResult(
+          `Session delete may not have completed cleanly: ${toolErrorMessage(error)}`
+        );
       }
     },
   });

--- a/src/tools/session/device-info.ts
+++ b/src/tools/session/device-info.ts
@@ -1,8 +1,14 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { execute } from '../../command.js';
 import { BatteryState } from 'appium-xcuitest-driver/build/lib/commands/enum.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 // iOS: maps UIDeviceBatteryState values to human-readable strings
 // @see https://github.com/appium/appium-xcuitest-driver/blob/5bdad71/lib/commands/enum.ts#L91
@@ -65,30 +71,20 @@ export default function deviceInfo(server: FastMCP): void {
       openWorldHint: false,
     },
     execute: async (args: z.infer<typeof schema>): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        return {
-          content: [{ type: 'text', text: 'No driver found' }],
-          isError: true,
-        };
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       if (args.action === 'info') {
         try {
           const result = await execute(driver, 'mobile: deviceInfo', {});
-          return {
-            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-          };
+          return textResult(JSON.stringify(result, null, 2));
         } catch (err: unknown) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Failed to get device info: ${err instanceof Error ? err.message : String(err)}`,
-              },
-            ],
-            isError: true,
-          };
+          return errorResult(
+            `Failed to get device info: ${toolErrorMessage(err)}`
+          );
         }
       }
 
@@ -97,21 +93,11 @@ export default function deviceInfo(server: FastMCP): void {
           const platform = getPlatformName(driver);
           const raw = await execute(driver, 'mobile: batteryInfo', {});
           const formatted = formatBatteryInfo(platform, raw);
-          return {
-            content: [
-              { type: 'text', text: JSON.stringify(formatted, null, 2) },
-            ],
-          };
+          return textResult(JSON.stringify(formatted, null, 2));
         } catch (err: unknown) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Failed to get battery info: ${err instanceof Error ? err.message : String(err)}`,
-              },
-            ],
-            isError: true,
-          };
+          return errorResult(
+            `Failed to get battery info: ${toolErrorMessage(err)}`
+          );
         }
       }
 
@@ -122,26 +108,15 @@ export default function deviceInfo(server: FastMCP): void {
             params.format = args.format;
           }
           const time = await execute(driver, 'mobile: getDeviceTime', params);
-          return {
-            content: [{ type: 'text', text: String(time) }],
-          };
+          return textResult(String(time));
         } catch (err: unknown) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Failed to get device time: ${err instanceof Error ? err.message : String(err)}`,
-              },
-            ],
-            isError: true,
-          };
+          return errorResult(
+            `Failed to get device time: ${toolErrorMessage(err)}`
+          );
         }
       }
 
-      return {
-        content: [{ type: 'text', text: `Unknown action: ${args.action}` }],
-        isError: true,
-      };
+      return errorResult(`Unknown action: ${args.action}`);
     },
   });
 }

--- a/src/tools/session/file-transfer.ts
+++ b/src/tools/session/file-transfer.ts
@@ -1,7 +1,13 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { execute } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 /**
  * Normalize the return value of mobile: pullFile (driver may return a string
@@ -57,10 +63,11 @@ export default function fileTransfer(server: FastMCP): void {
       args: z.infer<typeof schema>,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const driver = getDriver(args.sessionId);
-      if (!driver) {
-        throw new Error('No driver found');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
       }
+      const { driver } = resolved;
 
       try {
         const platform = getPlatformName(driver);
@@ -86,14 +93,9 @@ export default function fileTransfer(server: FastMCP): void {
             );
           }
 
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Successfully pushed file to device path: ${args.remotePath}`,
-              },
-            ],
-          };
+          return textResult(
+            `Successfully pushed file to device path: ${args.remotePath}`
+          );
         }
 
         let raw: unknown;
@@ -112,28 +114,17 @@ export default function fileTransfer(server: FastMCP): void {
         }
 
         const base64 = normalizePullResult(raw);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                remotePath: args.remotePath,
-                platform,
-                contentBase64: base64,
-              }),
-            },
-          ],
-        };
+        return textResult(
+          JSON.stringify({
+            remotePath: args.remotePath,
+            platform,
+            contentBase64: base64,
+          })
+        );
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed file action ${args.action}. err: ${message}`,
-            },
-          ],
-        };
+        return errorResult(
+          `Failed file action ${args.action}. err: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/session/geolocation.ts
+++ b/src/tools/session/geolocation.ts
@@ -1,7 +1,13 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getDriver, getPlatformName, PLATFORM } from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
 import { execute } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const schema = z.object({
   action: z
@@ -46,15 +52,12 @@ const schema = z.object({
 
 type GeolocationArgs = z.infer<typeof schema>;
 
-function textResult(text: string): ContentResult {
-  return { content: [{ type: 'text', text }] };
-}
-
 async function handleGet(args: GeolocationArgs): Promise<ContentResult> {
-  const driver = getDriver(args.sessionId);
-  if (!driver) {
-    throw new Error('No driver found');
+  const resolved = resolveDriver(args.sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
   }
+  const { driver } = resolved;
 
   const platform = getPlatformName(driver);
   let result: Record<string, any>;
@@ -81,10 +84,11 @@ async function handleSet(args: GeolocationArgs): Promise<ContentResult> {
     throw new Error('latitude and longitude are required for action=set');
   }
 
-  const driver = getDriver(args.sessionId);
-  if (!driver) {
-    throw new Error('No driver found');
+  const resolved = resolveDriver(args.sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
   }
+  const { driver } = resolved;
 
   const platform = getPlatformName(driver);
   const { latitude, longitude, altitude } = args;
@@ -113,10 +117,11 @@ async function handleSet(args: GeolocationArgs): Promise<ContentResult> {
 }
 
 async function handleReset(args: GeolocationArgs): Promise<ContentResult> {
-  const driver = getDriver(args.sessionId);
-  if (!driver) {
-    throw new Error('No driver found');
+  const resolved = resolveDriver(args.sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
   }
+  const { driver } = resolved;
 
   const platform = getPlatformName(driver);
 
@@ -158,9 +163,9 @@ export default function geolocation(server: FastMCP): void {
           case 'reset':
             return await handleReset(args);
         }
-      } catch (err: any) {
-        return textResult(
-          `Failed to ${args.action} geolocation. Error: ${err.toString()}`
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to ${args.action} geolocation. Error: ${toolErrorMessage(err)}`
         );
       }
     },

--- a/src/tools/session/list-sessions.ts
+++ b/src/tools/session/list-sessions.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { getDriver, getSessionId, listSessions } from '../../session-store.js';
+import { textResult } from '../tool-response.js';
 
 export default function listSessionsTool(server: any): void {
   server.addTool({
@@ -16,14 +17,7 @@ export default function listSessionsTool(server: any): void {
       const activeSessionId = getSessionId();
 
       if (sessions.length === 0) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: 'No active sessions found.',
-            },
-          ],
-        };
+        return textResult('No active sessions found.');
       }
 
       const sessionSummary = sessions
@@ -34,14 +28,9 @@ export default function listSessionsTool(server: any): void {
         })
         .join('\n');
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Active session: ${activeSessionId || 'Unknown'}\nSelect with: select_session { "sessionId": "..." }\n\nSessions:\n${sessionSummary}`,
-          },
-        ],
-      };
+      return textResult(
+        `Active session: ${activeSessionId || 'Unknown'}\nSelect with: select_session { "sessionId": "..." }\n\nSessions:\n${sessionSummary}`
+      );
     },
   });
 }

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -10,6 +10,7 @@ import {
   createDevicePickerUI,
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
+import { textResult } from '../tool-response.js';
 
 // Store selected device globally
 let selectedDeviceUdid: string | null = null;
@@ -67,26 +68,21 @@ function selectAndroidDevice(deviceUdid: string, devices: any[]): void {
  * Format device selection response for Android
  */
 function formatAndroidSelectionResponse(deviceUdid: string): any {
-  return {
-    content: [
+  return textResult(
+    JSON.stringify(
       {
-        type: 'text',
-        text: JSON.stringify(
-          {
-            message: `✅ Device selected: ${deviceUdid}`,
-            instructions:
-              '🚀 You can now create a session using the create_session tool with:',
-            platform: 'android',
-            capabilities: {
-              'appium:udid': deviceUdid,
-            },
-          },
-          null,
-          2
-        ),
+        message: `✅ Device selected: ${deviceUdid}`,
+        instructions:
+          '🚀 You can now create a session using the create_session tool with:',
+        platform: 'android',
+        capabilities: {
+          'appium:udid': deviceUdid,
+        },
       },
-    ],
-  };
+      null,
+      2
+    )
+  );
 }
 
 /**
@@ -97,14 +93,9 @@ function formatAndroidListResponse(devices: any[]): any {
     .map((device, index) => `  ${index + 1}. ${device.udid}`)
     .join('\n');
 
-  const textResponse = {
-    content: [
-      {
-        type: 'text',
-        text: `📱 Available Android devices/emulators (${devices.length}):\n${deviceList}\n\n⚠️ IMPORTANT: Please ask the user which device they want to use.\n\nOnce the user selects a device, call this tool again with the deviceUdid parameter set to their chosen device UDID.`,
-      },
-    ],
-  };
+  const textResponse = textResult(
+    `📱 Available Android devices/emulators (${devices.length}):\n${deviceList}\n\n⚠️ IMPORTANT: Please ask the user which device they want to use.\n\nOnce the user selects a device, call this tool again with the deviceUdid parameter set to their chosen device UDID.`
+  );
 
   // Add interactive UI picker
   const uiResource = createUIResource(
@@ -179,26 +170,21 @@ function formatIOSSelectionResponse(
   deviceName: string,
   deviceUdid: string
 ): any {
-  return {
-    content: [
+  return textResult(
+    JSON.stringify(
       {
-        type: 'text',
-        text: JSON.stringify(
-          {
-            message: `✅ Device selected: ${deviceName} (${deviceUdid})`,
-            instructions:
-              '🚀 You can now call the prepare_ios_simulator tool to boot and setup WDA on the simulator.',
-            platform: 'ios',
-            capabilities: {
-              'appium:udid': deviceUdid,
-            },
-          },
-          null,
-          2
-        ),
+        message: `✅ Device selected: ${deviceName} (${deviceUdid})`,
+        instructions:
+          '🚀 You can now call the prepare_ios_simulator tool to boot and setup WDA on the simulator.',
+        platform: 'ios',
+        capabilities: {
+          'appium:udid': deviceUdid,
+        },
       },
-    ],
-  };
+      null,
+      2
+    )
+  );
 }
 
 /**
@@ -215,14 +201,9 @@ function formatIOSListResponse(
     )
     .join('\n');
 
-  const textResponse = {
-    content: [
-      {
-        type: 'text',
-        text: `📱 Available iOS ${iosDeviceType === 'simulator' ? 'simulators' : 'devices'} (${devices.length}):\n${deviceList}\n\n⚠️ IMPORTANT: Please ask the user which device they want to use.\n\nOnce the user selects a device, call this tool again with the deviceUdid parameter set to their chosen device UDID.`,
-      },
-    ],
-  };
+  const textResponse = textResult(
+    `📱 Available iOS ${iosDeviceType === 'simulator' ? 'simulators' : 'devices'} (${devices.length}):\n${deviceList}\n\n⚠️ IMPORTANT: Please ask the user which device they want to use.\n\nOnce the user selects a device, call this tool again with the deviceUdid parameter set to their chosen device UDID.`
+  );
 
   // Add interactive UI picker
   const uiResource = createUIResource(

--- a/src/tools/session/select-session.ts
+++ b/src/tools/session/select-session.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { setActiveSession } from '../../session-store.js';
+import { textResult, errorResult } from '../tool-response.js';
 
 export default function selectSession(server: any): void {
   server.addTool({
@@ -17,25 +18,12 @@ export default function selectSession(server: any): void {
       const updated = setActiveSession(args.sessionId);
 
       if (!updated) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Session ${args.sessionId} was not found. Use list_sessions to see available IDs.`,
-            },
-          ],
-          isError: true,
-        };
+        return errorResult(
+          `Session ${args.sessionId} was not found. Use list_sessions to see available IDs.`
+        );
       }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Session ${args.sessionId} is now active.`,
-          },
-        ],
-      };
+      return textResult(`Session ${args.sessionId} is now active.`);
     },
   });
 }

--- a/src/tools/test-generation/generate-tests.ts
+++ b/src/tools/test-generation/generate-tests.ts
@@ -1,5 +1,6 @@
 import { FastMCP } from 'fastmcp';
 import { z } from 'zod';
+import { textResult } from '../tool-response.js';
 
 export default function generateTest(server: FastMCP): void {
   const generateTestSchema = z.object({
@@ -34,15 +35,7 @@ export default function generateTest(server: FastMCP): void {
       readOnlyHint: false,
       openWorldHint: false,
     },
-    execute: async (args: any, _context: any): Promise<any> => ({
-      content: [
-        {
-          type: 'text',
-          text: instructions({
-            steps: args.steps,
-          }),
-        },
-      ],
-    }),
+    execute: async (args: any, _context: any): Promise<any> =>
+      textResult(instructions({ steps: args.steps })),
   });
 }

--- a/src/tools/test-generation/locators.ts
+++ b/src/tools/test-generation/locators.ts
@@ -11,7 +11,6 @@
  */
 import { z } from 'zod';
 import {
-  getDriver,
   isAndroidUiautomator2DriverSession,
   isXCUITestDriverSession,
 } from '../../session-store.js';
@@ -22,6 +21,12 @@ import {
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
 import { getPageSource } from '../../command.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 export default function generateLocators(server: any): void {
   server.addTool({
@@ -42,69 +47,53 @@ export default function generateLocators(server: any): void {
       { log }: any
     ): Promise<any> => {
       log.info('Getting page source');
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) return resolved.result;
+      const { driver } = resolved;
+
       try {
-        // Check for active driver session
-
-        const driver = getDriver(args.sessionId);
-        if (!driver) {
-          throw new Error(
-            'No active driver session. Please create a session first.'
-          );
+        const pageSource = await getPageSource(driver);
+        if (!pageSource) {
+          return errorResult('Page source is empty or null.');
         }
 
-        try {
-          // Get the page source from the driver
-          const pageSource = await getPageSource(driver);
-          let driverName;
-          if (isAndroidUiautomator2DriverSession(driver)) {
-            driverName = await driver.caps.automationName?.toLowerCase();
-          } else if (isXCUITestDriverSession(driver)) {
-            driverName = await driver.caps.automationName?.toLowerCase();
-          } else {
-            driverName =
-              await driver.capabilities['appium:automationName']?.toLowerCase();
-          }
-          if (!pageSource) {
-            throw new Error('Page source is empty or null');
-          }
-          const sampleXML = pageSource;
-          const interactableElements = generateAllElementLocators(
-            sampleXML,
-            true,
-            driverName,
-            {
-              fetchableOnly: true,
-            }
-          );
+        let driverName: string;
+        if (isAndroidUiautomator2DriverSession(driver)) {
+          driverName = driver.caps.automationName?.toLowerCase() ?? '';
+        } else if (isXCUITestDriverSession(driver)) {
+          driverName = driver.caps.automationName?.toLowerCase() ?? '';
+        } else {
+          driverName =
+            driver.capabilities['appium:automationName']?.toLowerCase() ?? '';
+        }
 
-          const textResponse = {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({
-                  interactableElements,
-                  message: 'Page source retrieved successfully',
-                  instruction: `This the locators for the current page. Use this to generate code for the current page.
+        const interactableElements = generateAllElementLocators(
+          pageSource,
+          true,
+          driverName,
+          { fetchableOnly: true }
+        );
+
+        const textResponse = textResult(
+          JSON.stringify({
+            interactableElements,
+            message: 'Page source retrieved successfully',
+            instruction: `This the locators for the current page. Use this to generate code for the current page.
                      Using the template provided by generate://code-with-locators resource.`,
-                }),
-              },
-            ],
-          };
+          })
+        );
 
-          // Add interactive locator generator UI
-          const uiResource = createUIResource(
-            `ui://appium-mcp/locator-generator/${Date.now()}`,
-            createLocatorGeneratorUI(interactableElements)
-          );
+        const uiResource = createUIResource(
+          `ui://appium-mcp/locator-generator/${Date.now()}`,
+          createLocatorGeneratorUI(interactableElements)
+        );
 
-          return addUIResourceToResponse(textResponse, uiResource);
-        } catch (parseError: any) {
-          log.error('Error parsing XML:', parseError);
-          throw new Error(`Failed to parse XML: ${parseError.message}`);
-        }
-      } catch (error: any) {
-        log.error('Error getting page source:', error);
-        throw new Error(`Failed to get page source: ${error.message}`);
+        return addUIResourceToResponse(textResponse, uiResource);
+      } catch (err: unknown) {
+        log.error('Error getting page source:', err);
+        return errorResult(
+          `Failed to get page source: ${toolErrorMessage(err)}`
+        );
       }
     },
   });

--- a/src/tools/test-generation/locators.ts
+++ b/src/tools/test-generation/locators.ts
@@ -80,7 +80,7 @@ export default function generateLocators(server: any): void {
           JSON.stringify({
             interactableElements,
             message: 'Page source retrieved successfully',
-            instruction: `This the locators for the current page. Use this to generate code for the current page.
+            instruction: `These are the locators for the current page. Use this to generate code for the current page.
                      Using the template provided by generate://code-with-locators resource.`,
           })
         );

--- a/src/tools/test-generation/locators.ts
+++ b/src/tools/test-generation/locators.ts
@@ -48,7 +48,9 @@ export default function generateLocators(server: any): void {
     ): Promise<any> => {
       log.info('Getting page source');
       const resolved = resolveDriver(args.sessionId);
-      if (!resolved.ok) return resolved.result;
+      if (!resolved.ok) {
+        return resolved.result;
+      }
       const { driver } = resolved;
 
       try {


### PR DESCRIPTION
## Summary

- Completes the migration started in #263, all remaining tools that still used hand-built `{ content: [...] }` objects, direct `getDriver()` calls, or `throw`
- for tool-execution errors have been updated to use the shared helpers from `src/tools/tool-response.ts`.

Also fixes a bug in `appium_double_tap` on Android where element lookup was broken due to incorrectly re-finding the element by ID instead of using the provided UUID directly.

## Changes

**Migration to shared helpers** --> replaced inline content objects and `getDriver` calls across:
- `session/list-sessions.ts` — `textResult` for all return paths
- `session/delete-session.ts` — `textResult` / `errorResult`
- `session/select-session.ts` — `errorResult` replaces manual `isError: true`
- `session/create-session.ts` — `textResult` for success response
- `session/select-device.ts` — `textResult` in all formatter functions
- `ios/prepare-ios-simulator.ts` — `textResult` for result output
- `test-generation/locators.ts` — `resolveDriver` + `textResult` / `errorResult` (full migration)
- `test-generation/generate-tests.ts` — `textResult` for instruction output

**Bug fix** --> 
`interactions/double-tap.ts`:
on Android, the element rect lookup was calling `findElement('id', uuid)` when `uuid` is already the WebDriver element reference, not an accessibility ID. Now passes the UUID directly to `getElementRect`.

## What was left as is

- `list-apps.ts` / `resolve-app-id.ts` --> internal utility helpers that throw;
  callers already wrap them in try/catch with `errorResult`. Changing these would require a different return type, not covered by this PR
- `screenshot.ts` — uses `deps.getDriver` intentionally for dependency injection in tests; already uses `textResult` / `errorResult` for all responses