### PR TITLE
chore(docs): add env var section in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ This will automatically configure the MCP server for use with Claude Code. Make 
 
 ## ⚙️ Configuration
 
+### Environment Variables
+
+| Variable | Required | Description |
+| -------- | -------- | ----------- |
+| `ANDROID_HOME` | Required for Android | Path to the Android SDK (e.g. `~/Library/Android/sdk`) |
+| `CAPABILITIES_CONFIG` | Optional | Absolute path to a `capabilities.json` file with per-platform capability presets |
+| `SCREENSHOTS_DIR` | Optional | Directory where screenshots and screen recordings are saved. Defaults to the current working directory |
+| `NO_UI` | Optional | Set to `true` or `1` to disable HTML UI components — faster responses, fewer tokens. See [NO_UI Mode](#no_ui-mode) |
+| `APPIUM_MCP_WDA_APP_PATH` | Optional | Absolute path to a pre-extracted `WebDriverAgentRunner-Runner.app` bundle. When set, `prepare_ios_simulator` skips all GitHub downloads and uses this bundle directly — useful in environments where external downloads are blocked |
+| `REMOTE_SERVER_URL_ALLOW_REGEX` | Optional | Regex pattern that remote Appium server URLs must match. Defaults to `^https?://` |
+| `AI_VISION_API_BASE_URL` | Required for AI Vision | Base URL of the OpenAI-compatible vision model API |
+| `AI_VISION_API_KEY` | Required for AI Vision | API key for the vision model provider |
+| `AI_VISION_MODEL` | Optional | Vision model name (default: `Qwen3-VL-235B-A22B-Instruct`) |
+| `AI_VISION_COORD_TYPE` | Optional | Coordinate type: `normalized` (default) or `absolute` |
+| `AI_VISION_IMAGE_MAX_WIDTH` | Optional | Max image width in pixels before compression (default: `1080`) |
+| `AI_VISION_IMAGE_QUALITY` | Optional | JPEG quality 1–100 for compressed screenshots sent to the vision API (default: `80`) |
+
 ### Capabilities
 
 Create a `capabilities.json` file to define your device capabilities:
@@ -198,7 +215,7 @@ Configure AI-powered element finding using vision models. This feature allows yo
     "env": {
       "ANDROID_HOME": "/path/to/android/sdk",
       "AI_VISION_API_BASE_URL": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-      "AI_VISION_API_TOKEN": "your_api_key_here"
+      "AI_VISION_API_KEY": "your_api_key_here"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -225,10 +225,7 @@ Configure AI-powered element finding using vision models. This feature allows yo
 
 **Optional Environment Variables:**
 
-- `AI_VISION_MODEL`: Model name (default: `Qwen3-VL-235B-A22B-Instruct`)
-- `AI_VISION_COORD_TYPE`: Coordinate type - `normalized` or `absolute` (default: `normalized`)
-- `AI_VISION_IMAGE_MAX_WIDTH`: Max image width for compression in pixels (default: `1080`)
-- `AI_VISION_IMAGE_QUALITY`: JPEG quality 1-100 (default: `80`)
+See the [Environment Variables](#environment-variables) table above for the full list of `AI_VISION_*` options and their defaults.
 
 **Supported Vision Model Providers:**
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This will automatically configure the MCP server for use with Claude Code. Make 
 | Variable | Required | Description |
 | -------- | -------- | ----------- |
 | `ANDROID_HOME` | Required for Android | Path to the Android SDK (e.g. `~/Library/Android/sdk`) |
+| `JAVA_HOME` | Required for Android | Path to the JDK used by Appium drivers (e.g. `/Applications/Android Studio.app/Contents/jbr/Contents/Home`). |
 | `CAPABILITIES_CONFIG` | Optional | Absolute path to a `capabilities.json` file with per-platform capability presets |
 | `SCREENSHOTS_DIR` | Optional | Directory where screenshots and screen recordings are saved. Defaults to the current working directory |
 | `NO_UI` | Optional | Set to `true` or `1` to disable HTML UI components — faster responses, fewer tokens. See [NO_UI Mode](#no_ui-mode) |
@@ -150,6 +151,7 @@ This will automatically configure the MCP server for use with Claude Code. Make 
 | `AI_VISION_COORD_TYPE` | Optional | Coordinate type: `normalized` (default) or `absolute` |
 | `AI_VISION_IMAGE_MAX_WIDTH` | Optional | Max image width in pixels before compression (default: `1080`) |
 | `AI_VISION_IMAGE_QUALITY` | Optional | JPEG quality 1–100 for compressed screenshots sent to the vision API (default: `80`) |
+| `SENTENCE_TRANSFORMERS_MODEL` | Optional | Hugging Face model used for semantic search in Appium documentation queries (default: `Xenova/all-MiniLM-L6-v2`) |
 
 ### Capabilities
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ This will automatically configure the MCP server for use with Claude Code. Make 
 
 ### Environment Variables
 
+> **Note:** Appium driver prerequisites (`ANDROID_HOME`, `JAVA_HOME`, UiAutomator2/XCUITest driver setup) are not listed here, they are system-level requirements. Once this MCP server is configured, ask your AI assistant to set up the environment for you using the built-in `appium_skills` tool.
+
 | Variable | Required | Description |
 | -------- | -------- | ----------- |
-| `ANDROID_HOME` | Required for Android | Path to the Android SDK (e.g. `~/Library/Android/sdk`) |
-| `JAVA_HOME` | Required for Android | Path to the JDK used by Appium drivers (e.g. `/Applications/Android Studio.app/Contents/jbr/Contents/Home`). |
 | `CAPABILITIES_CONFIG` | Optional | Absolute path to a `capabilities.json` file with per-platform capability presets |
 | `SCREENSHOTS_DIR` | Optional | Directory where screenshots and screen recordings are saved. Defaults to the current working directory |
 | `NO_UI` | Optional | Set to `true` or `1` to disable HTML UI components — faster responses, fewer tokens. See [NO_UI Mode](#no_ui-mode) |

--- a/docs/AI_ELEMENT_FINDING_DESIGN.md
+++ b/docs/AI_ELEMENT_FINDING_DESIGN.md
@@ -72,7 +72,7 @@ AI_VISION_IMAGE_QUALITY=80      # JPEG quality 1-100 (default: 80)
       "ANDROID_HOME": "/Users/xyz/Library/Android/sdk",
       "AI_VISION_MODEL": "Qwen3-VL-235B-A22B-Instruct",
       "AI_VISION_API_BASE_URL": "https://api.your-provider.com",
-      "AI_VISION_API_TOKEN": "your_api_key_here",
+      "AI_VISION_API_KEY": "your_api_key_here",
       "AI_VISION_COORD_TYPE": "normalized"
     }
   }

--- a/docs/AI_ELEMENT_FINDING_DESIGN_CN.md
+++ b/docs/AI_ELEMENT_FINDING_DESIGN_CN.md
@@ -72,7 +72,7 @@ AI_VISION_IMAGE_QUALITY=80      # JPEG质量 1-100（默认：80）
       "ANDROID_HOME": "/Users/xyz/Library/Android/sdk",
       "AI_VISION_MODEL": "Qwen3-VL-235B-A22B-Instruct",
       "AI_VISION_API_BASE_URL": "https://api.your-provider.com",
-      "AI_VISION_API_TOKEN": "your_api_key_here",
+      "AI_VISION_API_KEY": "your_api_key_here",
       "AI_VISION_COORD_TYPE": "normalized"
     }
   }

--- a/docs/AI_VISION_E2E_GUIDE_CN.md
+++ b/docs/AI_VISION_E2E_GUIDE_CN.md
@@ -202,7 +202,7 @@ npm run inspect:built
       "console": "integratedTerminal",
       "env": {
         "AI_VISION_API_BASE_URL": "https://xxxxxxx" // 你需要替换为你的 API_BASE_URL,
-        "AI_VISION_API_TOKEN": "sk-xxxxx" // 你需要替换为你的 API_TOKEN,
+        "AI_VISION_API_KEY": "sk-xxxxx" // 你需要替换为你的 API_TOKEN,
         "AI_VISION_MODEL": "Qwen3-VL-235B-A22B-Instruct" // 你可以替换为任何你希望的VL模型名称，详见 benchmark 测试完成已支持的模型,
         "AI_VISION_COORD_TYPE": "normalized" // 不同模型的坐标类型不同，详见 benchmark 测试完成已支持的坐标类型,
         "AI_VISION_IMAGE_MAX_WIDTH": "1080",

--- a/docs/AI_VISION_E2E_GUIDE_EN.md
+++ b/docs/AI_VISION_E2E_GUIDE_EN.md
@@ -241,7 +241,7 @@ npm run inspect:built
   "console": "integratedTerminal",
   "env": {
     "AI_VISION_API_BASE_URL": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-    "AI_VISION_API_TOKEN": "sk-xxxxx",
+    "AI_VISION_API_KEY": "sk-xxxxx",
     "AI_VISION_MODEL": "Qwen3-VL-235B-A22B-Instruct",
     "AI_VISION_COORD_TYPE": "normalized",
     "AI_VISION_IMAGE_MAX_WIDTH": "1080",


### PR DESCRIPTION
Adds env var section in configuration - https://github.com/appium/appium-mcp/pull/281#issuecomment-4293825389

Also updates the correct env var to `AI_VISION_API_KEY` from `AI_VISION_API_TOKEN` as per the actual code.