### PR TITLE
feat: add APPIUM_MCP_ON_CLIENT_DISCONNECT toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This will automatically configure the MCP server for use with Claude Code. Make 
 | `CAPABILITIES_CONFIG` | Optional | Absolute path to a `capabilities.json` file with per-platform capability presets |
 | `SCREENSHOTS_DIR` | Optional | Directory where screenshots and screen recordings are saved. Defaults to the current working directory |
 | `NO_UI` | Optional | Set to `true` or `1` to disable HTML UI components — faster responses, fewer tokens. See [NO_UI Mode](#no_ui-mode) |
+| `APPIUM_MCP_ON_CLIENT_DISCONNECT` | Optional | Session cleanup when the MCP client disconnects: `delete_all` (default) deletes **MCP-owned** Appium sessions (`safeDeleteAllSessions`); `skip` keeps those sessions across disconnects (e.g. HTTP/stream clients that reconnect). Attached/remote sessions are not removed by this path. See [MCP disconnect behavior](#mcp-disconnect-behavior). |
 | `APPIUM_MCP_WDA_APP_PATH` | Optional | Absolute path to a pre-extracted `WebDriverAgentRunner-Runner.app` bundle. When set, `prepare_ios_simulator` skips all GitHub downloads and uses this bundle directly — useful in environments where external downloads are blocked |
 | `REMOTE_SERVER_URL_ALLOW_REGEX` | Optional | Regex pattern that remote Appium server URLs must match. Defaults to `^https?://` |
 | `AI_VISION_API_BASE_URL` | Required for AI Vision | Base URL of the OpenAI-compatible vision model API |
@@ -320,6 +321,14 @@ The following tools return lightweight text-only responses when NO_UI is enabled
 - ✅ Network-constrained environments
 - ✅ Scripted automation where human interaction is not needed
 - ❌ Interactive debugging and exploration (keep UI enabled for better experience)
+
+#### MCP disconnect behavior
+
+By default (`APPIUM_MCP_ON_CLIENT_DISCONNECT` unset or `delete_all`), when the **MCP client disconnects**, this server **deletes every MCP-owned Appium session** (the same sessions `safeDeleteAllSessions` targets) so embedded drivers are not left running after a short-lived assistant run. **Attached** sessions (`ownership=attached`) are unchanged by this teardown.
+
+HTTP and streamable MCP clients may **disconnect briefly** (reconnect, reload, proxy). If that tears down drivers you still need, set `APPIUM_MCP_ON_CLIENT_DISCONNECT` to `skip` in your MCP server `env` (same pattern as `NO_UI` above). With `skip`, sessions **survive** disconnect until you call `appium_session_management` with `action=delete`, or you stop the Appium server / process.
+
+**Tradeoff:** `skip` can leave **orphaned sessions** on your Appium server if nothing cleans up — use it when disconnect is not the same as “automation finished.”
 
 ## 🎯 Available Tools
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,27 @@ import registerResources from './resources/index.js';
 import { listSessions, safeDeleteAllSessions } from './session-store.js';
 import log from './logger.js';
 
+type DisconnectSessionPolicy = 'delete_all' | 'skip';
+
+/**
+ * MCP disconnect policy for Appium sessions tracked by this server.
+ * - delete_all (default): end every owned session when the MCP client disconnects (avoids leaked drivers).
+ * - skip: keep sessions across disconnects — needed for flaky HTTP/stream clients that reconnect briefly.
+ */
+function disconnectSessionPolicyFromEnv(): DisconnectSessionPolicy {
+  const raw = process.env.APPIUM_MCP_ON_CLIENT_DISCONNECT?.trim().toLowerCase();
+  if (!raw || raw === 'delete_all') {
+    return 'delete_all';
+  }
+  if (raw === 'skip') {
+    return 'skip';
+  }
+  log.warn(
+    `APPIUM_MCP_ON_CLIENT_DISCONNECT="${raw}" is not recognized (expected delete_all or skip); defaulting to delete_all`
+  );
+  return 'delete_all';
+}
+
 const server = new FastMCP({
   name: 'MCP Appium',
   version: '1.0.0',
@@ -21,9 +42,20 @@ server.on('connect', (event) => {
 
 server.on('disconnect', async (event) => {
   log.info('Client disconnected:', event.session);
+  const policy = disconnectSessionPolicyFromEnv();
+
   const ownedSessions = listSessions().filter(
     (session) => session.ownership === 'owned'
   );
+
+  if (ownedSessions.length > 0 && policy === 'skip') {
+    log.info(
+      `${ownedSessions.length} owned session(s) retained after MCP disconnect ` +
+        '(APPIUM_MCP_ON_CLIENT_DISCONNECT=skip). Delete explicitly via appium_session_management when finished.'
+    );
+    return;
+  }
+
   if (ownedSessions.length > 0) {
     try {
       log.info(

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,15 +13,14 @@ type DisconnectSessionPolicy = 'delete_all' | 'skip';
  */
 function disconnectSessionPolicyFromEnv(): DisconnectSessionPolicy {
   const raw = process.env.APPIUM_MCP_ON_CLIENT_DISCONNECT?.trim().toLowerCase();
-  if (!raw || raw === 'delete_all') {
-    return 'delete_all';
-  }
   if (raw === 'skip') {
     return 'skip';
   }
-  log.warn(
-    `APPIUM_MCP_ON_CLIENT_DISCONNECT="${raw}" is not recognized (expected delete_all or skip); defaulting to delete_all`
-  );
+  if (raw !== 'delete_all') {
+    log.warn(
+      `APPIUM_MCP_ON_CLIENT_DISCONNECT="${raw}" is not recognized (expected delete_all or skip); defaulting to delete_all`
+    );
+  }
   return 'delete_all';
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,7 @@ server.on('disconnect', async (event) => {
   if (ownedSessions.length > 0 && policy === 'skip') {
     log.info(
       `${ownedSessions.length} owned session(s) retained after MCP disconnect ` +
-        '(APPIUM_MCP_ON_CLIENT_DISCONNECT=skip). Delete explicitly via appium_session_management when finished.'
+        '(APPIUM_MCP_ON_CLIENT_DISCONNECT=skip). Delete explicitly via appium_session_management (action=delete) when finished.'
     );
     return;
   }


### PR DESCRIPTION
- delete_all (default): delete MCP-owned sessions on MCP disconnect (unchanged semantics with ownership filter).
- skip: retain owned sessions for HTTP/stream clients that reconnect briefly.
- README: env table + disconnect behavior (owned vs attached).