### PR TITLE
docs: integrator notes for sessions, transport, logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,26 @@ Set the `CAPABILITIES_CONFIG` environment variable to point to your configuratio
   - If `CAPABILITIES_CONFIG` is set, it will merge with the `general` section from your capabilities file.
 - This allows custom setups and non-standard platforms to work without changing server logic.
 
+### Integrator notes (sessions, transport, logging)
+
+For **CI**, **device farms**, or **multi-session** setups:
+
+#### Multi-session and `sessionId`
+
+The process keeps one **active** Appium session; tools use it when **`sessionId` is omitted**. If more than one session exists (see **`appium_session_management`** with **`action=list`**), pass **`sessionId` on every tool call** that must target a specific session. Do not assume the active session is stable if other clients or flows can create, select, or delete sessions.
+
+#### Client disconnect
+
+When the MCP **client disconnects**, the server **closes every session** it is tracking (Appium **`deleteSession`** for each). Transports that drop often—**`httpStream`** behind proxies, idle timeouts, or flaky clients—will **wipe automation** in one go. **stdio** is usually safer for a single long-lived operator; if you use **httpStream**, expect reconnects to require **new sessions**.
+
+#### Remote Appium, CI, and device farms
+
+For **grids, cloud labs, or CI**, prefer **`remoteServerUrl`** plus explicit **`capabilities`** on **`appium_session_management`** (**`action=create`**)—for example **`appium:udid`**, app path or id, platform version—rather than depending on local discovery. **`select_device`** is geared toward **local** ADB / simulator picking; use it as a **dev convenience**, not the main path for allocated remote devices.
+
+#### Tool logging and argument size
+
+Tool calls are logged with argument **redaction** implemented via **`JSON.stringify`**. Oversized payloads (huge **`capabilities`** objects, long strings) cost **CPU** and **log volume**. Prefer **`CAPABILITIES_CONFIG`** or smaller per-call objects when you can.
+
 ### Screenshots
 
 Set the `SCREENSHOTS_DIR` environment variable to specify where screenshots are saved. If not set, screenshots are saved to the current working directory. Supports both absolute and relative paths (relative paths are resolved from the current working directory). The directory is created automatically if it doesn't exist.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For **grids, cloud labs, or CI**, prefer **`remoteServerUrl`** plus explicit **`
 
 #### Tool logging and argument size
 
-Tool calls are logged with argument **redaction** implemented via **`JSON.stringify`**. Oversized payloads (huge **`capabilities`** objects, long strings) cost **CPU** and **log volume**. Prefer **`CAPABILITIES_CONFIG`** or smaller per-call objects when you can.
+Tool calls are logged with argument **redaction** implemented via **`JSON.stringify`**. Oversized payloads (especially long **base64 strings**, e.g., screenshot/image payloads, and also very large **`capabilities`** objects) cost **CPU** and **log volume**. Prefer **`CAPABILITIES_CONFIG`** and avoid passing large inline blobs in tool arguments when possible.
 
 ### Screenshots
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,6 +13,13 @@ Welcome! This guide will help you extend MCP Appium by adding new tools and reso
 - [Code Style Guidelines](#code-style-guidelines)
 - [Testing Your Tool](#testing-your-tool)
 - [Formatting Best Practices](#formatting-best-practices)
+- [Integrators (CI, farms, multi-session)](#integrators-ci-farms-multi-session)
+
+---
+
+## Integrators (CI, farms, multi-session)
+
+End-user behavior for **multiple sessions**, **MCP client disconnect**, **remote Appium / farms**, and **tool argument logging** lives in the main **README**, under **Configuration → Integrator notes (sessions, transport, logging)**. If you change session lifecycle (`session-store`, `server` disconnect handling) or the tool logging wrapper, update that README section so it stays accurate.
 
 ---
 


### PR DESCRIPTION
README.md: Under Configuration, after Platform names and "general" mode, added Integrator notes (sessions, transport, logging) with four subsections:
- Multi-session and sessionId -->  pass sessionId when multiple sessions exist; don’t rely only on active.
- Client disconnect --> all tracked sessions are closed on disconnect; httpStream / flaky clients called out; stdio noted as usually safer for one long-lived client.
- Remote Appium, CI, and device farms --> remoteServerUrl + capabilities on appium_session_management; select_device as local/dev convenience.
- Tool logging and argument size -->redaction via JSON.stringify; avoid huge capabilities payloads; prefer CAPABILITIES_CONFIG.
- docs/CONTRIBUTING.md -->Short Integrators section + TOC entry pointing maintainers at that README block when changing session lifecycle or tool logging.