### PR TITLE
feat(tools): single appium_mobile_keyboard tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,7 @@ The default regex pattern allows any URL that starts with `http://` or `https://
 | `appium_drag_and_drop` | Perform a drag and drop gesture from a source location to a target location (supports element-to-element, element-to-coordinates, coordinates-to-element, and coordinates-to-coordinates) |
 | `appium_perform_actions` | Execute raw W3C Actions API sequences for custom multi-touch gestures (rotate, three-finger swipe, edge swipes, precise timing). Prefer `appium_gesture` for standard gestures. |
 | `appium_set_value`    | Enter text into an input field                                                               |
-| `appium_mobile_hide_keyboard` | Dismiss the on-screen keyboard (`mobile: hideKeyboard`) |
-| `appium_mobile_is_keyboard_shown` | Whether the on-screen keyboard is visible (`mobile: isKeyboardShown`) |
+| `appium_mobile_keyboard` | Hide the on-screen keyboard or query visibility. `action=hide` \| `is_shown` (`keys` optional for hide). |
 | `appium_get_text`     | Get text content from an element                                                             |
 | `appium_get_clipboard` | Get the current clipboard content as plain text from the device            |
 | `appium_set_clipboard` | Set the device clipboard to the provided plain text                        |

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -35,7 +35,7 @@ This directory contains all MCP tools available in MCP Appium.
 - `drag-and-drop.ts` - Drag and drop elements or coordinates
 - `press-key.ts` - Press navigation keys or physical buttons
 - `set-value.ts` - Enter text
-- `keyboard.ts` - Soft keyboard: `appium_mobile_hide_keyboard` / `appium_mobile_is_keyboard_shown`
+- `keyboard.ts` - Soft keyboard (`appium_mobile_keyboard`; `action=hide` \| `is_shown`)
 - `get-text.ts` - Get element text
 - `get-page-source.ts` - Get page source (XML) from current screen
 - `screenshot.ts` - Capture screenshots

--- a/src/tools/interactions/keyboard.ts
+++ b/src/tools/interactions/keyboard.ts
@@ -52,11 +52,8 @@ async function handleIsShown(sessionId?: string): Promise<ContentResult> {
   }
   const { driver } = resolved;
 
-  const raw = await execute(driver, 'mobile: isKeyboardShown', {});
-  if (typeof raw !== 'boolean') {
-    throw new Error(`Unexpected isKeyboardShown result type: ${typeof raw}`);
-  }
-  return textResult(JSON.stringify({ keyboardShown: raw }, null, 2));
+  const keyboardShown = await execute(driver, 'mobile: isKeyboardShown', {});
+  return textResult(JSON.stringify({ keyboardShown }, null, 2));
 }
 
 export default function keyboard(server: FastMCP): void {

--- a/src/tools/interactions/keyboard.ts
+++ b/src/tools/interactions/keyboard.ts
@@ -8,91 +8,86 @@ import {
   toolErrorMessage,
 } from '../tool-response.js';
 
-export default function keyboard(server: FastMCP): void {
-  const hideKeyboardSchema = z.object({
-    keys: z
-      .array(z.string())
-      .optional()
-      .describe(
-        'Optional key names used to dismiss the keyboard (e.g. "done" on tablets). ' +
-          'Maps to the `keys` argument of mobile: hideKeyboard. Omit for default behavior.'
-      ),
-    sessionId: z
-      .string()
-      .optional()
-      .describe('Session ID to target. If omitted, uses the active session.'),
-  });
+const schema = z.object({
+  action: z
+    .enum(['hide', 'is_shown'])
+    .describe(
+      'hide: dismiss the software keyboard (mobile: hideKeyboard). ' +
+        'is_shown: whether the keyboard is visible (mobile: isKeyboardShown).'
+    ),
+  keys: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'hide only: optional key names to dismiss the keyboard (e.g. "done"). ' +
+        'Forwarded to mobile: hideKeyboard when non-empty. Ignored for is_shown.'
+    ),
+  sessionId: z
+    .string()
+    .optional()
+    .describe('Session ID to target. If omitted, uses the active session.'),
+});
 
+type KeyboardArgs = z.infer<typeof schema>;
+
+async function handleHide(
+  sessionId: string | undefined,
+  keys: string[] | undefined
+): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
+  const params = keys && keys.length > 0 ? { keys } : {};
+  await execute(driver, 'mobile: hideKeyboard', params);
+  return textResult('Keyboard dismissed successfully.');
+}
+
+async function handleIsShown(sessionId?: string): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
+  const { driver } = resolved;
+
+  const raw = await execute(driver, 'mobile: isKeyboardShown', {});
+  if (typeof raw !== 'boolean') {
+    throw new Error(`Unexpected isKeyboardShown result type: ${typeof raw}`);
+  }
+  return textResult(JSON.stringify({ keyboardShown: raw }, null, 2));
+}
+
+export default function keyboard(server: FastMCP): void {
   server.addTool({
-    name: 'appium_mobile_hide_keyboard',
+    name: 'appium_mobile_keyboard',
     description:
-      'Dismiss the on-screen software keyboard via Appium `mobile: hideKeyboard`. ' +
-      'Supports Android (UiAutomator2) and iOS (XCUITest). ' +
-      'May fail when no dismiss control exists; use gestures or back as a fallback.',
-    parameters: hideKeyboardSchema,
+      'Hide the software keyboard or check if it is visible (Android UiAutomator2 / iOS XCUITest). ' +
+      'action=hide uses mobile: hideKeyboard; action=is_shown uses mobile: isKeyboardShown.',
+    parameters: schema,
     annotations: {
       readOnlyHint: false,
       openWorldHint: false,
     },
     execute: async (
-      args: z.infer<typeof hideKeyboardSchema>,
+      args: KeyboardArgs,
       _context: Record<string, unknown> | undefined
     ): Promise<ContentResult> => {
-      const resolved = resolveDriver(args.sessionId);
-      if (!resolved.ok) {
-        return resolved.result;
-      }
-      const { driver } = resolved;
-
       try {
-        const params =
-          args.keys && args.keys.length > 0 ? { keys: args.keys } : {};
-        await execute(driver, 'mobile: hideKeyboard', params);
-        return textResult('Keyboard dismissed successfully.');
-      } catch (err: unknown) {
-        return errorResult(
-          `Failed to hide keyboard. Error: ${toolErrorMessage(err)}`
-        );
-      }
-    },
-  });
-
-  server.addTool({
-    name: 'appium_mobile_is_keyboard_shown',
-    description:
-      'Return whether the system on-screen keyboard is visible using Appium `mobile: isKeyboardShown`. ' +
-      'Supports Android (UiAutomator2) and iOS (XCUITest). Response is JSON: `{ "keyboardShown": true|false }`.',
-    parameters: z.object({
-      sessionId: z
-        .string()
-        .optional()
-        .describe('Session ID to target. If omitted, uses the active session.'),
-    }),
-    annotations: {
-      readOnlyHint: true,
-      openWorldHint: false,
-    },
-    execute: async (
-      args: { sessionId?: string },
-      _context: Record<string, unknown> | undefined
-    ): Promise<ContentResult> => {
-      const resolved = resolveDriver(args.sessionId);
-      if (!resolved.ok) {
-        return resolved.result;
-      }
-      const { driver } = resolved;
-
-      try {
-        const raw = await execute(driver, 'mobile: isKeyboardShown', {});
-        if (typeof raw !== 'boolean') {
-          throw new Error(
-            `Unexpected isKeyboardShown result type: ${typeof raw}`
-          );
+        switch (args.action) {
+          case 'hide':
+            return await handleHide(args.sessionId, args.keys);
+          case 'is_shown':
+            return await handleIsShown(args.sessionId);
         }
-        return textResult(JSON.stringify({ keyboardShown: raw }, null, 2));
       } catch (err: unknown) {
+        const msg = toolErrorMessage(err);
+        if (args.action === 'hide') {
+          return errorResult(`Failed to hide keyboard. Error: ${msg}`);
+        }
         return errorResult(
-          `Failed to query keyboard visibility. Error: ${toolErrorMessage(err)}`
+          `Failed to query keyboard visibility. Error: ${msg}`
         );
       }
     },


### PR DESCRIPTION
Replaces `appium_mobile_hide_keyboard` and `appium_mobile_is_keyboard_shown` with **`appium_mobile_keyboard`**, same consolidation style as other MCP tools (flat schema, `action` switch).

### API
- **`action`**: `hide` | `is_shown`
- **`sessionId`**: optional (omit for active session)
- **`keys`**: optional, **hide only** --> passed through to `mobile: hideKeyboard` when non-empty; ignored for **`is_shown`**