### PR TITLE
fix: loading mcp server to start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ async function startServer(): Promise<void> {
 
   try {
     if (useHttpStream) {
-      server.start({
+      await server.start({
         transportType: 'httpStream',
         httpStream: {
           endpoint: '/sse',
@@ -28,7 +28,7 @@ async function startServer(): Promise<void> {
       log.info('Waiting for client connections...');
     } else {
       // Start with stdio transport
-      server.start({
+      await server.start({
         transportType: 'stdio',
       });
 


### PR DESCRIPTION
 npx cold-start delay + stderr noise                                                                                                                
                                                                                                                                                       
 When Cursor runs npx appium-mcp@latest, npm has to download/install the package every time. During that install phase, npm prints deprecation warnings
   (koa-router, glob) to stderr. Cursor logs these as [error] entries. The install takes ~15-25 seconds, and by the time the actual MCP server starts,  
  Cursor's connection handshake may have already timed out or been aborted. 
  
  
<img width="1475" height="617" alt="image" src="https://github.com/user-attachments/assets/e5a4e02f-ef9a-40ed-b873-bf80c2af1328" />
<img width="1050" height="83" alt="image" src="https://github.com/user-attachments/assets/13471b5a-f5bf-44df-a619-da6a86068965" />
