### PR TITLE
feat(tools): structured logs, toolErrorMessage, canonical elementId line

### DIFF
--- a/src/tools/gestures/handlers/tap.ts
+++ b/src/tools/gestures/handlers/tap.ts
@@ -213,8 +213,6 @@ export async function handleLongPress(
         ],
       },
     ]);
-    // Coordinate-based W3C path (including element→coords fallback): do not emit a
-    // canonical elementId line — the gesture target is the point, not native element press.
     return textResult(
       `Successfully long pressed at (${x}, ${y}) for ${duration}ms.`
     );

--- a/src/tools/gestures/handlers/tap.ts
+++ b/src/tools/gestures/handlers/tap.ts
@@ -150,7 +150,7 @@ export async function handleDoubleTap(
       },
     ]);
     return textResult(`Successfully double tapped at (${x}, ${y}).`);
-  } catch (err) {
+  } catch (err: unknown) {
     return errorResult(
       `Failed to perform double_tap. ${toolErrorMessage(err)}`
     );
@@ -213,12 +213,8 @@ export async function handleLongPress(
         ],
       },
     ]);
-    if (args.elementUUID) {
-      return textResultWithPrimaryElementId(
-        args.elementUUID,
-        `Successfully long pressed at (${x}, ${y}) for ${duration}ms.`
-      );
-    }
+    // Coordinate-based W3C path (including element→coords fallback): do not emit a
+    // canonical elementId line — the gesture target is the point, not native element press.
     return textResult(
       `Successfully long pressed at (${x}, ${y}) for ${duration}ms.`
     );

--- a/src/tools/gestures/handlers/tap.ts
+++ b/src/tools/gestures/handlers/tap.ts
@@ -10,6 +10,7 @@ import {
 import {
   errorResult,
   textResult,
+  textResultWithPrimaryElementId,
   toolErrorMessage,
 } from '../../tool-response.js';
 import type { GestureArgs } from '../schema.js';
@@ -74,12 +75,16 @@ export async function handleTap(
           return errorResult(parsed.error);
         }
         await performActions(driver, w3cTapAt(parsed.x, parsed.y));
-        return textResult(
+        return textResultWithPrimaryElementId(
+          args.elementUUID,
           `Successfully tapped at AI element coordinates (${parsed.x}, ${parsed.y}).`
         );
       }
       await elementClick(driver, args.elementUUID);
-      return textResult(`Successfully tapped element ${args.elementUUID}.`);
+      return textResultWithPrimaryElementId(
+        args.elementUUID,
+        `Successfully tapped element ${args.elementUUID}.`
+      );
     }
 
     if (args.x === undefined || args.y === undefined) {
@@ -91,7 +96,7 @@ export async function handleTap(
     return textResult(
       `Successfully tapped at coordinates (${args.x}, ${args.y}).`
     );
-  } catch (err) {
+  } catch (err: unknown) {
     return errorResult(`Failed to perform tap. ${toolErrorMessage(err)}`);
   }
 }
@@ -110,7 +115,8 @@ export async function handleDoubleTap(
         await execute(driver, 'mobile: doubleTap', {
           elementId: args.elementUUID,
         });
-        return textResult(
+        return textResultWithPrimaryElementId(
+          args.elementUUID,
           `Successfully double tapped element ${args.elementUUID}.`
         );
       }
@@ -174,7 +180,8 @@ export async function handleLongPress(
             elementId: args.elementUUID,
             duration: duration / 1000,
           });
-          return textResult(
+          return textResultWithPrimaryElementId(
+            args.elementUUID,
             `Successfully long pressed element ${args.elementUUID} for ${duration}ms.`
           );
         } catch {
@@ -206,10 +213,16 @@ export async function handleLongPress(
         ],
       },
     ]);
+    if (args.elementUUID) {
+      return textResultWithPrimaryElementId(
+        args.elementUUID,
+        `Successfully long pressed at (${x}, ${y}) for ${duration}ms.`
+      );
+    }
     return textResult(
       `Successfully long pressed at (${x}, ${y}) for ${duration}ms.`
     );
-  } catch (err) {
+  } catch (err: unknown) {
     return errorResult(
       `Failed to perform long_press. ${toolErrorMessage(err)}`
     );

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,7 +12,7 @@
  * See src/tools/README.md for tool organization.
  * See src/tools/metadata/README.md for YAML metadata approach.
  */
-import type { FastMCP } from 'fastmcp';
+import type { ContentResult, FastMCP } from 'fastmcp';
 import log from '../logger.js';
 import answerAppium from './documentation/answer-appium.js';
 import appiumSkills from './documentation/appium-skills.js';
@@ -50,6 +50,30 @@ import app from './app-management/app.js';
 import context from './context/context.js';
 
 type RegisteredTool = Parameters<FastMCP['addTool']>[0];
+
+function sessionIdFromToolArgs(args: unknown): string | undefined {
+  if (
+    args &&
+    typeof args === 'object' &&
+    'sessionId' in args &&
+    typeof (args as { sessionId?: unknown }).sessionId === 'string'
+  ) {
+    return (args as { sessionId: string }).sessionId;
+  }
+  return undefined;
+}
+
+function isErrorFromToolResult(result: unknown): boolean {
+  if (
+    result &&
+    typeof result === 'object' &&
+    'content' in result &&
+    Array.isArray((result as { content: unknown }).content)
+  ) {
+    return (result as ContentResult).isError === true;
+  }
+  return false;
+}
 
 export default function registerTools(server: FastMCP): void {
   // Wrap addTool to inject logging around tool execution
@@ -108,14 +132,29 @@ export default function registerTools(server: FastMCP): void {
         log.info(`[TOOL START] ${toolName}`, redactArgs(args));
         try {
           const result = await originalExecute(args, context);
-          const duration = Date.now() - start;
-          log.info(`[TOOL END] ${toolName} (${duration}ms)`);
+          const durationMs = Date.now() - start;
+          log.info(
+            JSON.stringify({
+              tool: toolName,
+              durationMs,
+              sessionId: sessionIdFromToolArgs(args),
+              isError: isErrorFromToolResult(result),
+            })
+          );
           return result;
         } catch (err: unknown) {
-          const duration = Date.now() - start;
+          const durationMs = Date.now() - start;
+          log.info(
+            JSON.stringify({
+              tool: toolName,
+              durationMs,
+              sessionId: sessionIdFromToolArgs(args),
+              isError: true,
+            })
+          );
           const msg =
             err instanceof Error ? err.stack || err.message : String(err);
-          log.error(`[TOOL ERROR] ${toolName} (${duration}ms): ${msg}`);
+          log.error(`[TOOL ERROR] ${toolName} (${durationMs}ms): ${msg}`);
           throw err;
         }
       },

--- a/src/tools/interactions/active-element.ts
+++ b/src/tools/interactions/active-element.ts
@@ -35,9 +35,7 @@ export default function getActiveElement(server: FastMCP): void {
 
       try {
         const element = await _getActiveElement(driver);
-        const elementId = readWebElementId(
-          element as unknown as Record<string, unknown>
-        );
+        const elementId = readWebElementId(element);
 
         if (!elementId) {
           throw new Error(

--- a/src/tools/interactions/active-element.ts
+++ b/src/tools/interactions/active-element.ts
@@ -3,9 +3,10 @@ import { z } from 'zod';
 import { getActiveElement as _getActiveElement } from '../../command.js';
 import {
   resolveDriver,
-  textResult,
+  textResultWithPrimaryElementId,
   errorResult,
   toolErrorMessage,
+  readWebElementId,
 } from '../tool-response.js';
 
 export default function getActiveElement(server: FastMCP): void {
@@ -34,9 +35,9 @@ export default function getActiveElement(server: FastMCP): void {
 
       try {
         const element = await _getActiveElement(driver);
-        const elementId =
-          element['element-6066-11e4-a52e-4f735466cecf'] ??
-          (element as unknown as { ELEMENT?: string }).ELEMENT;
+        const elementId = readWebElementId(
+          element as unknown as Record<string, unknown>
+        );
 
         if (!elementId) {
           throw new Error(
@@ -44,8 +45,9 @@ export default function getActiveElement(server: FastMCP): void {
           );
         }
 
-        return textResult(
-          `Successfully found an active element. Element id: ${elementId}`
+        return textResultWithPrimaryElementId(
+          elementId,
+          'Successfully found an active element.'
         );
       } catch (err: unknown) {
         return errorResult(

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -102,9 +102,7 @@ export default function findElement(server: FastMCP): void {
             args.strategy,
             args.selector
           );
-          const elementId = readWebElementId(
-            element as unknown as Record<string, unknown>
-          );
+          const elementId = readWebElementId(element);
           if (!elementId) {
             throw new Error('Element was returned without a valid element ID');
           }

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -6,9 +6,10 @@ import { AIVisionFinder } from '../../ai-finder/vision-finder.js';
 import log from '../../logger.js';
 import {
   resolveDriver,
-  textResult,
+  textResultWithPrimaryElementId,
   errorResult,
   toolErrorMessage,
+  readWebElementId,
 } from '../tool-response.js';
 
 // Module-level singleton: ensures the LRU cache persists across tool calls.
@@ -101,8 +102,15 @@ export default function findElement(server: FastMCP): void {
             args.strategy,
             args.selector
           );
-          return textResult(
-            `Successfully found element ${args.selector} with strategy ${args.strategy}. Element id ${element['element-6066-11e4-a52e-4f735466cecf']}`
+          const elementId = readWebElementId(
+            element as unknown as Record<string, unknown>
+          );
+          if (!elementId) {
+            throw new Error('Element was returned without a valid element ID');
+          }
+          return textResultWithPrimaryElementId(
+            elementId,
+            `Successfully found element ${args.selector} with strategy ${args.strategy}.`
           );
         }
 
@@ -146,13 +154,13 @@ export default function findElement(server: FastMCP): void {
         const elementUUID = `ai-element:${result.center.x},${result.center.y}:${result.bbox.join(',')}`;
 
         // Step 5: Build response text with optional annotated image path
-        let responseText = `Successfully found "${result.target}" at coordinates (${result.center.x}, ${result.center.y}) using AI vision. Element id ${elementUUID}`;
+        let detail = `Successfully found "${result.target}" at coordinates (${result.center.x}, ${result.center.y}) using AI vision.`;
 
         if (result.annotatedImagePath) {
-          responseText += `; vision image: ${result.annotatedImagePath}`;
+          detail += ` Vision image: ${result.annotatedImagePath}`;
         }
 
-        return textResult(responseText);
+        return textResultWithPrimaryElementId(elementUUID, detail);
       } catch (err: unknown) {
         const errorMessage = toolErrorMessage(err);
         log.error('Failed to find element:', errorMessage);

--- a/src/tools/interactions/get-element-attribute.ts
+++ b/src/tools/interactions/get-element-attribute.ts
@@ -4,7 +4,7 @@ import { elementUUIDScheme } from '../../schema.js';
 import { getElementAttribute } from '../../command.js';
 import {
   resolveDriver,
-  textResult,
+  textResultWithPrimaryElementId,
   errorResult,
   toolErrorMessage,
 } from '../tool-response.js';
@@ -48,11 +48,11 @@ export default function getElementAttributeTool(server: FastMCP): void {
           args.elementUUID,
           args.attribute
         );
-        return textResult(
+        const detail =
           value !== null
             ? `Attribute "${args.attribute}" of element ${args.elementUUID}: ${value}`
-            : `Attribute "${args.attribute}" is not set on element ${args.elementUUID}`
-        );
+            : `Attribute "${args.attribute}" is not set on element ${args.elementUUID}`;
+        return textResultWithPrimaryElementId(args.elementUUID, detail);
       } catch (err: unknown) {
         return errorResult(
           `Failed to get attribute "${args.attribute}" from element ${args.elementUUID}. err: ${toolErrorMessage(err)}`

--- a/src/tools/interactions/get-text.ts
+++ b/src/tools/interactions/get-text.ts
@@ -4,7 +4,7 @@ import { elementUUIDScheme } from '../../schema.js';
 import { getElementText } from '../../command.js';
 import {
   resolveDriver,
-  textResult,
+  textResultWithPrimaryElementId,
   errorResult,
   toolErrorMessage,
 } from '../tool-response.js';
@@ -38,8 +38,9 @@ export default function getText(server: FastMCP): void {
 
       try {
         const text = await getElementText(driver, args.elementUUID);
-        return textResult(
-          `Successfully got text ${text} from element ${args.elementUUID}`
+        return textResultWithPrimaryElementId(
+          args.elementUUID,
+          `Successfully got text ${text} from element ${args.elementUUID}.`
         );
       } catch (err: unknown) {
         return errorResult(

--- a/src/tools/interactions/set-value.ts
+++ b/src/tools/interactions/set-value.ts
@@ -64,7 +64,7 @@ export default function setValue(server: FastMCP): void {
         return textResult(detail);
       } catch (err: unknown) {
         return errorResult(
-          `Failed to set value ${args.text} into element ${args.elementUUID}. err: ${toolErrorMessage(err)}`
+          `Failed to set value ${args.text} into element ${args.elementUUID ?? '(focus)'}. err: ${toolErrorMessage(err)}`
         );
       }
     },

--- a/src/tools/interactions/set-value.ts
+++ b/src/tools/interactions/set-value.ts
@@ -5,6 +5,7 @@ import { setValue as _setValue } from '../../command.js';
 import {
   resolveDriver,
   textResult,
+  textResultWithPrimaryElementId,
   errorResult,
   toolErrorMessage,
 } from '../tool-response.js';
@@ -56,9 +57,11 @@ export default function setValue(server: FastMCP): void {
           args.text,
           args.w3cActions
         );
-        return textResult(
-          `Successfully set value ${args.text} into element ${args.elementUUID}`
-        );
+        const detail = `Successfully set value ${args.text} into element ${args.elementUUID ?? '(focus)'}${args.w3cActions ? ' via W3C Actions' : ''}.`;
+        if (args.elementUUID) {
+          return textResultWithPrimaryElementId(args.elementUUID, detail);
+        }
+        return textResult(detail);
       } catch (err: unknown) {
         return errorResult(
           `Failed to set value ${args.text} into element ${args.elementUUID}. err: ${toolErrorMessage(err)}`

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -21,7 +21,7 @@ import {
   createSessionDashboardUI,
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
-import { textResult } from '../tool-response.js';
+import { textResult, toolErrorMessage } from '../tool-response.js';
 import WebDriver from 'webdriver';
 
 // Define capabilities type
@@ -52,8 +52,8 @@ async function loadCapabilitiesConfig(): Promise<CapabilitiesConfig> {
     await access(configPath, constants.F_OK);
     const configContent = await readFile(configPath, 'utf8');
     return JSON.parse(configContent);
-  } catch (error) {
-    log.warn(`Failed to parse capabilities config: ${error}`);
+  } catch (error: unknown) {
+    log.warn(`Failed to parse capabilities config: ${toolErrorMessage(error)}`);
     return { android: {}, ios: {}, general: {} };
   }
 }

--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -12,12 +12,18 @@ export function toolErrorMessage(err: unknown): string {
 }
 
 /**
- * Reads the WebDriver element id from a findElement/activeElement payload.
+ * Reads the WebDriver element id from a findElement/activeElement payload,
+ * or returns the value when the driver already returned a plain id string.
  */
-export function readWebElementId(
-  element: Record<string, unknown>
-): string | undefined {
-  const id = element[W3C_ELEMENT_ID] ?? element.ELEMENT;
+export function readWebElementId(element: unknown): string | undefined {
+  if (typeof element === 'string') {
+    return element;
+  }
+  if (element === null || typeof element !== 'object') {
+    return undefined;
+  }
+  const rec = element as Record<string, unknown>;
+  const id = rec[W3C_ELEMENT_ID] ?? rec.ELEMENT;
   return typeof id === 'string' ? id : undefined;
 }
 
@@ -28,15 +34,21 @@ export function textResult(text: string): ContentResult {
   return { content: [{ type: 'text', text }] };
 }
 
+function sanitizePrimaryElementIdLine(elementId: string): string {
+  return elementId.replace(/[\r\n]+/g, '').trim();
+}
+
 /**
  * Canonical first line: machine-parseable `elementId:<value>`, then human-readable detail.
+ * Strips newlines from elementId so the first line stays one logical field for parsers.
  */
 export function textResultWithPrimaryElementId(
   elementId: string,
   detail: string
 ): ContentResult {
+  const safeId = sanitizePrimaryElementIdLine(elementId);
   const d = detail.replace(/^\s+/, '');
-  return textResult(`elementId:${elementId}\n${d}`);
+  return textResult(`elementId:${safeId}\n${d}`);
 }
 
 /**

--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -17,7 +17,7 @@ export function toolErrorMessage(err: unknown): string {
 export function readWebElementId(
   element: Record<string, unknown>
 ): string | undefined {
-  const id = element[W3C_ELEMENT_ID] ?? element['ELEMENT'];
+  const id = element[W3C_ELEMENT_ID] ?? element.ELEMENT;
   return typeof id === 'string' ? id : undefined;
 }
 

--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -65,8 +65,7 @@ export type DriverOrError =
 
 /**
  * Resolves the driver for a tool call or returns a standardised error result.
- * Named resolveDriver (not requireDriver / getDriverOrThrow) to make clear
- * it never throws.
+ * Does not throw.
  */
 export function resolveDriver(sessionId?: string): DriverOrError {
   const driver = getDriver(sessionId);

--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -2,6 +2,8 @@ import type { ContentResult } from 'fastmcp';
 import type { DriverInstance } from '../session-store.js';
 import { getDriver } from '../session-store.js';
 
+const W3C_ELEMENT_ID = 'element-6066-11e4-a52e-4f735466cecf';
+
 /**
  * Normalizes unknown errors into a message string for tool responses.
  */
@@ -10,10 +12,31 @@ export function toolErrorMessage(err: unknown): string {
 }
 
 /**
+ * Reads the WebDriver element id from a findElement/activeElement payload.
+ */
+export function readWebElementId(
+  element: Record<string, unknown>
+): string | undefined {
+  const id = element[W3C_ELEMENT_ID] ?? element['ELEMENT'];
+  return typeof id === 'string' ? id : undefined;
+}
+
+/**
  * Standard success ContentResult.
  */
 export function textResult(text: string): ContentResult {
   return { content: [{ type: 'text', text }] };
+}
+
+/**
+ * Canonical first line: machine-parseable `elementId:<value>`, then human-readable detail.
+ */
+export function textResultWithPrimaryElementId(
+  elementId: string,
+  detail: string
+): ContentResult {
+  const d = detail.replace(/^\s+/, '');
+  return textResult(`elementId:${elementId}\n${d}`);
 }
 
 /**


### PR DESCRIPTION
- Log one JSON object per tool finish: tool, durationMs, sessionId, isError.
- Derive isError from ContentResult when execute returns that shape.
- Add readWebElementId and textResultWithPrimaryElementId helpers.
- Use elementId first line for find, active-element, tap, get-text, set-value (when elementUUID), get-attribute.
- Use toolErrorMessage in create-session capabilities config catch.