### PR TITLE
feat: scroll-until-found for appium_find_element

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ The default regex pattern allows any URL that starts with `http://` or `https://
 
 | Tool                  | Description                                                                                  |
 | --------------------- | -------------------------------------------------------------------------------------------- |
-| `appium_find_element` | Find a specific element using traditional locator strategies (xpath, id, accessibility id, etc.) **OR** AI-powered natural language descriptions (e.g., "yellow search button at bottom"). Traditional mode supports optional **`scrollUntilFound`**: scroll between find attempts until the element appears, the page source stops changing after a scroll, or **`maxScrollAttempts`** is reached (not available with `ai_instruction`). |
-| `appium_gesture`      | Perform a touch gesture. `action` = `tap`, `double_tap`, `long_press`, `scroll`, `swipe`, `pinch_zoom`, or `scroll_to_element`. Supports element UUIDs (including AI-found `ai-element:` UUIDs) and raw coordinates. For swipe, use `speed` = `slow` \| `normal` \| `fast` (fast for pull-to-refresh). |
+| `appium_find_element` | Find a specific element using traditional locator strategies (xpath, id, accessibility id, etc.) **OR** AI-powered natural language descriptions (e.g., "yellow search button at bottom"). To scroll until an element appears, use **`appium_gesture`** with **`action=scroll_to_element`** (same `strategy` / `selector` as find). |
+| `appium_gesture`      | Perform a touch gesture. `action` = `tap`, `double_tap`, `long_press`, `scroll`, `swipe`, `pinch_zoom`, or **`scroll_to_element`**. **`scroll_to_element`** scrolls vertically (`direction` = `up` \| `down`) until the locator matches, **page source stops changing** after a scroll (end of list), or **`maxScrollAttempts`** (default 10, max 80). Optional **`scrollDistance`** (0.05–1) or **`scrollDistancePreset`** = `small` \| `medium` \| `large`. Supports element UUIDs and raw coordinates for other actions. For swipe, use `speed` = `slow` \| `normal` \| `fast` (fast for pull-to-refresh). |
 | `appium_drag_and_drop` | Perform a drag and drop gesture from a source location to a target location (supports element-to-element, element-to-coordinates, coordinates-to-element, and coordinates-to-coordinates) |
 | `appium_perform_actions` | Execute raw W3C Actions API sequences for custom multi-touch gestures (rotate, three-finger swipe, edge swipes, precise timing). Prefer `appium_gesture` for standard gestures. |
 | `appium_set_value`    | Enter text into an input field                                                               |
@@ -399,20 +399,22 @@ This example demonstrates a complete e-commerce checkout flow that can be automa
 }
 ```
 
-**Traditional mode — scroll until found (lists / long screens):**
+**Scroll until element is on screen (`appium_gesture` / `scroll_to_element`):**
 ```json
 {
-  "tool": "appium_find_element",
+  "tool": "appium_gesture",
   "arguments": {
+    "action": "scroll_to_element",
     "strategy": "xpath",
     "selector": "//*[contains(@text,'My header')]",
-    "scrollUntilFound": true,
-    "scrollDirection": "down",
-    "scrollDistance": 0.45,
-    "maxScrollAttempts": 40
+    "direction": "down",
+    "maxScrollAttempts": 40,
+    "scrollDistancePreset": "medium"
   }
 }
 ```
+
+Use **`scrollDistance`** (0.05–1) instead of **`scrollDistancePreset`** when you want an exact fraction. Then call **`appium_find_element`** with the same `strategy` / `selector` to obtain the element id.
 
 **AI Mode (Natural Language):**
 ```json

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ The default regex pattern allows any URL that starts with `http://` or `https://
 
 | Tool                  | Description                                                                                  |
 | --------------------- | -------------------------------------------------------------------------------------------- |
-| `appium_find_element` | Find a specific element using traditional locator strategies (xpath, id, accessibility id, etc.) **OR** AI-powered natural language descriptions (e.g., "yellow search button at bottom"). Supports both traditional and AI modes. |
+| `appium_find_element` | Find a specific element using traditional locator strategies (xpath, id, accessibility id, etc.) **OR** AI-powered natural language descriptions (e.g., "yellow search button at bottom"). Traditional mode supports optional **`scrollUntilFound`**: scroll between find attempts until the element appears, the page source stops changing after a scroll, or **`maxScrollAttempts`** is reached (not available with `ai_instruction`). |
 | `appium_gesture`      | Perform a touch gesture. `action` = `tap`, `double_tap`, `long_press`, `scroll`, `swipe`, `pinch_zoom`, or `scroll_to_element`. Supports element UUIDs (including AI-found `ai-element:` UUIDs) and raw coordinates. For swipe, use `speed` = `slow` \| `normal` \| `fast` (fast for pull-to-refresh). |
 | `appium_drag_and_drop` | Perform a drag and drop gesture from a source location to a target location (supports element-to-element, element-to-coordinates, coordinates-to-element, and coordinates-to-coordinates) |
 | `appium_perform_actions` | Execute raw W3C Actions API sequences for custom multi-touch gestures (rotate, three-finger swipe, edge swipes, precise timing). Prefer `appium_gesture` for standard gestures. |
@@ -395,6 +395,21 @@ This example demonstrates a complete e-commerce checkout flow that can be automa
   "arguments": {
     "strategy": "xpath",
     "selector": "//android.widget.Button[@text='Search']"
+  }
+}
+```
+
+**Traditional mode — scroll until found (lists / long screens):**
+```json
+{
+  "tool": "appium_find_element",
+  "arguments": {
+    "strategy": "xpath",
+    "selector": "//*[contains(@text,'My header')]",
+    "scrollUntilFound": true,
+    "scrollDirection": "down",
+    "scrollDistance": 0.45,
+    "maxScrollAttempts": 40
   }
 }
 ```

--- a/src/tools/gestures/handlers/scroll-to-element.ts
+++ b/src/tools/gestures/handlers/scroll-to-element.ts
@@ -57,10 +57,7 @@ export async function handleScrollToElement(
       : 'down';
 
   const maxScroll = args.maxScrollAttempts;
-  if (
-    args.scrollDistancePreset &&
-    args.scrollDistance !== undefined
-  ) {
+  if (args.scrollDistancePreset && args.scrollDistance !== undefined) {
     log.warn(
       'scroll_to_element: scrollDistancePreset is set; ignoring scrollDistance'
     );

--- a/src/tools/gestures/handlers/scroll-to-element.ts
+++ b/src/tools/gestures/handlers/scroll-to-element.ts
@@ -1,6 +1,7 @@
 import type { ContentResult } from 'fastmcp';
 import type { DriverInstance } from '../../../session-store.js';
 import { getPageSource } from '../../../command.js';
+import log from '../../../logger.js';
 import {
   errorResult,
   textResult,
@@ -56,6 +57,14 @@ export async function handleScrollToElement(
       : 'down';
 
   const maxScroll = args.maxScrollAttempts;
+  if (
+    args.scrollDistancePreset &&
+    args.scrollDistance !== undefined
+  ) {
+    log.warn(
+      'scroll_to_element: scrollDistancePreset is set; ignoring scrollDistance'
+    );
+  }
   const distance = resolveScrollDistance(args);
 
   try {

--- a/src/tools/gestures/handlers/scroll-to-element.ts
+++ b/src/tools/gestures/handlers/scroll-to-element.ts
@@ -1,15 +1,32 @@
 import type { ContentResult } from 'fastmcp';
 import type { DriverInstance } from '../../../session-store.js';
-import { getPlatformName, PLATFORM } from '../../../session-store.js';
-import { execute, getWindowRect, performActions } from '../../../command.js';
+import { getPageSource } from '../../../command.js';
 import {
   errorResult,
   textResult,
   toolErrorMessage,
 } from '../../tool-response.js';
 import type { GestureArgs } from '../schema.js';
+import { performVerticalScroll } from './swipe-scroll.js';
 
-const MAX_SCROLL_ATTEMPTS = 10;
+const PRESET_TO_DISTANCE: Record<
+  NonNullable<GestureArgs['scrollDistancePreset']>,
+  number
+> = {
+  small: 0.25,
+  medium: 0.45,
+  large: 1,
+};
+
+function resolveScrollDistance(args: GestureArgs): number {
+  if (args.scrollDistancePreset) {
+    return PRESET_TO_DISTANCE[args.scrollDistancePreset];
+  }
+  if (args.scrollDistance !== undefined) {
+    return args.scrollDistance;
+  }
+  return 0.45;
+}
 
 async function tryFindElement(
   driver: DriverInstance,
@@ -22,45 +39,6 @@ async function tryFindElement(
   } catch {
     return false;
   }
-}
-
-async function performW3CScroll(
-  driver: DriverInstance,
-  direction: 'up' | 'down'
-): Promise<void> {
-  const { width, height } = await getWindowRect(driver);
-  const startX = Math.floor(width / 2);
-  const startY =
-    direction === 'down' ? Math.floor(height * 0.8) : Math.floor(height * 0.2);
-  const endY =
-    direction === 'down' ? Math.floor(height * 0.2) : Math.floor(height * 0.8);
-
-  await performActions(driver, [
-    {
-      type: 'pointer',
-      id: 'finger1',
-      parameters: { pointerType: 'touch' },
-      actions: [
-        { type: 'pointerMove', duration: 0, x: startX, y: startY },
-        { type: 'pointerDown', button: 0 },
-        { type: 'pause', duration: 250 },
-        { type: 'pointerMove', duration: 600, x: startX, y: endY },
-        { type: 'pointerUp', button: 0 },
-      ],
-    },
-  ]);
-}
-
-async function scrollOnce(
-  driver: DriverInstance,
-  direction: 'up' | 'down'
-): Promise<void> {
-  const platform = getPlatformName(driver);
-  if (platform === PLATFORM.ios) {
-    await execute(driver, 'mobile: scroll', { direction });
-    return;
-  }
-  await performW3CScroll(driver, direction);
 }
 
 export async function handleScrollToElement(
@@ -77,6 +55,9 @@ export async function handleScrollToElement(
       ? args.direction
       : 'down';
 
+  const maxScroll = args.maxScrollAttempts;
+  const distance = resolveScrollDistance(args);
+
   try {
     if (await tryFindElement(driver, args.strategy, args.selector)) {
       return textResult(
@@ -84,17 +65,34 @@ export async function handleScrollToElement(
       );
     }
 
-    for (let attempt = 1; attempt <= MAX_SCROLL_ATTEMPTS; attempt++) {
-      await scrollOnce(driver, direction);
+    let scrollsDone = 0;
+    while (scrollsDone < maxScroll) {
+      const xmlBefore = await getPageSource(driver);
+      try {
+        await performVerticalScroll(driver, { direction, distance });
+      } catch (scrollErr: unknown) {
+        return errorResult(
+          `Scroll failed during scroll_to_element: ${toolErrorMessage(scrollErr)}`
+        );
+      }
+      const xmlAfter = await getPageSource(driver);
+      scrollsDone++;
+
       if (await tryFindElement(driver, args.strategy, args.selector)) {
         return textResult(
-          `Successfully scrolled to element ${args.selector} after ${attempt} scroll(s).`
+          `Successfully scrolled to element ${args.selector} after ${scrollsDone} scroll(s).`
+        );
+      }
+
+      if (xmlBefore === xmlAfter) {
+        return errorResult(
+          `Element not found; page source did not change after scroll (likely end of scrollable content). selector=${args.selector}`
         );
       }
     }
 
     return errorResult(
-      `Element ${args.selector} not found after ${MAX_SCROLL_ATTEMPTS} scrolls in direction '${direction}'.`
+      `Element ${args.selector} not found after ${maxScroll} scroll(s) in direction '${direction}'.`
     );
   } catch (err) {
     return errorResult(`Failed to scroll_to_element. ${toolErrorMessage(err)}`);

--- a/src/tools/gestures/handlers/swipe-scroll.ts
+++ b/src/tools/gestures/handlers/swipe-scroll.ts
@@ -55,8 +55,7 @@ export type VerticalScrollOptions = {
 
 /**
  * Vertical swipe in the middle of the window, scaled by `distance` (0.05–1).
- * Used by `appium_find_element` when `scrollUntilFound` is true; matches the
- * legacy `appium_scroll` gesture distances.
+ * Used by `appium_gesture` `scroll_to_element`; matches legacy scroll distances.
  */
 export async function performVerticalScroll(
   driver: DriverInstance,

--- a/src/tools/gestures/handlers/swipe-scroll.ts
+++ b/src/tools/gestures/handlers/swipe-scroll.ts
@@ -26,6 +26,85 @@ interface Rect {
 
 const SCROLL_DURATION_MS = 800;
 const SCROLL_INITIAL_PAUSE_MS = 250;
+/** Pointer move duration for programmatic vertical scroll (matches legacy appium_scroll). */
+const VERTICAL_SCROLL_MOVE_MS = 600;
+
+function verticalScrollYs(
+  height: number,
+  direction: 'up' | 'down',
+  distance: number
+): { startY: number; endY: number } {
+  const mid = height * 0.5;
+  const halfSpan = height * 0.3 * distance;
+  if (direction === 'down') {
+    return {
+      startY: Math.floor(mid + halfSpan),
+      endY: Math.floor(mid - halfSpan),
+    };
+  }
+  return {
+    startY: Math.floor(mid - halfSpan),
+    endY: Math.floor(mid + halfSpan),
+  };
+}
+
+export type VerticalScrollOptions = {
+  direction: 'up' | 'down';
+  distance: number;
+};
+
+/**
+ * Vertical swipe in the middle of the window, scaled by `distance` (0.05–1).
+ * Used by `appium_find_element` when `scrollUntilFound` is true; matches the
+ * legacy `appium_scroll` gesture distances.
+ */
+export async function performVerticalScroll(
+  driver: DriverInstance,
+  options: VerticalScrollOptions
+): Promise<void> {
+  const rect = await getWindowRect(driver);
+  const { width, height } = rect;
+  const startX = Math.floor(width / 2);
+  const { startY, endY } = verticalScrollYs(
+    height,
+    options.direction,
+    options.distance
+  );
+
+  if (getPlatformName(driver) === PLATFORM.android) {
+    await performActions(driver, [
+      {
+        type: 'pointer',
+        id: 'finger1',
+        parameters: { pointerType: 'touch' },
+        actions: [
+          { type: 'pointerMove', duration: 0, x: startX, y: startY },
+          { type: 'pointerDown', button: 0 },
+          { type: 'pause', duration: SCROLL_INITIAL_PAUSE_MS },
+          {
+            type: 'pointerMove',
+            duration: VERTICAL_SCROLL_MOVE_MS,
+            x: startX,
+            y: endY,
+          },
+          { type: 'pointerUp', button: 0 },
+        ],
+      },
+    ]);
+  } else if (getPlatformName(driver) === PLATFORM.ios) {
+    await execute(driver, 'mobile: scroll', {
+      direction: options.direction,
+      startX,
+      startY,
+      endX: startX,
+      endY,
+    });
+  } else {
+    throw new Error(
+      `Unsupported platform: ${getPlatformName(driver)}. Only Android and iOS are supported.`
+    );
+  }
+}
 
 const SWIPE_SPEED_PROFILES = {
   slow: { duration: 600, initialPause: 250 },

--- a/src/tools/gestures/schema.ts
+++ b/src/tools/gestures/schema.ts
@@ -16,6 +16,9 @@ export type GestureAction = (typeof GESTURE_ACTIONS)[number];
 export const SWIPE_SPEEDS = ['slow', 'normal', 'fast'] as const;
 export type SwipeSpeed = (typeof SWIPE_SPEEDS)[number];
 
+export const SCROLL_DISTANCE_PRESETS = ['small', 'medium', 'large'] as const;
+export type ScrollDistancePreset = (typeof SCROLL_DISTANCE_PRESETS)[number];
+
 export const LOCATOR_STRATEGIES = [
   'xpath',
   'id',
@@ -39,7 +42,9 @@ export const gestureSchema = z.object({
         `scroll: browse a list, feed, or page to reveal content. ` +
         `swipe: dismiss a card, switch screens or tabs, navigate a carousel, or pull-to-refresh (use speed=fast). ` +
         `pinch_zoom: zoom in (scale > 1) or out (scale < 1) on maps, images, or any zoomable view. ` +
-        `scroll_to_element: scroll until a specific element is on screen.`
+        `scroll_to_element: scroll until a specific element is on screen (strategy + selector + direction up|down). ` +
+        `Stops when the element is found, page source is unchanged after a scroll (end of scrollable content), or maxScrollAttempts is reached. ` +
+        `Optional scrollDistance (0.05–1) or scrollDistancePreset (small|medium|large).`
     ),
 
   elementUUID: elementUUIDScheme
@@ -138,6 +143,35 @@ export const gestureSchema = z.object({
     .string()
     .optional()
     .describe(`Locator selector value. Required for: scroll_to_element.`),
+
+  maxScrollAttempts: z
+    .number()
+    .int()
+    .min(1)
+    .max(80)
+    .optional()
+    .default(10)
+    .describe(
+      `scroll_to_element only: maximum scroll attempts after the element is not yet visible (default 10).`
+    ),
+
+  scrollDistance: z
+    .number()
+    .min(0.05)
+    .max(1)
+    .optional()
+    .describe(
+      `scroll_to_element only: vertical swipe length as a fraction 0.05–1 (same scale as legacy scroll). ` +
+        `Ignored when scrollDistancePreset is set. Default 0.45 if neither preset nor scrollDistance is set.`
+    ),
+
+  scrollDistancePreset: z
+    .enum(SCROLL_DISTANCE_PRESETS)
+    .optional()
+    .describe(
+      `scroll_to_element only: convenience preset — small ≈ light nudge (0.25), medium ≈ 0.45, large = full default swipe (1). ` +
+        `When set, overrides scrollDistance.`
+    ),
 
   sessionId: z
     .string()

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -71,7 +71,7 @@ export default function findElement(server: FastMCP): void {
 
 **Environment Variables Required for AI Mode**:
 - AI_VISION_API_BASE_URL: Vision model API endpoint (required)
-- AI_VISION_API_KEY: Vision API authentication key (required)
+- AI_VISION_API_KEY: API authentication key (required)
 - AI_VISION_MODEL: Model name (optional, defaults to Qwen3-VL-235B-A22B-Instruct)
 - AI_VISION_COORD_TYPE: Coordinate type (optional, defaults to normalized)
 
@@ -99,14 +99,12 @@ export default function findElement(server: FastMCP): void {
               'selector is required for traditional locator strategies'
             );
           }
-
-          const idKey = 'element-6066-11e4-a52e-4f735466cecf';
           const element = await driver.findElement(
             args.strategy,
             args.selector
           );
           return textResult(
-            `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${(element as Record<string, string>)[idKey]}`
+            `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${element['element-6066-11e4-a52e-4f735466cecf']}`
           );
         }
 
@@ -136,7 +134,7 @@ export default function findElement(server: FastMCP): void {
 
         const { width, height } = metadata;
 
-        // Step 3: Find element using AI (singleton to preserve LRU cache across tool calls)
+        // Step 3: Find element using AI (singleton to preserve LRU cache across calls)
         const finder = getAIVisionFinder();
         const result = await finder.findElement(
           screenshotBase64,

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -1,10 +1,9 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getScreenshot, getPageSource } from '../../command.js';
+import { getScreenshot } from '../../command.js';
 import { imageUtil } from '@appium/support';
 import { AIVisionFinder } from '../../ai-finder/vision-finder.js';
 import log from '../../logger.js';
-import { performVerticalScroll } from '../gestures/handlers/swipe-scroll.js';
 import {
   resolveDriver,
   textResult,
@@ -53,39 +52,6 @@ export const findElementSchema = z.object({
     .string()
     .optional()
     .describe('Session ID to target. If omitted, uses the active session.'),
-  scrollUntilFound: z
-    .boolean()
-    .optional()
-    .default(false)
-    .describe(
-      'Traditional strategies only: if true, scroll and retry until the element is found, scrolling no longer changes the page (end of list), or maxScrollAttempts is reached.'
-    ),
-  scrollDirection: z
-    .enum(['up', 'down'])
-    .optional()
-    .default('down')
-    .describe(
-      'Used with scrollUntilFound: which way to swipe between find attempts.'
-    ),
-  scrollDistance: z
-    .number()
-    .min(0.05)
-    .max(1)
-    .optional()
-    .default(0.45)
-    .describe(
-      'Used with scrollUntilFound: same meaning as appium_scroll distance (0.05–1).'
-    ),
-  maxScrollAttempts: z
-    .number()
-    .int()
-    .min(1)
-    .max(80)
-    .optional()
-    .default(40)
-    .describe(
-      'Used with scrollUntilFound: maximum scroll attempts after a failed find.'
-    ),
 });
 
 export default function findElement(server: FastMCP): void {
@@ -105,13 +71,11 @@ export default function findElement(server: FastMCP): void {
 
 **Environment Variables Required for AI Mode**:
 - AI_VISION_API_BASE_URL: Vision model API endpoint (required)
-- AI_VISION_API_KEY: API authentication key (required)
+- AI_VISION_API_KEY: Vision API authentication key (required)
 - AI_VISION_MODEL: Model name (optional, defaults to Qwen3-VL-235B-A22B-Instruct)
 - AI_VISION_COORD_TYPE: Coordinate type (optional, defaults to normalized)
 
-**Scroll until found (traditional strategies only)**:
-- Set scrollUntilFound=true to scroll the screen after each failed find until the element appears, the page stops changing (end of scrollable content), or maxScrollAttempts is reached.
-- Not supported with strategy ai_instruction.`,
+**Scrolling until an element appears**: use \`appium_gesture\` with \`action=scroll_to_element\` (same strategy + selector), not this tool.`,
     parameters: findElementSchema,
     annotations: {
       readOnlyHint: true,
@@ -137,63 +101,12 @@ export default function findElement(server: FastMCP): void {
           }
 
           const idKey = 'element-6066-11e4-a52e-4f735466cecf';
-
-          if (!args.scrollUntilFound) {
-            const element = await driver.findElement(
-              args.strategy,
-              args.selector
-            );
-            return textResult(
-              `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${(element as Record<string, string>)[idKey]}`
-            );
-          }
-
-          let scrollsDone = 0;
-          const maxScroll = args.maxScrollAttempts;
-
-          while (true) {
-            try {
-              const element = await driver.findElement(
-                args.strategy,
-                args.selector
-              );
-              const elId = (element as Record<string, string>)[idKey];
-              const afterScroll =
-                scrollsDone > 0 ? ` after ${scrollsDone} scroll(s)` : '';
-              return textResult(
-                `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${elId}${afterScroll}.`
-              );
-            } catch (findErr) {
-              if (scrollsDone >= maxScroll) {
-                return errorResult(
-                  `Failed to find element after ${scrollsDone} scroll attempt(s). ${toolErrorMessage(findErr)}`
-                );
-              }
-              const xmlBefore = await getPageSource(driver);
-              try {
-                await performVerticalScroll(driver, {
-                  direction: args.scrollDirection,
-                  distance: args.scrollDistance,
-                });
-              } catch (scrollErr: unknown) {
-                return errorResult(
-                  `Scroll failed while searching for element: ${toolErrorMessage(scrollErr)}. Last find error: ${toolErrorMessage(findErr)}`
-                );
-              }
-              const xmlAfter = await getPageSource(driver);
-              scrollsDone++;
-              if (xmlBefore === xmlAfter) {
-                return errorResult(
-                  `Element not found; page source did not change after scroll (likely end of scrollable content). selector=${args.selector}. Last find error: ${toolErrorMessage(findErr)}`
-                );
-              }
-            }
-          }
-        }
-
-        if (args.scrollUntilFound) {
-          return errorResult(
-            'scrollUntilFound is only supported for traditional locator strategies, not ai_instruction.'
+          const element = await driver.findElement(
+            args.strategy,
+            args.selector
+          );
+          return textResult(
+            `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${(element as Record<string, string>)[idKey]}`
           );
         }
 
@@ -223,7 +136,7 @@ export default function findElement(server: FastMCP): void {
 
         const { width, height } = metadata;
 
-        // Step 3: Find element using AI (singleton to preserve LRU cache across calls)
+        // Step 3: Find element using AI (singleton to preserve LRU cache across tool calls)
         const finder = getAIVisionFinder();
         const result = await finder.findElement(
           screenshotBase64,

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -1,9 +1,10 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getScreenshot } from '../../command.js';
+import { getScreenshot, getPageSource } from '../../command.js';
 import { imageUtil } from '@appium/support';
 import { AIVisionFinder } from '../../ai-finder/vision-finder.js';
 import log from '../../logger.js';
+import { performVerticalScroll } from '../gestures/handlers/swipe-scroll.js';
 import {
   resolveDriver,
   textResult,
@@ -52,6 +53,39 @@ export const findElementSchema = z.object({
     .string()
     .optional()
     .describe('Session ID to target. If omitted, uses the active session.'),
+  scrollUntilFound: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Traditional strategies only: if true, scroll and retry until the element is found, scrolling no longer changes the page (end of list), or maxScrollAttempts is reached.'
+    ),
+  scrollDirection: z
+    .enum(['up', 'down'])
+    .optional()
+    .default('down')
+    .describe(
+      'Used with scrollUntilFound: which way to swipe between find attempts.'
+    ),
+  scrollDistance: z
+    .number()
+    .min(0.05)
+    .max(1)
+    .optional()
+    .default(0.45)
+    .describe(
+      'Used with scrollUntilFound: same meaning as appium_scroll distance (0.05–1).'
+    ),
+  maxScrollAttempts: z
+    .number()
+    .int()
+    .min(1)
+    .max(80)
+    .optional()
+    .default(40)
+    .describe(
+      'Used with scrollUntilFound: maximum scroll attempts after a failed find.'
+    ),
 });
 
 export default function findElement(server: FastMCP): void {
@@ -73,7 +107,11 @@ export default function findElement(server: FastMCP): void {
 - AI_VISION_API_BASE_URL: Vision model API endpoint (required)
 - AI_VISION_API_KEY: API authentication key (required)
 - AI_VISION_MODEL: Model name (optional, defaults to Qwen3-VL-235B-A22B-Instruct)
-- AI_VISION_COORD_TYPE: Coordinate type (optional, defaults to normalized)`,
+- AI_VISION_COORD_TYPE: Coordinate type (optional, defaults to normalized)
+
+**Scroll until found (traditional strategies only)**:
+- Set scrollUntilFound=true to scroll the screen after each failed find until the element appears, the page stops changing (end of scrollable content), or maxScrollAttempts is reached.
+- Not supported with strategy ai_instruction.`,
     parameters: findElementSchema,
     annotations: {
       readOnlyHint: true,
@@ -97,12 +135,65 @@ export default function findElement(server: FastMCP): void {
               'selector is required for traditional locator strategies'
             );
           }
-          const element = await driver.findElement(
-            args.strategy,
-            args.selector
-          );
-          return textResult(
-            `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${element['element-6066-11e4-a52e-4f735466cecf']}`
+
+          const idKey = 'element-6066-11e4-a52e-4f735466cecf';
+
+          if (!args.scrollUntilFound) {
+            const element = await driver.findElement(
+              args.strategy,
+              args.selector
+            );
+            return textResult(
+              `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${(element as Record<string, string>)[idKey]}`
+            );
+          }
+
+          let scrollsDone = 0;
+          const maxScroll = args.maxScrollAttempts;
+
+          while (true) {
+            try {
+              const element = await driver.findElement(
+                args.strategy,
+                args.selector
+              );
+              const elId = (element as Record<string, string>)[idKey];
+              const afterScroll =
+                scrollsDone > 0 ? ` after ${scrollsDone} scroll(s)` : '';
+              return textResult(
+                `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${elId}${afterScroll}.`
+              );
+            } catch (findErr) {
+              if (scrollsDone >= maxScroll) {
+                return errorResult(
+                  `Failed to find element after ${scrollsDone} scroll attempt(s). ${toolErrorMessage(findErr)}`
+                );
+              }
+              const xmlBefore = await getPageSource(driver);
+              try {
+                await performVerticalScroll(driver, {
+                  direction: args.scrollDirection,
+                  distance: args.scrollDistance,
+                });
+              } catch (scrollErr: unknown) {
+                return errorResult(
+                  `Scroll failed while searching for element: ${toolErrorMessage(scrollErr)}. Last find error: ${toolErrorMessage(findErr)}`
+                );
+              }
+              const xmlAfter = await getPageSource(driver);
+              scrollsDone++;
+              if (xmlBefore === xmlAfter) {
+                return errorResult(
+                  `Element not found; page source did not change after scroll (likely end of scrollable content). selector=${args.selector}. Last find error: ${toolErrorMessage(findErr)}`
+                );
+              }
+            }
+          }
+        }
+
+        if (args.scrollUntilFound) {
+          return errorResult(
+            'scrollUntilFound is only supported for traditional locator strategies, not ai_instruction.'
           );
         }
 


### PR DESCRIPTION
- Add optional scrollUntilFound for traditional locators: scroll between find attempts until found, page source stops changing after scroll, or maxScrollAttempts
- Reuse vertical swipe from scroll.ts (performVerticalScroll) for consistent behavior with appium_scroll
- Document parameters and example in README