### PR TITLE
feat(session): add attach/detach support with owned/attached session …

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,11 +317,11 @@ MCP Appium provides a comprehensive set of tools organized into the following ca
 
 | Tool             | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `appium_session_management` | Unified session management. `action=create`: start a new session for Android, iOS, or `general` capabilities (see 'general' mode above); forwards capabilities to a remote server via WebDriver `newSession` when `remoteServerUrl` is provided. `action=delete`: stop and clean up a session (defaults to active). `action=list`: show all active sessions. `action=select`: switch the active session by `sessionId`. |
+| `appium_session_management` | Unified session management. `action=create`: start a new session for Android, iOS, or `general` capabilities (see 'general' mode above); forwards capabilities to a remote server via WebDriver `newSession` when `remoteServerUrl` is provided. `action=attach`: connect MCP Appium to an already-running remote Appium session without taking ownership. `action=detach`: forget an attached session without deleting the real remote session. `action=delete`: stop and clean up an owned session (defaults to active). `action=list`: show all active sessions, including ownership. `action=select`: switch the active session by `sessionId`. |
 | `appium_mobile_device_control` | Control device behavior: lock/unlock the screen, shake the device, or open the notifications panel (`action`: `lock` \| `unlock` \| `shake` \| `open_notifications`). `shake` is iOS only; `open_notifications` is Android only; `seconds` is optional for timed lock. |
 | `appium_driver_settings` | Read or update Appium driver session settings in one tool. `action=get` returns current settings as JSON; `action=update` merges a `settings` map (driver-specific keys; use `action=get` first to inspect). |
 
-The remote server URL in `appium_session_management` (action=create) can be set via the `remoteServerUrl` parameter.
+The remote server URL in `appium_session_management` (action=create or action=attach) can be set via the `remoteServerUrl` parameter.
 If `REMOTE_SERVER_URL_ALLOW_REGEX` is set, the URL must match the provided regex pattern for security reasons.
 This allows you to restrict which remote servers can be used with your MCP Appium instance, preventing unauthorized connections.
 The default regex pattern allows any URL that starts with `http://` or `https://`.

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,11 +21,13 @@ server.on('connect', (event) => {
 
 server.on('disconnect', async (event) => {
   log.info('Client disconnected:', event.session);
-  const sessions = listSessions();
-  if (sessions.length > 0) {
+  const ownedSessions = listSessions().filter(
+    (session) => session.ownership === 'owned'
+  );
+  if (ownedSessions.length > 0) {
     try {
       log.info(
-        `${sessions.length} active session(s) detected on disconnect, cleaning up...`
+        `${ownedSessions.length} owned session(s) detected on disconnect, cleaning up...`
       );
       const deletedCount = await safeDeleteAllSessions();
       log.info(
@@ -35,7 +37,7 @@ server.on('disconnect', async (event) => {
       log.error('Error cleaning up session on disconnect:', error);
     }
   } else {
-    log.info('No active sessions to clean up on disconnect.');
+    log.info('No owned sessions to clean up on disconnect.');
   }
 });
 

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -106,13 +106,17 @@ export function setSession(
     return;
   }
 
+  // `getAppiumSessionCapabilities()` may return metadata fields without the
+  // `appium:` prefix, so accept both namespaced and non-namespaced variants.
   const metadata: SessionMetadata = {
     platform:
       (capabilities.platformName as string | undefined) ??
       (capabilities['appium:platformName'] as string | undefined) ??
       null,
     automationName:
-      (capabilities['appium:automationName'] as string | undefined) ?? null,
+      (capabilities['appium:automationName'] as string | undefined) ??
+      (capabilities.automationName as string | undefined) ??
+      null,
     deviceName:
       (capabilities['appium:deviceName'] as string | undefined) ??
       (capabilities.deviceName as string | undefined) ??
@@ -236,23 +240,26 @@ function selectNextActiveSessionId(deletedSessionId: string): string | null {
   return nextSession ?? null;
 }
 
-export function detachSession(sessionId?: string): boolean {
+export function detachSession(sessionId?: string): void {
   const id = sessionId ?? activeSessionId;
   if (!id) {
-    log.info('No active session to detach.');
-    return false;
+    throw new Error('No active session to detach.');
   }
 
   const session = sessions.get(id);
   if (!session) {
-    log.info(`Session ${id} not found.`);
-    return false;
+    throw new Error(`Session ${id} not found.`);
+  }
+
+  if (session.ownership !== 'attached') {
+    throw new Error(
+      `Session ${id} is owned by MCP Appium. Use action=delete to remove it.`
+    );
   }
 
   sessions.delete(id);
   activeSessionId = selectNextActiveSessionId(id);
   log.info(`Session ${id} detached successfully.`);
-  return true;
 }
 
 export async function safeDeleteSession(sessionId?: string): Promise<boolean> {

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -239,17 +239,6 @@ export function hasActiveSession(): boolean {
   return !!session && !session.isDeletingSession;
 }
 
-function selectNextActiveSessionId(deletedSessionId: string): string | null {
-  if (activeSessionId !== deletedSessionId) {
-    return activeSessionId;
-  }
-
-  const nextSession = Array.from(sessions.keys()).find(
-    (id) => id !== deletedSessionId
-  );
-  return nextSession ?? null;
-}
-
 /**
  * Remove an attached session from the in-memory MCP session registry without
  * calling `deleteSession()` on the remote Appium server.

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -169,6 +169,16 @@ export function listSessions(): Array<{
   }));
 }
 
+/**
+ * Return the ownership mode for a session.
+ *
+ * Owned sessions were created by MCP Appium and should be deleted through MCP.
+ * Attached sessions were adopted from an external Appium server and can be
+ * detached without deleting the remote session.
+ *
+ * @param sessionId - Optional session id to inspect. Defaults to the active session.
+ * @returns The session ownership mode, or `null` when the session is missing.
+ */
 export function getSessionOwnership(
   sessionId?: string
 ): SessionOwnership | null {
@@ -240,6 +250,14 @@ function selectNextActiveSessionId(deletedSessionId: string): string | null {
   return nextSession ?? null;
 }
 
+/**
+ * Remove an attached session from the in-memory MCP session registry without
+ * calling `deleteSession()` on the remote Appium server.
+ *
+ * @param sessionId - Optional session id to detach. Defaults to the active session.
+ * @throws {Error} If there is no target session, the session is missing, or
+ *   the session is owned by MCP Appium.
+ */
 export function detachSession(sessionId?: string): void {
   const id = sessionId ?? activeSessionId;
   if (!id) {

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -10,6 +10,7 @@ export type DriverInstance =
   | XCUITestDriver;
 export type NullableDriverInstance = DriverInstance | null;
 export type SessionCapabilities = Record<string, any>;
+export type SessionOwnership = 'owned' | 'attached';
 
 interface SessionMetadata {
   platform: string | null;
@@ -23,6 +24,7 @@ interface SessionInfo {
   sessionId: string;
   currentContext: string | null;
   isDeletingSession: boolean;
+  ownership: SessionOwnership;
   metadata: SessionMetadata;
 }
 
@@ -96,7 +98,8 @@ export function isXCUITestDriverSession(
 export function setSession(
   d: DriverInstance,
   id: string | null,
-  capabilities: SessionCapabilities = {}
+  capabilities: SessionCapabilities = {},
+  ownership: SessionOwnership = 'owned'
 ) {
   if (!id) {
     activeSessionId = null;
@@ -122,6 +125,7 @@ export function setSession(
     sessionId: id,
     currentContext: 'NATIVE_APP',
     isDeletingSession: false,
+    ownership,
     metadata,
   });
   activeSessionId = id;
@@ -143,6 +147,7 @@ export function listSessions(): Array<{
   sessionId: string;
   currentContext: string | null;
   isActive: boolean;
+  ownership: SessionOwnership;
   platform: string | null;
   automationName: string | null;
   deviceName: string | null;
@@ -152,11 +157,22 @@ export function listSessions(): Array<{
     sessionId: session.sessionId,
     currentContext: session.currentContext,
     isActive: session.sessionId === activeSessionId,
+    ownership: session.ownership,
     platform: session.metadata.platform,
     automationName: session.metadata.automationName,
     deviceName: session.metadata.deviceName,
     capabilities: session.metadata.capabilities,
   }));
+}
+
+export function getSessionOwnership(
+  sessionId?: string
+): SessionOwnership | null {
+  const id = sessionId ?? activeSessionId;
+  if (!id) {
+    return null;
+  }
+  return sessions.get(id)?.ownership ?? null;
 }
 
 export function setActiveSession(sessionId: string): boolean {
@@ -209,6 +225,36 @@ export function hasActiveSession(): boolean {
   return !!session && !session.isDeletingSession;
 }
 
+function selectNextActiveSessionId(deletedSessionId: string): string | null {
+  if (activeSessionId !== deletedSessionId) {
+    return activeSessionId;
+  }
+
+  const nextSession = Array.from(sessions.keys()).find(
+    (id) => id !== deletedSessionId
+  );
+  return nextSession ?? null;
+}
+
+export function detachSession(sessionId?: string): boolean {
+  const id = sessionId ?? activeSessionId;
+  if (!id) {
+    log.info('No active session to detach.');
+    return false;
+  }
+
+  const session = sessions.get(id);
+  if (!session) {
+    log.info(`Session ${id} not found.`);
+    return false;
+  }
+
+  sessions.delete(id);
+  activeSessionId = selectNextActiveSessionId(id);
+  log.info(`Session ${id} detached successfully.`);
+  return true;
+}
+
 export async function safeDeleteSession(sessionId?: string): Promise<boolean> {
   const id = sessionId ?? activeSessionId;
 
@@ -258,7 +304,9 @@ export async function safeDeleteSession(sessionId?: string): Promise<boolean> {
 
 export async function safeDeleteAllSessions(): Promise<number> {
   let deletedCount = 0;
-  const sessionIds = Array.from(sessions.keys());
+  const sessionIds = Array.from(sessions.values())
+    .filter((session) => session.ownership === 'owned')
+    .map((session) => session.sessionId);
 
   for (const sessionId of sessionIds) {
     try {

--- a/src/tests/session-store.test.ts
+++ b/src/tests/session-store.test.ts
@@ -24,11 +24,13 @@ await jest.unstable_mockModule('../logger', () => ({
 }));
 
 const {
+  detachSession,
   isRemoteDriverSession,
   isAndroidUiautomator2DriverSession,
   isXCUITestDriverSession,
   setSession,
   getDriver,
+  getSessionOwnership,
   getSessionId,
   listSessions,
   setActiveSession,
@@ -42,8 +44,7 @@ const {
   PLATFORM,
 } = await import('../session-store.js');
 
-const { AndroidUiautomator2Driver } =
-  await import('appium-uiautomator2-driver');
+const { AndroidUiautomator2Driver } = await import('appium-uiautomator2-driver');
 const { XCUITestDriver } = await import('appium-xcuitest-driver');
 
 // Shared mock driver factory with a controllable deleteSession.
@@ -54,6 +55,9 @@ function makeMockDriver(deleteSessionImpl?: () => Promise<void>) {
 afterEach(async () => {
   // Remove all sessions to reset shared module-level state between tests.
   await safeDeleteAllSessions();
+  for (const session of listSessions()) {
+    detachSession(session.sessionId);
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -185,6 +189,14 @@ describe('setSession', () => {
       (s) => s.sessionId === 'session-fallback'
     );
     expect(session?.platform).toBe('iOS');
+  });
+
+  test('stores ownership and exposes it through list/get helpers', () => {
+    const driver = makeMockDriver();
+    setSession(driver, 'session-attached', {}, 'attached');
+
+    expect(getSessionOwnership('session-attached')).toBe('attached');
+    expect(listSessions()[0]?.ownership).toBe('attached');
   });
 });
 
@@ -464,6 +476,52 @@ describe('safeDeleteAllSessions', () => {
     const count = await safeDeleteAllSessions();
     // Only the good session should have been deleted.
     expect(count).toBe(1);
+  });
+
+  test('deletes only owned sessions', async () => {
+    let ownedDeleted = false;
+    setSession(
+      {
+        deleteSession: async () => {
+          ownedDeleted = true;
+        },
+      } as any,
+      'owned-session',
+      {},
+      'owned'
+    );
+    setSession(makeMockDriver(), 'attached-session', {}, 'attached');
+
+    const count = await safeDeleteAllSessions();
+
+    expect(count).toBe(1);
+    expect(ownedDeleted).toBe(true);
+    expect(getDriver('owned-session')).toBeNull();
+    expect(getDriver('attached-session')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detachSession / getSessionOwnership
+// ---------------------------------------------------------------------------
+describe('detachSession / getSessionOwnership', () => {
+  test('returns null ownership for a missing session', () => {
+    expect(getSessionOwnership('missing')).toBeNull();
+  });
+
+  test('detaches an attached session without deleting it', () => {
+    let deleted = false;
+    const driver = {
+      deleteSession: async () => {
+        deleted = true;
+      },
+    } as any;
+
+    setSession(driver, 'attached-session', {}, 'attached');
+
+    expect(detachSession('attached-session')).toBe(true);
+    expect(getDriver('attached-session')).toBeNull();
+    expect(deleted).toBe(false);
   });
 });
 

--- a/src/tests/session-store.test.ts
+++ b/src/tests/session-store.test.ts
@@ -56,7 +56,9 @@ afterEach(async () => {
   // Remove all sessions to reset shared module-level state between tests.
   await safeDeleteAllSessions();
   for (const session of listSessions()) {
-    detachSession(session.sessionId);
+    if (session.ownership === 'attached') {
+      detachSession(session.sessionId);
+    }
   }
 });
 
@@ -178,6 +180,21 @@ describe('setSession', () => {
     expect(session?.platform).toBe('Android');
     expect(session?.automationName).toBe('UiAutomator2');
     expect(session?.deviceName).toBe('Pixel 5');
+  });
+
+  test('accepts non-prefixed metadata fields from attached session capabilities', () => {
+    const driver = makeMockDriver();
+    setSession(driver, 'session-meta-fallback', {
+      platformName: 'Android',
+      automationName: 'UiAutomator2',
+      deviceName: 'Pixel 9 Pro XL',
+    });
+    const session = listSessions().find(
+      (s) => s.sessionId === 'session-meta-fallback'
+    );
+    expect(session?.platform).toBe('Android');
+    expect(session?.automationName).toBe('UiAutomator2');
+    expect(session?.deviceName).toBe('Pixel 9 Pro XL');
   });
 
   test('falls back to appium:platformName when platformName is absent', () => {
@@ -509,6 +526,15 @@ describe('detachSession / getSessionOwnership', () => {
     expect(getSessionOwnership('missing')).toBeNull();
   });
 
+  test('does not detach an owned session', () => {
+    setSession(makeMockDriver(), 'owned-session', {}, 'owned');
+
+    expect(() => detachSession('owned-session')).toThrow(
+      'Session owned-session is owned by MCP Appium. Use action=delete to remove it.'
+    );
+    expect(getDriver('owned-session')).not.toBeNull();
+  });
+
   test('detaches an attached session without deleting it', () => {
     let deleted = false;
     const driver = {
@@ -519,7 +545,7 @@ describe('detachSession / getSessionOwnership', () => {
 
     setSession(driver, 'attached-session', {}, 'attached');
 
-    expect(detachSession('attached-session')).toBe(true);
+    expect(() => detachSession('attached-session')).not.toThrow();
     expect(getDriver('attached-session')).toBeNull();
     expect(deleted).toBe(false);
   });

--- a/src/tests/session-store.test.ts
+++ b/src/tests/session-store.test.ts
@@ -44,7 +44,8 @@ const {
   PLATFORM,
 } = await import('../session-store.js');
 
-const { AndroidUiautomator2Driver } = await import('appium-uiautomator2-driver');
+const { AndroidUiautomator2Driver } =
+  await import('appium-uiautomator2-driver');
 const { XCUITestDriver } = await import('appium-xcuitest-driver');
 
 // Shared mock driver factory with a controllable deleteSession.

--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, jest } from '@jest/globals';
+import { beforeEach, describe, test, expect, jest } from '@jest/globals';
 
 // ── module mocks ──────────────────────────────────────────────────────────────
 
@@ -28,13 +28,21 @@ jest.unstable_mockModule('appium-xcuitest-driver', () => ({
   XCUITestDriver: class {},
 }));
 jest.unstable_mockModule('webdriver', () => ({
-  default: { newSession: async () => ({ sessionId: 'remote-session-id' }) },
+  default: {
+    newSession: async () => ({ sessionId: 'remote-session-id' }),
+    attachToSession: async () => ({
+      sessionId: 'attached-session-id',
+      capabilities: { platformName: 'Android' },
+    }),
+  },
 }));
 
 jest.unstable_mockModule('../../../session-store', () => ({
   getDriver: jest.fn(),
+  getSessionOwnership: jest.fn(),
   getSessionId: jest.fn(),
   listSessions: jest.fn(),
+  detachSession: jest.fn(),
   setActiveSession: jest.fn(),
   safeDeleteSession: jest.fn(),
   setSession: jest.fn(),
@@ -52,25 +60,23 @@ jest.unstable_mockModule('../../../ui/mcp-ui-utils', () => ({
 
 const {
   getDriver,
+  getSessionOwnership,
   getSessionId,
   listSessions,
+  detachSession,
   setActiveSession,
   safeDeleteSession,
+  setSession,
 } = await import('../../../session-store.js');
 
 const mockGetDriver = getDriver as jest.MockedFunction<typeof getDriver>;
-const mockGetSessionId = getSessionId as jest.MockedFunction<
-  typeof getSessionId
->;
-const mockListSessions = listSessions as jest.MockedFunction<
-  typeof listSessions
->;
-const mockSetActiveSession = setActiveSession as jest.MockedFunction<
-  typeof setActiveSession
->;
-const mockSafeDeleteSession = safeDeleteSession as jest.MockedFunction<
-  typeof safeDeleteSession
->;
+const mockGetSessionOwnership = getSessionOwnership as jest.MockedFunction<typeof getSessionOwnership>;
+const mockGetSessionId = getSessionId as jest.MockedFunction<typeof getSessionId>;
+const mockListSessions = listSessions as jest.MockedFunction<typeof listSessions>;
+const mockDetachSession = detachSession as jest.MockedFunction<typeof detachSession>;
+const mockSetActiveSession = setActiveSession as jest.MockedFunction<typeof setActiveSession>;
+const mockSafeDeleteSession = safeDeleteSession as jest.MockedFunction<typeof safeDeleteSession>;
+const mockSetSession = setSession as jest.MockedFunction<typeof setSession>;
 
 const {
   buildAndroidCapabilities,
@@ -83,13 +89,14 @@ const {
 
 const mockServer = { addTool: jest.fn() } as any;
 
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 async function getToolExecute() {
-  const { default: session } =
-    await import('../../../tools/session/session.js');
+  const { default: session } = await import('../../../tools/session/session.js');
   session(mockServer);
-  return (mockServer.addTool as jest.MockedFunction<any>).mock.calls.at(
-    -1
-  )?.[0];
+  return (mockServer.addTool as jest.MockedFunction<any>).mock.calls.at(-1)?.[0];
 }
 
 // ── appium_session_management tool tests ─────────────────────────────────────────────────
@@ -110,6 +117,7 @@ describe('appium_session_management tool', () => {
         {
           sessionId: 'abc123',
           isActive: true,
+          ownership: 'owned',
           platform: 'Android',
           automationName: 'UiAutomator2',
           deviceName: 'Pixel 6',
@@ -124,6 +132,7 @@ describe('appium_session_management tool', () => {
       const result = await tool.execute({ action: 'list' }, undefined);
       expect(result.content[0].text).toContain('abc123');
       expect(result.content[0].text).toContain('active');
+      expect(result.content[0].text).toContain('ownership=owned');
     });
   });
 
@@ -165,14 +174,30 @@ describe('appium_session_management tool', () => {
   describe('action: delete', () => {
     test('deletes active session when no sessionId given', async () => {
       const tool = await getToolExecute();
+      mockGetSessionOwnership.mockReturnValue('owned');
       mockSafeDeleteSession.mockResolvedValue(true as any);
 
       const result = await tool.execute({ action: 'delete' }, undefined);
       expect(result.content[0].text).toContain('deleted successfully');
     });
 
+    test('rejects deleting an attached session', async () => {
+      const tool = await getToolExecute();
+      mockGetSessionOwnership.mockReturnValue('attached');
+
+      const result = await tool.execute(
+        { action: 'delete', sessionId: 'borrowed' },
+        undefined
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('action=detach');
+      expect(mockSafeDeleteSession).not.toHaveBeenCalled();
+    });
+
     test('reports not found when session does not exist', async () => {
       const tool = await getToolExecute();
+      mockGetSessionOwnership.mockReturnValue('owned');
       mockSafeDeleteSession.mockResolvedValue(false as any);
 
       const result = await tool.execute(
@@ -181,6 +206,92 @@ describe('appium_session_management tool', () => {
       );
       expect(result.content[0].text).toContain('ghost');
       expect(result.content[0].text).toContain('not found');
+    });
+  });
+
+  describe('action: attach', () => {
+    test('returns error when remoteServerUrl is missing', async () => {
+      const tool = await getToolExecute();
+
+      const result = await tool.execute(
+        { action: 'attach', sessionId: 'borrowed' },
+        undefined
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe(
+        'remoteServerUrl is required for attach action'
+      );
+    });
+
+    test('returns error when sessionId is missing', async () => {
+      const tool = await getToolExecute();
+
+      const result = await tool.execute(
+        { action: 'attach', remoteServerUrl: 'http://localhost:4723' },
+        undefined
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe(
+        'sessionId is required for attach action'
+      );
+    });
+
+    test('attaches an existing remote session as attached ownership', async () => {
+      const tool = await getToolExecute();
+      mockListSessions.mockReturnValue([
+        { sessionId: 'borrowed', isActive: true, ownership: 'attached' },
+      ] as any);
+
+      const result = await tool.execute(
+        {
+          action: 'attach',
+          remoteServerUrl: 'http://localhost:4723',
+          sessionId: 'borrowed',
+        },
+        undefined
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('Attached to existing session');
+      expect(mockSetSession).toHaveBeenCalledWith(
+        expect.anything(),
+        'borrowed',
+        { platformName: 'Android' },
+        'attached'
+      );
+    });
+  });
+
+  describe('action: detach', () => {
+    test('rejects detaching an owned session', async () => {
+      const tool = await getToolExecute();
+      mockGetSessionOwnership.mockReturnValue('owned');
+
+      const result = await tool.execute(
+        { action: 'detach', sessionId: 'owned-session' },
+        undefined
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('action=delete');
+      expect(mockDetachSession).not.toHaveBeenCalled();
+    });
+
+    test('detaches an attached session', async () => {
+      const tool = await getToolExecute();
+      mockGetSessionOwnership.mockReturnValue('attached');
+      mockDetachSession.mockReturnValue(true);
+
+      const result = await tool.execute(
+        { action: 'detach', sessionId: 'borrowed' },
+        undefined
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('detached successfully');
+      expect(mockDetachSession).toHaveBeenCalledWith('borrowed');
     });
   });
 

--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -2,6 +2,13 @@ import { beforeEach, describe, test, expect, jest } from '@jest/globals';
 
 // ── module mocks ──────────────────────────────────────────────────────────────
 
+const mockAttachToSession = jest.fn<
+  (options: Record<string, unknown>) => Promise<any>
+>(async (_options: Record<string, unknown>) => ({
+  sessionId: 'attached-session-id',
+  capabilities: { platformName: 'Android' },
+}));
+
 jest.unstable_mockModule('../../../tools/session/select-device', () => ({
   getSelectedDevice: () => 'device-udid',
   getSelectedDeviceType: () => 'simulator',
@@ -30,10 +37,7 @@ jest.unstable_mockModule('appium-xcuitest-driver', () => ({
 jest.unstable_mockModule('webdriver', () => ({
   default: {
     newSession: async () => ({ sessionId: 'remote-session-id' }),
-    attachToSession: async () => ({
-      sessionId: 'attached-session-id',
-      capabilities: { platformName: 'Android' },
-    }),
+    attachToSession: mockAttachToSession,
   },
 }));
 
@@ -91,6 +95,11 @@ const mockServer = { addTool: jest.fn() } as any;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockGetSessionOwnership.mockReturnValue(null);
+  mockAttachToSession.mockResolvedValue({
+    sessionId: 'attached-session-id',
+    capabilities: { platformName: 'Android' },
+  });
 });
 
 async function getToolExecute() {
@@ -181,18 +190,18 @@ describe('appium_session_management tool', () => {
       expect(result.content[0].text).toContain('deleted successfully');
     });
 
-    test('rejects deleting an attached session', async () => {
+    test('allows deleting an attached session when explicitly requested', async () => {
       const tool = await getToolExecute();
-      mockGetSessionOwnership.mockReturnValue('attached');
+      mockSafeDeleteSession.mockResolvedValue(true as any);
 
       const result = await tool.execute(
         { action: 'delete', sessionId: 'borrowed' },
         undefined
       );
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('action=detach');
-      expect(mockSafeDeleteSession).not.toHaveBeenCalled();
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('deleted successfully');
+      expect(mockSafeDeleteSession).toHaveBeenCalledWith('borrowed');
     });
 
     test('reports not found when session does not exist', async () => {
@@ -238,11 +247,147 @@ describe('appium_session_management tool', () => {
       );
     });
 
-    test('attaches an existing remote session as attached ownership', async () => {
+    test('attaches an existing remote session and prefers getAppiumSessionCapabilities per field', async () => {
       const tool = await getToolExecute();
       mockListSessions.mockReturnValue([
         { sessionId: 'borrowed', isActive: true, ownership: 'attached' },
       ] as any);
+      mockAttachToSession.mockResolvedValue({
+        sessionId: 'attached-session-id',
+        getAppiumSessionCapabilities: async () => ({
+          capabilities: {
+            platformName: 'Android',
+            automationName: 'UiAutomator2',
+          },
+        }),
+        getSession: async () => ({
+          platformName: 'iOS',
+          automationName: 'XCUITest',
+          deviceName: 'Ignored Device',
+        }),
+      } as any);
+
+      const result = await tool.execute(
+        {
+          action: 'attach',
+          remoteServerUrl: 'http://localhost:4723',
+          sessionId: 'borrowed',
+          capabilities: {
+            platformName: 'Provided',
+            automationName: 'UiAutomator2',
+            deviceName: 'Pixel 9 Pro XL',
+            'appium:app': 'demo.apk',
+          },
+        },
+        undefined
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('Attached to existing session');
+      expect(mockAttachToSession).toHaveBeenCalledWith({
+        sessionId: 'borrowed',
+        protocol: 'http',
+        hostname: 'localhost',
+        port: 4723,
+        path: '/',
+        capabilities: {
+          platformName: 'Provided',
+          automationName: 'UiAutomator2',
+          deviceName: 'Pixel 9 Pro XL',
+          'appium:app': 'demo.apk',
+        },
+      });
+      expect(mockSetSession).toHaveBeenCalledWith(
+        expect.anything(),
+        'borrowed',
+        {
+          'appium:app': 'demo.apk',
+          platformName: 'Android',
+          'appium:automationName': 'UiAutomator2',
+          'appium:deviceName': 'Ignored Device',
+        },
+        'attached'
+      );
+    });
+
+    test('falls back to getSession when getAppiumSessionCapabilities is unavailable', async () => {
+      const tool = await getToolExecute();
+      mockAttachToSession.mockResolvedValue({
+        sessionId: 'attached-session-id',
+        getAppiumSessionCapabilities: async () => {
+          throw new Error('unsupported');
+        },
+        getSession: async () => ({
+          platformName: 'Android',
+          automationName: 'UiAutomator2',
+        }),
+      } as any);
+
+      const result = await tool.execute(
+        {
+          action: 'attach',
+          remoteServerUrl: 'http://localhost:4723',
+          sessionId: 'borrowed',
+          capabilities: {
+            deviceName: 'Pixel 9 Pro XL',
+            'appium:app': 'demo.apk',
+          },
+        },
+        undefined
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(mockSetSession).toHaveBeenCalledWith(
+        expect.anything(),
+        'borrowed',
+        {
+          'appium:app': 'demo.apk',
+          platformName: 'Android',
+          'appium:automationName': 'UiAutomator2',
+          'appium:deviceName': 'Pixel 9 Pro XL',
+        },
+        'attached'
+      );
+    });
+
+    test('falls back to provided capabilities when runtime capability methods are unavailable', async () => {
+      const tool = await getToolExecute();
+      mockAttachToSession.mockResolvedValue({
+        sessionId: 'attached-session-id',
+      } as any);
+
+      const result = await tool.execute(
+        {
+          action: 'attach',
+          remoteServerUrl: 'http://localhost:4723',
+          sessionId: 'borrowed',
+          capabilities: {
+            platformName: 'Android',
+            'appium:automationName': 'UiAutomator2',
+            deviceName: 'Pixel 9 Pro XL',
+            'appium:app': 'demo.apk',
+          },
+        },
+        undefined
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(mockSetSession).toHaveBeenCalledWith(
+        expect.anything(),
+        'borrowed',
+        {
+          'appium:app': 'demo.apk',
+          platformName: 'Android',
+          'appium:automationName': 'UiAutomator2',
+          'appium:deviceName': 'Pixel 9 Pro XL',
+        },
+        'attached'
+      );
+    });
+
+    test('detaches an existing attached session before re-attaching the same id', async () => {
+      const tool = await getToolExecute();
+      mockGetSessionOwnership.mockReturnValue('attached');
 
       const result = await tool.execute(
         {
@@ -254,13 +399,27 @@ describe('appium_session_management tool', () => {
       );
 
       expect(result.isError).toBeFalsy();
-      expect(result.content[0].text).toContain('Attached to existing session');
-      expect(mockSetSession).toHaveBeenCalledWith(
-        expect.anything(),
-        'borrowed',
-        { platformName: 'Android' },
-        'attached'
+      expect(mockDetachSession).toHaveBeenCalledWith('borrowed');
+      expect(mockAttachToSession).toHaveBeenCalled();
+    });
+
+    test('rejects attaching over an existing owned session', async () => {
+      const tool = await getToolExecute();
+      mockGetSessionOwnership.mockReturnValue('owned');
+
+      const result = await tool.execute(
+        {
+          action: 'attach',
+          remoteServerUrl: 'http://localhost:4723',
+          sessionId: 'owned-session',
+        },
+        undefined
       );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('action=select');
+      expect(mockDetachSession).not.toHaveBeenCalled();
+      expect(mockAttachToSession).not.toHaveBeenCalled();
     });
   });
 
@@ -282,7 +441,6 @@ describe('appium_session_management tool', () => {
     test('detaches an attached session', async () => {
       const tool = await getToolExecute();
       mockGetSessionOwnership.mockReturnValue('attached');
-      mockDetachSession.mockReturnValue(true);
 
       const result = await tool.execute(
         { action: 'detach', sessionId: 'borrowed' },

--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -74,12 +74,24 @@ const {
 } = await import('../../../session-store.js');
 
 const mockGetDriver = getDriver as jest.MockedFunction<typeof getDriver>;
-const mockGetSessionOwnership = getSessionOwnership as jest.MockedFunction<typeof getSessionOwnership>;
-const mockGetSessionId = getSessionId as jest.MockedFunction<typeof getSessionId>;
-const mockListSessions = listSessions as jest.MockedFunction<typeof listSessions>;
-const mockDetachSession = detachSession as jest.MockedFunction<typeof detachSession>;
-const mockSetActiveSession = setActiveSession as jest.MockedFunction<typeof setActiveSession>;
-const mockSafeDeleteSession = safeDeleteSession as jest.MockedFunction<typeof safeDeleteSession>;
+const mockGetSessionOwnership = getSessionOwnership as jest.MockedFunction<
+  typeof getSessionOwnership
+>;
+const mockGetSessionId = getSessionId as jest.MockedFunction<
+  typeof getSessionId
+>;
+const mockListSessions = listSessions as jest.MockedFunction<
+  typeof listSessions
+>;
+const mockDetachSession = detachSession as jest.MockedFunction<
+  typeof detachSession
+>;
+const mockSetActiveSession = setActiveSession as jest.MockedFunction<
+  typeof setActiveSession
+>;
+const mockSafeDeleteSession = safeDeleteSession as jest.MockedFunction<
+  typeof safeDeleteSession
+>;
 const mockSetSession = setSession as jest.MockedFunction<typeof setSession>;
 
 const {
@@ -103,9 +115,12 @@ beforeEach(() => {
 });
 
 async function getToolExecute() {
-  const { default: session } = await import('../../../tools/session/session.js');
+  const { default: session } =
+    await import('../../../tools/session/session.js');
   session(mockServer);
-  return (mockServer.addTool as jest.MockedFunction<any>).mock.calls.at(-1)?.[0];
+  return (mockServer.addTool as jest.MockedFunction<any>).mock.calls.at(
+    -1
+  )?.[0];
 }
 
 // ── appium_session_management tool tests ─────────────────────────────────────────────────

--- a/src/tools/session/attach-session.ts
+++ b/src/tools/session/attach-session.ts
@@ -1,0 +1,68 @@
+import WebDriver from 'webdriver';
+import { URL } from 'node:url';
+import { listSessions, setSession, type SessionCapabilities } from '../../session-store.js';
+import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
+import { getPortFromUrl, validateRemoteServerUrl } from './create-session.js';
+
+function getAttachedCapabilities(client: unknown): SessionCapabilities {
+  if (!client || typeof client !== 'object') {
+    return {};
+  }
+  const maybeClient = client as {
+    capabilities?: SessionCapabilities;
+    caps?: SessionCapabilities;
+  };
+  return maybeClient.capabilities ?? maybeClient.caps ?? {};
+}
+
+export async function attachSessionAction(args: {
+  remoteServerUrl: string;
+  sessionId: string;
+  capabilities?: Record<string, any>;
+}): Promise<any> {
+  try {
+    validateRemoteServerUrl(
+      args.remoteServerUrl,
+      process.env.REMOTE_SERVER_URL_ALLOW_REGEX
+    );
+
+    const remoteUrl = new URL(args.remoteServerUrl);
+    const protocol = remoteUrl.protocol.replace(':', '');
+    const port = getPortFromUrl(remoteUrl);
+    const user = remoteUrl.username
+      ? decodeURIComponent(remoteUrl.username)
+      : undefined;
+    const key = remoteUrl.password
+      ? decodeURIComponent(remoteUrl.password)
+      : undefined;
+
+    const client = await (
+      WebDriver as unknown as {
+        attachToSession: (options: Record<string, unknown>) => Promise<unknown>;
+      }
+    ).attachToSession({
+      sessionId: args.sessionId,
+      protocol,
+      hostname: remoteUrl.hostname,
+      port,
+      path: remoteUrl.pathname,
+      ...(user && key ? { user, key } : {}),
+    });
+
+    const capabilities = args.capabilities ?? getAttachedCapabilities(client);
+    setSession(
+      client as Parameters<typeof setSession>[0],
+      args.sessionId,
+      capabilities,
+      'attached'
+    );
+
+    return textResult(
+      `Attached to existing session ${args.sessionId}. Active sessions: ${listSessions().length}`
+    );
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to attach session ${args.sessionId}. ${toolErrorMessage(err)}`
+    );
+  }
+}

--- a/src/tools/session/attach-session.ts
+++ b/src/tools/session/attach-session.ts
@@ -1,18 +1,44 @@
-import WebDriver from 'webdriver';
+import WebDriver, { type Client } from 'webdriver';
 import { URL } from 'node:url';
-import { listSessions, setSession, type SessionCapabilities } from '../../session-store.js';
+import { detachSession, getSessionOwnership, listSessions, setSession, type SessionCapabilities } from '../../session-store.js';
 import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 import { getPortFromUrl, validateRemoteServerUrl } from './create-session.js';
 
-function getAttachedCapabilities(client: unknown): SessionCapabilities {
-  if (!client || typeof client !== 'object') {
-    return {};
+function readCapabilities(value: unknown): SessionCapabilities | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
   }
-  const maybeClient = client as {
-    capabilities?: SessionCapabilities;
-    caps?: SessionCapabilities;
-  };
-  return maybeClient.capabilities ?? maybeClient.caps ?? {};
+
+  const record = value as Record<string, unknown>;
+  const nested = record.capabilities ?? record.caps;
+
+  if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+    return nested as SessionCapabilities;
+  }
+
+  return record as SessionCapabilities;
+}
+
+const METADATA_FIELDS = [
+  ['platformName', 'appium:platformName', 'platformName'],
+  ['automationName', 'appium:automationName', 'appium:automationName'],
+  ['deviceName', 'appium:deviceName', 'appium:deviceName'],
+] as const;
+
+async function readClientCapabilities(
+  client: Client,
+  methodName: 'getAppiumSessionCapabilities' | 'getSession'
+): Promise<SessionCapabilities | undefined> {
+  const method = client[methodName];
+  if (typeof method !== 'function') {
+    return undefined;
+  }
+
+  try {
+    return readCapabilities(await method.call(client));
+  } catch {
+    return undefined;
+  }
 }
 
 export async function attachSessionAction(args: {
@@ -21,6 +47,16 @@ export async function attachSessionAction(args: {
   capabilities?: Record<string, any>;
 }): Promise<any> {
   try {
+    const existingOwnership = getSessionOwnership(args.sessionId);
+    if (existingOwnership === 'owned') {
+      return errorResult(
+        `Session ${args.sessionId} is already managed by MCP Appium as an owned session. Use action=select to activate it.`
+      );
+    }
+    if (existingOwnership === 'attached') {
+      detachSession(args.sessionId);
+    }
+
     validateRemoteServerUrl(
       args.remoteServerUrl,
       process.env.REMOTE_SERVER_URL_ALLOW_REGEX
@@ -36,26 +72,50 @@ export async function attachSessionAction(args: {
       ? decodeURIComponent(remoteUrl.password)
       : undefined;
 
-    const client = await (
-      WebDriver as unknown as {
-        attachToSession: (options: Record<string, unknown>) => Promise<unknown>;
-      }
-    ).attachToSession({
+    const client: Client = await WebDriver.attachToSession({
       sessionId: args.sessionId,
       protocol,
       hostname: remoteUrl.hostname,
       port,
       path: remoteUrl.pathname,
+      capabilities: args.capabilities,
       ...(user && key ? { user, key } : {}),
     });
 
-    const capabilities = args.capabilities ?? getAttachedCapabilities(client);
-    setSession(
-      client as Parameters<typeof setSession>[0],
-      args.sessionId,
-      capabilities,
-      'attached'
+    const [appiumCapabilities, sessionCapabilities] = await Promise.all([
+      readClientCapabilities(client, 'getAppiumSessionCapabilities'),
+      readClientCapabilities(client, 'getSession'),
+    ]);
+
+    const sources = [
+      appiumCapabilities,
+      sessionCapabilities,
+      args.capabilities,
+    ];
+    const capabilities: SessionCapabilities = Object.assign(
+      {},
+      args.capabilities ?? {},
+      sessionCapabilities ?? {},
+      appiumCapabilities ?? {}
     );
+
+    for (const [plainKey, prefixedKey, targetKey] of METADATA_FIELDS) {
+      const source = sources.find(
+        (candidate) =>
+          candidate?.[plainKey] !== undefined ||
+          candidate?.[prefixedKey] !== undefined
+      );
+      const value = source?.[plainKey] ?? source?.[prefixedKey];
+
+      delete capabilities[plainKey];
+      delete capabilities[prefixedKey];
+
+      if (value !== undefined) {
+        capabilities[targetKey] = value;
+      }
+    }
+
+    setSession(client, args.sessionId, capabilities, 'attached');
 
     return textResult(
       `Attached to existing session ${args.sessionId}. Active sessions: ${listSessions().length}`

--- a/src/tools/session/attach-session.ts
+++ b/src/tools/session/attach-session.ts
@@ -1,9 +1,22 @@
 import WebDriver, { type Client } from 'webdriver';
 import { URL } from 'node:url';
-import { detachSession, getSessionOwnership, listSessions, setSession, type SessionCapabilities } from '../../session-store.js';
+import {
+  detachSession,
+  getSessionOwnership,
+  listSessions,
+  setSession,
+  type SessionCapabilities,
+} from '../../session-store.js';
 import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 import { getPortFromUrl, validateRemoteServerUrl } from './create-session.js';
 
+/**
+ * Normalize capability payloads returned by Appium/WebdriverIO into a flat
+ * capability record.
+ *
+ * @param value - Raw response payload from session capability APIs.
+ * @returns A capability record when one can be derived, otherwise `undefined`.
+ */
 function readCapabilities(value: unknown): SessionCapabilities | undefined {
   if (!value || typeof value !== 'object') {
     return undefined;
@@ -25,6 +38,13 @@ const METADATA_FIELDS = [
   ['deviceName', 'appium:deviceName', 'appium:deviceName'],
 ] as const;
 
+/**
+ * Read capabilities from a WebdriverIO client method when available.
+ *
+ * @param client - Attached WebdriverIO client for the target Appium session.
+ * @param methodName - Capability reader to invoke on the client.
+ * @returns Parsed capabilities, or `undefined` when the method is missing or fails.
+ */
 async function readClientCapabilities(
   client: Client,
   methodName: 'getAppiumSessionCapabilities' | 'getSession'
@@ -41,6 +61,14 @@ async function readClientCapabilities(
   }
 }
 
+/**
+ * Attach MCP Appium to an existing remote Appium session without taking
+ * ownership of the underlying session lifecycle.
+ *
+ * @param args - Remote server location, target session id, and optional
+ *   capability overrides to seed local metadata.
+ * @returns A tool response describing whether the attach succeeded.
+ */
 export async function attachSessionAction(args: {
   remoteServerUrl: string;
   sessionId: string;

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -295,7 +295,7 @@ export async function createSessionAction(args: {
         capabilities: finalCapabilities,
       });
       sessionId = client.sessionId;
-      setSession(client, client.sessionId, finalCapabilities);
+      setSession(client, client.sessionId, finalCapabilities, 'owned');
     } else {
       if (platform === 'general') {
         throw new Error(
@@ -305,7 +305,7 @@ export async function createSessionAction(args: {
       const driver = createDriverForPlatform(platform);
       log.info(`Sending session with ${driver.constructor.name}`);
       sessionId = await createDriverSession(driver, finalCapabilities);
-      setSession(driver, sessionId, finalCapabilities);
+      setSession(driver, sessionId, finalCapabilities, 'owned');
     }
 
     const sessionIdStr =

--- a/src/tools/session/delete-session.ts
+++ b/src/tools/session/delete-session.ts
@@ -1,8 +1,16 @@
-import { safeDeleteSession } from '../../session-store.js';
-import log from '../../logger.js';
-import { textResult, toolErrorMessage } from '../tool-response.js';
+import { getSessionOwnership, safeDeleteSession } from '../../session-store.js';
+import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 
 export async function deleteSessionAction(sessionId?: string): Promise<any> {
+  const ownership = getSessionOwnership(sessionId);
+  if (ownership === 'attached') {
+    return errorResult(
+      sessionId
+        ? `Session ${sessionId} was attached from an external client. Use action=detach instead of action=delete.`
+        : 'Active session was attached from an external client. Use action=detach instead of action=delete.'
+    );
+  }
+
   try {
     const deleted = await safeDeleteSession(sessionId);
     if (deleted) {
@@ -11,17 +19,14 @@ export async function deleteSessionAction(sessionId?: string): Promise<any> {
           ? `Session ${sessionId} deleted successfully.`
           : 'Active session deleted successfully.'
       );
-    } else {
-      return textResult(
-        sessionId
-          ? `Session ${sessionId} not found or deletion already in progress.`
-          : 'No active session found or deletion already in progress.'
-      );
     }
-  } catch (error: unknown) {
-    log.error(`Error deleting session`, error);
-    return textResult(
-      `Session delete may not have completed cleanly: ${toolErrorMessage(error)}`
+
+    return errorResult(
+      sessionId
+        ? `Session ${sessionId} not found or deletion already in progress.`
+        : 'No active session found or deletion already in progress.'
     );
+  } catch (error: unknown) {
+    return errorResult(`Failed to delete session. ${toolErrorMessage(error)}`);
   }
 }

--- a/src/tools/session/delete-session.ts
+++ b/src/tools/session/delete-session.ts
@@ -1,16 +1,7 @@
-import { getSessionOwnership, safeDeleteSession } from '../../session-store.js';
+import { safeDeleteSession } from '../../session-store.js';
 import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 
 export async function deleteSessionAction(sessionId?: string): Promise<any> {
-  const ownership = getSessionOwnership(sessionId);
-  if (ownership === 'attached') {
-    return errorResult(
-      sessionId
-        ? `Session ${sessionId} was attached from an external client. Use action=detach instead of action=delete.`
-        : 'Active session was attached from an external client. Use action=detach instead of action=delete.'
-    );
-  }
-
   try {
     const deleted = await safeDeleteSession(sessionId);
     if (deleted) {

--- a/src/tools/session/detach-session.ts
+++ b/src/tools/session/detach-session.ts
@@ -1,0 +1,31 @@
+import { detachSession, getSessionOwnership } from '../../session-store.js';
+import { errorResult, textResult } from '../tool-response.js';
+
+export async function detachSessionAction(sessionId?: string): Promise<any> {
+  const ownership = getSessionOwnership(sessionId);
+  if (!ownership) {
+    return errorResult(
+      sessionId ? `Session ${sessionId} not found.` : 'No active session found.'
+    );
+  }
+  if (ownership !== 'attached') {
+    return errorResult(
+      sessionId
+        ? `Session ${sessionId} is owned by MCP Appium. Use action=delete to remove it.`
+        : 'Active session is owned by MCP Appium. Use action=delete to remove it.'
+    );
+  }
+
+  const detached = detachSession(sessionId);
+  if (!detached) {
+    return errorResult(
+      sessionId ? `Session ${sessionId} not found.` : 'No active session found.'
+    );
+  }
+
+  return textResult(
+    sessionId
+      ? `Session ${sessionId} detached successfully.`
+      : 'Active session detached successfully.'
+  );
+}

--- a/src/tools/session/detach-session.ts
+++ b/src/tools/session/detach-session.ts
@@ -1,5 +1,5 @@
 import { detachSession, getSessionOwnership } from '../../session-store.js';
-import { errorResult, textResult } from '../tool-response.js';
+import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 
 export async function detachSessionAction(sessionId?: string): Promise<any> {
   const ownership = getSessionOwnership(sessionId);
@@ -16,11 +16,10 @@ export async function detachSessionAction(sessionId?: string): Promise<any> {
     );
   }
 
-  const detached = detachSession(sessionId);
-  if (!detached) {
-    return errorResult(
-      sessionId ? `Session ${sessionId} not found.` : 'No active session found.'
-    );
+  try {
+    detachSession(sessionId);
+  } catch (error: unknown) {
+    return errorResult(toolErrorMessage(error));
   }
 
   return textResult(

--- a/src/tools/session/detach-session.ts
+++ b/src/tools/session/detach-session.ts
@@ -1,6 +1,13 @@
 import { detachSession, getSessionOwnership } from '../../session-store.js';
 import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 
+/**
+ * Detach an attached Appium session from MCP Appium without deleting the
+ * remote session itself.
+ *
+ * @param sessionId - Optional session id to detach. Defaults to the active session.
+ * @returns A tool response describing whether the detach succeeded.
+ */
 export async function detachSessionAction(sessionId?: string): Promise<any> {
   const ownership = getSessionOwnership(sessionId);
   if (!ownership) {

--- a/src/tools/session/list-sessions.ts
+++ b/src/tools/session/list-sessions.ts
@@ -13,7 +13,7 @@ export async function listSessionsAction(): Promise<any> {
     .map((session, index) => {
       const driver = getDriver(session.sessionId);
       const rawClassName = driver?.constructor?.name;
-      return `${index + 1}. sessionId=${session.sessionId}${session.isActive ? ' (active)' : ''}\n   driverInstance=${rawClassName}, platform=${session.platform}, automationName=${session.automationName}, deviceName=${session.deviceName}, currentContext=${session.currentContext}`;
+      return `${index + 1}. sessionId=${session.sessionId}${session.isActive ? ' (active)' : ''}\n   driverInstance=${rawClassName}, ownership=${session.ownership}, platform=${session.platform}, automationName=${session.automationName}, deviceName=${session.deviceName}, currentContext=${session.currentContext}`;
     })
     .join('\n');
 

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -8,7 +8,14 @@ import { listSessionsAction } from './list-sessions.js';
 import { selectSessionAction } from './select-session.js';
 import { errorResult, toolErrorMessage } from '../tool-response.js';
 
-const SESSION_ACTIONS = ['create', 'attach', 'detach', 'delete', 'list', 'select'] as const;
+const SESSION_ACTIONS = [
+  'create',
+  'attach',
+  'detach',
+  'delete',
+  'list',
+  'select',
+] as const;
 
 const CREATE_SESSION_DESCRIPTION = `Create a new Appium session with Android, iOS or any device/driver Appium supports.
       DEFAULT MODE (no remoteServerUrl) — USE THIS UNLESS THE USER EXPLICITLY PROVIDES A SERVER URL:

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -1,12 +1,14 @@
 import type { FastMCP } from 'fastmcp';
 import { z } from 'zod';
+import { attachSessionAction } from './attach-session.js';
 import { createSessionAction } from './create-session.js';
 import { deleteSessionAction } from './delete-session.js';
+import { detachSessionAction } from './detach-session.js';
 import { listSessionsAction } from './list-sessions.js';
 import { selectSessionAction } from './select-session.js';
 import { errorResult, toolErrorMessage } from '../tool-response.js';
 
-const SESSION_ACTIONS = ['create', 'delete', 'list', 'select'] as const;
+const SESSION_ACTIONS = ['create', 'attach', 'detach', 'delete', 'list', 'select'] as const;
 
 const CREATE_SESSION_DESCRIPTION = `Create a new Appium session with Android, iOS or any device/driver Appium supports.
       DEFAULT MODE (no remoteServerUrl) — USE THIS UNLESS THE USER EXPLICITLY PROVIDES A SERVER URL:
@@ -30,8 +32,10 @@ const schema = z.object({
     .describe(
       'Action to perform. ' +
         `create: ${CREATE_SESSION_DESCRIPTION}` +
+        'attach: Attach MCP Appium to an existing remote Appium session without taking ownership of its lifecycle. Requires remoteServerUrl and sessionId.' +
+        'detach: Remove an attached Appium session from MCP Appium without deleting the real remote session. Defaults to the active session.' +
         'delete: Delete a mobile session and clean up resources. If sessionId is omitted, deletes the active session.' +
-        'list: List all active Appium sessions managed by this MCP server, including active flag and current context.' +
+        'list: List all active Appium sessions managed by this MCP server, including active flag, ownership, and current context.' +
         'select: Set an existing Appium session as the active session for subsequent tool calls (requires sessionId).'
     ),
   platform: z
@@ -54,13 +58,13 @@ const schema = z.object({
     .string()
     .optional()
     .describe(
-      'Remote Appium server URL for create (e.g. http://localhost:4723). Omit to use local server.'
+      'Remote Appium server URL for create or attach (e.g. http://localhost:4723). Omit to use local server for create.'
     ),
   sessionId: z
     .string()
     .optional()
     .describe(
-      'For delete: session to remove (defaults to active). For select: session to activate. Required for select.'
+      'For attach: existing session to connect to. For delete: session to remove (defaults to active). For detach: attached session to remove from MCP (defaults to active). For select: session to activate. Required for attach and select.'
     ),
 });
 
@@ -68,7 +72,7 @@ export default function session(server: FastMCP): void {
   server.addTool({
     name: 'appium_session_management',
     description:
-      'Manage Appium sessions. Use action=create to start a session, delete to stop one, list to see all active sessions, or select to switch the active session.',
+      'Manage Appium sessions. Use action=create to start a session, attach to connect to an existing one, detach to forget an attached session, delete to stop one, list to see all active sessions, or select to switch the active session.',
     parameters: schema,
     annotations: {
       destructiveHint: true,
@@ -86,6 +90,24 @@ export default function session(server: FastMCP): void {
             capabilities: args.capabilities,
             remoteServerUrl: args.remoteServerUrl,
           });
+        }
+
+        if (args.action === 'attach') {
+          if (!args.remoteServerUrl) {
+            return errorResult('remoteServerUrl is required for attach action');
+          }
+          if (!args.sessionId) {
+            return errorResult('sessionId is required for attach action');
+          }
+          return attachSessionAction({
+            remoteServerUrl: args.remoteServerUrl,
+            sessionId: args.sessionId,
+            capabilities: args.capabilities,
+          });
+        }
+
+        if (args.action === 'detach') {
+          return detachSessionAction(args.sessionId);
         }
 
         if (args.action === 'delete') {


### PR DESCRIPTION
…ownership

- Integrate attach and detach into unified session management
- Track session ownership in the session store; created sessions are owned
- Reject deleting attached sessions; disconnect cleans up only owned sessions
- Expose ownership in session listing output

Fixes https://github.com/appium/appium-mcp/issues/279