### PR TITLE
fix(click): rename default export to clickElement

### DIFF
--- a/src/tools/interactions/click.ts
+++ b/src/tools/interactions/click.ts
@@ -13,7 +13,7 @@ import {
   toolErrorMessage,
 } from '../tool-response.js';
 
-export default function generateTest(server: FastMCP): void {
+export default function clickElement(server: FastMCP): void {
   const clickActionSchema = z.object({
     elementUUID: elementUUIDScheme,
     sessionId: z


### PR DESCRIPTION
rename export default function generateTest → export default function clickElement to be:
- Clearer code navigation, grep, and stack traces
- No behavioral change to appium_click