### PR TITLE
feat(tools): consolidate driver settings into appium_driver_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,7 @@ MCP Appium provides a comprehensive set of tools organized into the following ca
 | `create_session` | Create a new mobile automation session for Android, iOS, or `general` capabilities (see 'general' mode above). If a remote Appium server is referenced, `create_session` forwards the final capabilities to that server via the WebDriver `newSession` API - include device selection (e.g., `appium:udid`) in `capabilities` when targeting a remote server. |
 | `delete_session` | Delete the current mobile session and clean up resources                                                    |
 | `appium_mobile_device_control` | Control device behavior: lock/unlock the screen, shake the device, or open the notifications panel (`action`: `lock` \| `unlock` \| `shake` \| `open_notifications`). `shake` is iOS only; `open_notifications` is Android only; `seconds` is optional for timed lock. |
-| `appium_get_settings` | Read current Appium driver session settings (idle timeouts, animation-related flags, selector waits, etc.). Helps diagnose and tune flaky automation. |
-| `appium_update_settings` | Merge key-value updates into driver session settings (driver-specific keys; use `appium_get_settings` to inspect). |
+| `appium_driver_settings` | Read or update Appium driver session settings in one tool. `action=get` returns current settings as JSON; `action=update` merges a `settings` map (driver-specific keys; use `action=get` first to inspect). |
 
 The remote server URL in `create_session` can be set via the `remoteServerUrl` parameter.
 If `REMOTE_SERVER_URL_ALLOW_REGEX` is set, the URL must match the provided regex pattern for security reasons.

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -11,7 +11,7 @@ This directory contains all MCP tools available in MCP Appium.
 - `device-control.ts` - Device controls in one tool (`appium_mobile_device_control`; `action=lock|unlock|shake|open_notifications`)
 - `select-device.ts` - Discover devices and select one (auto-selects if only one found)
 - `file-transfer.ts` - Push/pull files on device (`appium_mobile_file` with `action=push|pull`)
-- `driver-settings.ts` - Read/update Appium driver session settings (`appium_get_settings`, `appium_update_settings`)
+- `driver-settings.ts` - Read/update Appium driver session settings (`appium_driver_settings`, `action`: `get` \| `update`)
 
 ### iOS Setup (`ios/`)
 

--- a/src/tools/session/driver-settings.ts
+++ b/src/tools/session/driver-settings.ts
@@ -11,78 +11,84 @@ import {
   toolErrorMessage,
 } from '../tool-response.js';
 
-const updateSettingsSchema = z.object({
+const schema = z.object({
+  action: z
+    .enum(['get', 'update'])
+    .describe(
+      'get: read current Appium driver session settings (timeouts, selector waits, flags). ' +
+        'update: merge a settings map into the session (requires settings).'
+    ),
   settings: z
     .record(z.string(), z.any())
+    .optional()
     .describe(
-      'Key-value map of Appium driver settings to merge into the current session. ' +
-        'Valid keys depend on the driver (e.g. Android UiAutomator2: waitForIdleTimeout, ' +
-        'waitForSelectorTimeout, ignoreUnimportantViews; iOS XCUITest has its own set). ' +
-        'Call appium_get_settings first to inspect current values.'
+      'Required when action is update. Driver-specific keys (e.g. Android UiAutomator2: ' +
+        'waitForIdleTimeout, waitForSelectorTimeout, ignoreUnimportantViews; iOS XCUITest has its own set). ' +
+        'Use action=get first to inspect current values.'
     ),
+  sessionId: z
+    .string()
+    .optional()
+    .describe('Session ID to target. If omitted, uses the active session.'),
 });
+
+type DriverSettingsArgs = z.infer<typeof schema>;
+
+async function handleGet(sessionId?: string): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
+  const settings = await getSessionDriverSettings(driver);
+  return textResult(JSON.stringify(settings, null, 2));
+}
+
+async function handleUpdate(
+  sessionId: string | undefined,
+  settings: Record<string, unknown>
+): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
+  await updateSessionDriverSettings(driver, settings);
+  return textResult('Successfully updated driver settings.');
+}
 
 export default function driverSettings(server: FastMCP): void {
   server.addTool({
-    name: 'appium_get_settings',
+    name: 'appium_driver_settings',
     description:
-      'Read current Appium driver session settings (e.g. idle timeouts, animation flags, ' +
-      'selector waits). Use this to tune stability for agent-driven flows. Works for embedded ' +
-      'UiAutomator2/XCUITest sessions and remote WebDriver clients that support Appium settings.',
-    parameters: z.object({}),
-    annotations: {
-      readOnlyHint: true,
-      openWorldHint: false,
-    },
-    execute: async (
-      _args: Record<string, never>,
-      _context: Record<string, unknown> | undefined
-    ): Promise<ContentResult> => {
-      const resolved = resolveDriver();
-      if (!resolved.ok) {
-        return resolved.result;
-      }
-      const { driver } = resolved;
-
-      try {
-        const settings = await getSessionDriverSettings(driver);
-        return textResult(JSON.stringify(settings, null, 2));
-      } catch (err: unknown) {
-        return errorResult(
-          `Failed to get driver settings. Error: ${toolErrorMessage(err)}`
-        );
-      }
-    },
-  });
-
-  server.addTool({
-    name: 'appium_update_settings',
-    description:
-      'Update Appium driver session settings by merging the provided map into the current ' +
-      'configuration. Useful to reduce flakiness (e.g. adjust waitForIdleTimeout) or toggle ' +
-      'driver-specific behavior. Keys are driver-specific; use appium_get_settings to see ' +
-      'what is supported.',
-    parameters: updateSettingsSchema,
+      'Read or update Appium driver session settings (e.g. idle timeouts, selector waits). ' +
+      'Use action=get to return JSON settings; action=update merges a map into the session. ' +
+      'Works for embedded UiAutomator2/XCUITest sessions and remote WebDriver clients that support Appium settings.',
+    parameters: schema,
     annotations: {
       readOnlyHint: false,
       openWorldHint: false,
     },
     execute: async (
-      args: z.infer<typeof updateSettingsSchema>,
+      args: DriverSettingsArgs,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const resolved = resolveDriver();
-      if (!resolved.ok) {
-        return resolved.result;
-      }
-      const { driver } = resolved;
-
       try {
-        await updateSessionDriverSettings(driver, args.settings);
-        return textResult('Successfully updated driver settings.');
+        switch (args.action) {
+          case 'get':
+            return await handleGet(args.sessionId);
+          case 'update': {
+            if (args.settings === undefined) {
+              return errorResult('settings is required for update action');
+            }
+            return await handleUpdate(args.sessionId, args.settings);
+          }
+        }
       } catch (err: unknown) {
         return errorResult(
-          `Failed to update driver settings. Error: ${toolErrorMessage(err)}`
+          `Failed to ${args.action} driver settings. Error: ${toolErrorMessage(err)}`
         );
       }
     },


### PR DESCRIPTION
- Replaces appium_get_settings and appium_update_settings with one tool, action get | update, optional sessionId, Zod discriminated union for settings on update; error handling aligned with geolocation; breaking for old tool names. Changelog + README updated.