### PR TITLE
fix(find-elements): gate ai instructions behind a config env

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ This will automatically configure the MCP server for use with Claude Code. Make 
 | `NO_UI` | Optional | Set to `true` or `1` to disable HTML UI components — faster responses, fewer tokens. See [NO_UI Mode](#no_ui-mode) |
 | `APPIUM_MCP_WDA_APP_PATH` | Optional | Absolute path to a pre-extracted `WebDriverAgentRunner-Runner.app` bundle. When set, `prepare_ios_simulator` skips all GitHub downloads and uses this bundle directly — useful in environments where external downloads are blocked |
 | `REMOTE_SERVER_URL_ALLOW_REGEX` | Optional | Regex pattern that remote Appium server URLs must match. Defaults to `^https?://` |
-| `AI_VISION_API_BASE_URL` | Required for AI Vision | Base URL of the OpenAI-compatible vision model API |
-| `AI_VISION_API_KEY` | Required for AI Vision | API key for the vision model provider |
+| `AI_VISION_ENABLED` | Optional | Set to `true` to register the `appium_ai` tool (vision-based element finding). When unset or `false`, the AI tool is **not registered** and the LLM has no way to invoke vision-based finding. Requires `AI_VISION_API_BASE_URL` and `AI_VISION_API_KEY` to also be set, otherwise the server fails to start. |
+| `AI_VISION_API_BASE_URL` | Required when `AI_VISION_ENABLED=true` | Base URL of the OpenAI-compatible vision model API |
+| `AI_VISION_API_KEY` | Required when `AI_VISION_ENABLED=true` | API key for the vision model provider |
 | `AI_VISION_MODEL` | Optional | Vision model name (default: `Qwen3-VL-235B-A22B-Instruct`) |
 | `AI_VISION_COORD_TYPE` | Optional | Coordinate type: `normalized` (default) or `absolute` |
 | `AI_VISION_IMAGE_MAX_WIDTH` | Optional | Max image width in pixels before compression (default: `1080`) |
@@ -227,7 +228,9 @@ To start recording, call `appium_screen_recording` with `action="start"`. You ma
 
 ### AI Vision Element Finding
 
-Configure AI-powered element finding using vision models. This feature allows you to locate UI elements using natural language descriptions instead of traditional XPath or ID selectors.
+Configure AI-powered element finding using vision models. When enabled, a separate tool — **`appium_ai`** — is registered alongside `appium_find_element`. It exposes `action=find_element`, which locates UI elements from natural-language descriptions and returns a coordinate UUID (`ai-element:x,y:bbox`) that can be passed to `appium_gesture` (`tap` / `double_tap` / `long_press`).
+
+**This feature is opt-in.** When `AI_VISION_ENABLED` is unset or `false`, the `appium_ai` tool is **not registered** and the LLM has no way to invoke vision-based finding — keeping `appium_find_element` purely traditional. This deliberate gating prevents the model from defaulting to a slow, paid vision call when a stable locator (accessibility id, resource-id, etc.) would do the job.
 
 **Required Environment Variables:**
 
@@ -236,12 +239,15 @@ Configure AI-powered element finding using vision models. This feature allows yo
   "appium-mcp": {
     "env": {
       "ANDROID_HOME": "/path/to/android/sdk",
+      "AI_VISION_ENABLED": "true",
       "AI_VISION_API_BASE_URL": "https://dashscope.aliyuncs.com/compatible-mode/v1",
       "AI_VISION_API_KEY": "your_api_key_here"
     }
   }
 }
 ```
+
+If `AI_VISION_ENABLED=true` is set without both API vars, the server fails to start with a clear error message — misconfiguration is surfaced immediately rather than mid-test.
 
 **Optional Environment Variables:**
 
@@ -356,7 +362,8 @@ The default regex pattern allows any URL that starts with `http://` or `https://
 
 | Tool                  | Description                                                                                  |
 | --------------------- | -------------------------------------------------------------------------------------------- |
-| `appium_find_element` | Find a specific element using traditional locator strategies (xpath, id, accessibility id, etc.) **OR** AI-powered natural language descriptions (e.g., "yellow search button at bottom"). To scroll until an element appears, use **`appium_gesture`** with **`action=scroll_to_element`** (same `strategy` / `selector` as find). |
+| `appium_find_element` | Find a specific element using traditional locator strategies (xpath, id, accessibility id, etc.). To scroll until an element appears, use **`appium_gesture`** with **`action=scroll_to_element`** (same `strategy` / `selector` as find). |
+| `appium_ai` | **Opt-in (gated by `AI_VISION_ENABLED=true`).** Vision-based element finding — fallback for when traditional locators don't work. `action=find_element` takes a natural-language `instruction` (e.g., "yellow search button at bottom") and returns a coordinate UUID consumable by **`appium_gesture`** (`tap` / `double_tap` / `long_press`). See [AI Vision Element Finding](#ai-vision-element-finding) for setup. |
 | `appium_gesture`      | Perform a touch gesture. `action` = `tap`, `double_tap`, `long_press`, `scroll`, `swipe`, `pinch_zoom`, or **`scroll_to_element`**. **`scroll_to_element`** scrolls vertically (`direction` = `up` \| `down`) until the locator matches, **page source stops changing** after a scroll (end of list), or **`maxScrollAttempts`** (default 10, max 80). Optional **`scrollDistance`** (0.05–1) or **`scrollDistancePreset`** = `small` \| `medium` \| `large`. Supports element UUIDs and raw coordinates for other actions. For swipe, use `speed` = `slow` \| `normal` \| `fast` (fast for pull-to-refresh). |
 | `appium_drag_and_drop` | Perform a drag and drop gesture from a source location to a target location (supports element-to-element, element-to-coordinates, coordinates-to-element, and coordinates-to-coordinates) |
 | `appium_perform_actions` | Execute raw W3C Actions API sequences for custom multi-touch gestures (rotate, three-finger swipe, edge swipes, precise timing). Prefer `appium_gesture` for standard gestures. |
@@ -449,29 +456,43 @@ This example demonstrates a complete e-commerce checkout flow that can be automa
 
 Use **`scrollDistance`** (0.05–1) instead of **`scrollDistancePreset`** when you want an exact fraction. Then call **`appium_find_element`** with the same `strategy` / `selector` to obtain the element id.
 
-**AI Mode (Natural Language):**
+**AI Mode (Natural Language) — requires `AI_VISION_ENABLED=true`:**
+
+When the AI tool is enabled, use **`appium_ai`** (not `appium_find_element`) for vision-based finding:
+
 ```json
 {
-  "tool": "appium_find_element",
+  "tool": "appium_ai",
   "arguments": {
-    "strategy": "ai_instruction",
-    "ai_instruction": "yellow search button at the bottom of the screen"
+    "action": "find_element",
+    "instruction": "yellow search button at the bottom of the screen"
   }
 }
 ```
 
-**More AI Mode Examples:**
+The returned UUID (`ai-element:x,y:bbox`) flows directly into `appium_gesture`:
+
+```json
+{
+  "tool": "appium_gesture",
+  "arguments": {
+    "action": "tap",
+    "elementUUID": "ai-element:540,2280:480,2240,600,2320"
+  }
+}
+```
+
+**More instruction examples:**
 - `"username input field at top"`
 - `"settings icon in top-right corner"`
 - `"red delete button next to the item"`
 - `"blue submit button at bottom"`
 - `"profile picture in navigation bar"`
 
-**Benefits of AI Mode:**
-- **No Complex Selectors**: Describe elements in plain language
-- **Resilient to UI Changes**: Semantic understanding adapts to layout changes
-- **Faster Development**: No need to inspect element hierarchies
-- **Works Across Languages**: Describe in any language you're comfortable with
+**When to reach for `appium_ai` vs `appium_find_element`:**
+- **Prefer `appium_find_element`** whenever a stable accessibility id, resource-id, or unique text exists — faster, free, deterministic.
+- **Use `appium_ai`** only when the element has no stable identifier, the page source is unavailable, or you must locate by visual cues (color, position, icon).
+- See [AI Vision Element Finding](#ai-vision-element-finding) for setup and configuration.
 
 ### Working in Your Native Language
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The default regex pattern allows any URL that starts with `http://` or `https://
 
 | Tool                  | Description                                                                                  |
 | --------------------- | -------------------------------------------------------------------------------------------- |
-| `appium_find_element` | Find a specific element using traditional locator strategies (xpath, id, accessibility id, etc.). To scroll until an element appears, use **`appium_gesture`** with **`action=scroll_to_element`** (same `strategy` / `selector` as find). |
+| `appium_find_element` | Find a specific element using traditional locator strategies. **Strategy priority**: `accessibility id` > `id` > platform-native (`-ios predicate string` / `-ios class chain` on iOS, `-android uiautomator` on Android) > `xpath` (last resort — slow & brittle). To scroll until an element appears, use **`appium_gesture`** with **`action=scroll_to_element`** (same `strategy` / `selector` as find). |
 | `appium_ai` | **Opt-in (gated by `AI_VISION_ENABLED=true`).** Vision-based element finding — fallback for when traditional locators don't work. `action=find_element` takes a natural-language `instruction` (e.g., "yellow search button at bottom") and returns a coordinate UUID consumable by **`appium_gesture`** (`tap` / `double_tap` / `long_press`). See [AI Vision Element Finding](#ai-vision-element-finding) for setup. |
 | `appium_gesture`      | Perform a touch gesture. `action` = `tap`, `double_tap`, `long_press`, `scroll`, `swipe`, `pinch_zoom`, or **`scroll_to_element`**. **`scroll_to_element`** scrolls vertically (`direction` = `up` \| `down`) until the locator matches, **page source stops changing** after a scroll (end of list), or **`maxScrollAttempts`** (default 10, max 80). Optional **`scrollDistance`** (0.05–1) or **`scrollDistancePreset`** = `small` \| `medium` \| `large`. Supports element UUIDs and raw coordinates for other actions. For swipe, use `speed` = `slow` \| `normal` \| `fast` (fast for pull-to-refresh). |
 | `appium_drag_and_drop` | Perform a drag and drop gesture from a source location to a target location (supports element-to-element, element-to-coordinates, coordinates-to-element, and coordinates-to-coordinates) |
@@ -428,7 +428,22 @@ This example demonstrates a complete e-commerce checkout flow that can be automa
 
 ### AI-Powered Element Finding Examples
 
-**Traditional Mode (XPath/ID):**
+**Traditional Mode — prefer stable identifiers:**
+
+Try strategies in priority order: `accessibility id` first, then `id`, then platform-native predicates (`-ios predicate string` / `-ios class chain` on iOS, `-android uiautomator` on Android). Reach for `xpath` only when nothing more stable exists.
+
+```json
+{
+  "tool": "appium_find_element",
+  "arguments": {
+    "strategy": "accessibility id",
+    "selector": "search-button"
+  }
+}
+```
+
+`xpath` fallback (when no accessibility id, resource-id, or platform-native predicate works):
+
 ```json
 {
   "tool": "appium_find_element",

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -51,7 +51,8 @@ When searching for elements, follow this priority order for efficiency:
    - Best for: Finding what element currently has focus
 
 2. **`appium_find_element`** (PRIORITY 2) - Use this to search for a specific target element
-   - Specify strategy (xpath, id, accessibility id, etc.) and selector
+   - Specify strategy and selector
+   - Strategy priority: `accessibility id` > `id` > platform-native (`-ios predicate string` / `-ios class chain` on iOS, `-android uiautomator` on Android) > `xpath` (last resort)
    - Returns specific element UUID
    - Best for: Targeting a known element
 

--- a/src/tools/ai/ai.ts
+++ b/src/tools/ai/ai.ts
@@ -1,0 +1,36 @@
+import type { ContentResult, FastMCP } from 'fastmcp';
+import { resolveDriver } from '../tool-response.js';
+import { AI_ACTIONS, aiSchema, type AIArgs } from './schema.js';
+import { handleFindElement } from './handlers/find-element.js';
+
+export default function ai(server: FastMCP): void {
+  server.addTool({
+    name: 'appium_ai',
+    description:
+      `Vision-based AI capabilities (FALLBACK - use only when traditional tools cannot locate the element). ` +
+      `Use 'action' to choose: ${AI_ACTIONS.join(', ')}. ` +
+      `find_element: locate an element from a natural-language description; returns a coordinate UUID (ai-element:x,y:bbox) usable with appium_gesture. ` +
+      `Prefer appium_find_element with xpath/id/accessibility id/text first. ` +
+      `Reach for this tool only when the element has no stable identifier, the page source is unavailable, or you need to locate by purely visual cues (color, position, icon).`,
+    parameters: aiSchema,
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
+    execute: async (
+      args: AIArgs,
+      _context: Record<string, unknown> | undefined
+    ): Promise<ContentResult> => {
+      const resolved = resolveDriver(args.sessionId);
+      if (!resolved.ok) {
+        return resolved.result;
+      }
+      const { driver } = resolved;
+
+      switch (args.action) {
+        case 'find_element':
+          return handleFindElement(driver, args);
+      }
+    },
+  });
+}

--- a/src/tools/ai/config.ts
+++ b/src/tools/ai/config.ts
@@ -1,0 +1,35 @@
+/**
+ * AI tool enablement and configuration.
+ *
+ * The AI tool is gated behind AI_VISION_ENABLED to prevent the LLM from
+ * defaulting to vision-based finding when a traditional locator would work,
+ * and to keep cost/latency surprises out of the default experience.
+ *
+ * Contract:
+ *   - AI_VISION_ENABLED !== 'true'  → tool is not registered.
+ *   - AI_VISION_ENABLED === 'true'  → AI_VISION_API_BASE_URL and
+ *     AI_VISION_API_KEY MUST be set, or server startup fails fast.
+ */
+
+const ENABLED_FLAG = 'AI_VISION_ENABLED';
+const REQUIRED_WHEN_ENABLED = [
+  'AI_VISION_API_BASE_URL',
+  'AI_VISION_API_KEY',
+] as const;
+
+export function isAIEnabled(): boolean {
+  return process.env[ENABLED_FLAG]?.toLowerCase() === 'true';
+}
+
+export function assertAIConfig(): void {
+  if (!isAIEnabled()) {
+    return;
+  }
+  const missing = REQUIRED_WHEN_ENABLED.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(
+      `${ENABLED_FLAG}=true but required env vars are missing: ${missing.join(', ')}. ` +
+        `Set them or unset ${ENABLED_FLAG} to disable the AI tool.`
+    );
+  }
+}

--- a/src/tools/ai/handlers/find-element.ts
+++ b/src/tools/ai/handlers/find-element.ts
@@ -1,0 +1,74 @@
+import type { ContentResult } from 'fastmcp';
+import { imageUtil } from '@appium/support';
+import type { DriverInstance } from '../../../session-store.js';
+import { getScreenshot } from '../../../command.js';
+import { AIVisionFinder } from '../../../ai-finder/vision-finder.js';
+import log from '../../../logger.js';
+import {
+  errorResult,
+  textResultWithPrimaryElementId,
+  toolErrorMessage,
+} from '../../tool-response.js';
+import type { AIArgs } from '../schema.js';
+
+// Module-level singleton: ensures the LRU cache persists across tool calls.
+// Creating a new AIVisionFinder() on every call would reset the cache each time.
+let _finderInstance: AIVisionFinder | null = null;
+function getAIVisionFinder(): AIVisionFinder {
+  if (!_finderInstance) {
+    _finderInstance = new AIVisionFinder();
+  }
+  return _finderInstance;
+}
+
+export async function handleFindElement(
+  driver: DriverInstance,
+  args: AIArgs
+): Promise<ContentResult> {
+  if (!args.instruction) {
+    return errorResult(
+      'instruction is required for action=find_element. ' +
+        'Example: { action: "find_element", instruction: "yellow search button at bottom" }'
+    );
+  }
+
+  try {
+    log.info(
+      `Finding element using AI with instruction: "${args.instruction}"`
+    );
+
+    const screenshotBase64 = await getScreenshot(driver);
+
+    const imageBuffer = Buffer.from(screenshotBase64, 'base64');
+    const sharp = imageUtil.requireSharp();
+    const metadata = await sharp(imageBuffer).metadata();
+
+    if (!metadata.width || !metadata.height) {
+      throw new Error('Failed to get image dimensions from screenshot');
+    }
+
+    const { width, height } = metadata;
+
+    const finder = getAIVisionFinder();
+    const result = await finder.findElement(
+      screenshotBase64,
+      args.instruction,
+      width,
+      height
+    );
+
+    // Format: "ai-element:{x},{y}:{bbox}" — consumed by appium_gesture handlers.
+    const elementUUID = `ai-element:${result.center.x},${result.center.y}:${result.bbox.join(',')}`;
+
+    let detail = `Successfully found "${result.target}" at coordinates (${result.center.x}, ${result.center.y}) using AI vision.`;
+    if (result.annotatedImagePath) {
+      detail += ` Vision image: ${result.annotatedImagePath}`;
+    }
+
+    return textResultWithPrimaryElementId(elementUUID, detail);
+  } catch (err: unknown) {
+    const errorMessage = toolErrorMessage(err);
+    log.error('AI find_element failed:', errorMessage);
+    return errorResult(`AI find_element failed. Error: ${errorMessage}`);
+  }
+}

--- a/src/tools/ai/schema.ts
+++ b/src/tools/ai/schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const AI_ACTIONS = ['find_element'] as const;
+export type AIAction = (typeof AI_ACTIONS)[number];
+
+export const aiSchema = z.object({
+  action: z
+    .enum(AI_ACTIONS)
+    .describe(
+      `AI capability to invoke. ` +
+        `find_element: locate an element from a natural-language description using a vision model. ` +
+        `Returns a coordinate UUID (format: ai-element:x,y:bbox) usable with appium_gesture (tap/double_tap/long_press).`
+    ),
+
+  instruction: z
+    .string()
+    .optional()
+    .describe(
+      `Natural-language description of the target element. ` +
+        `Required for: find_element. ` +
+        `Examples: "yellow search button at bottom", "username input field at top", "settings icon in top-right corner".`
+    ),
+
+  sessionId: z
+    .string()
+    .optional()
+    .describe('Session ID to target. If omitted, uses the active session.'),
+});
+
+export type AIArgs = z.infer<typeof aiSchema>;

--- a/src/tools/gestures/handlers/tap.ts
+++ b/src/tools/gestures/handlers/tap.ts
@@ -13,9 +13,15 @@ import {
   textResultWithPrimaryElementId,
   toolErrorMessage,
 } from '../../tool-response.js';
+import { isAIEnabled } from '../../ai/config.js';
 import type { GestureArgs } from '../schema.js';
 
 const AI_ELEMENT_PREFIX = 'ai-element:';
+
+const AI_DISABLED_REJECTION =
+  `Received an ai-element: UUID, but the appium_ai tool is not registered ` +
+  `(AI_VISION_ENABLED is not set to true). Use appium_find_element to get a real ` +
+  `element UUID, or enable AI_VISION_ENABLED=true with the required AI_VISION_* keys.`;
 
 export async function handleTap(
   driver: DriverInstance,
@@ -24,6 +30,9 @@ export async function handleTap(
   try {
     if (args.elementUUID) {
       if (args.elementUUID.startsWith(AI_ELEMENT_PREFIX)) {
+        if (!isAIEnabled()) {
+          return errorResult(AI_DISABLED_REJECTION);
+        }
         const parsed = parseAiElementCoords(args.elementUUID);
         if ('error' in parsed) {
           return errorResult(parsed.error);

--- a/src/tools/gestures/schema.ts
+++ b/src/tools/gestures/schema.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 import { elementUUIDScheme } from '../../schema.js';
+import { isAIEnabled } from '../ai/config.js';
+
+const AI_UUID_HINT = isAIEnabled()
+  ? `Supports AI coordinate UUIDs (format: ai-element:x,y:bbox) returned by appium_ai. `
+  : '';
 
 export const GESTURE_ACTIONS = [
   'tap',
@@ -50,7 +55,8 @@ export const gestureSchema = z.object({
   elementUUID: elementUUIDScheme
     .optional()
     .describe(
-      `UUID of the element to act on. Supports AI coordinate UUIDs (format: ai-element:x,y:bbox). ` +
+      `UUID of the element to act on. ` +
+        AI_UUID_HINT +
         `Used by: tap, double_tap, long_press, pinch_zoom. ` +
         `For scroll/swipe, when provided with direction, the gesture is calculated relative to this element instead of the whole screen.`
     ),

--- a/src/tools/gestures/schema.ts
+++ b/src/tools/gestures/schema.ts
@@ -20,15 +20,15 @@ export const SCROLL_DISTANCE_PRESETS = ['small', 'medium', 'large'] as const;
 export type ScrollDistancePreset = (typeof SCROLL_DISTANCE_PRESETS)[number];
 
 export const LOCATOR_STRATEGIES = [
-  'xpath',
-  'id',
-  'name',
-  'class name',
   'accessibility id',
-  'css selector',
-  '-android uiautomator',
+  'id',
   '-ios predicate string',
   '-ios class chain',
+  '-android uiautomator',
+  'xpath',
+  'name',
+  'class name',
+  'css selector',
 ] as const;
 
 export const gestureSchema = z.object({
@@ -140,7 +140,11 @@ export const gestureSchema = z.object({
   strategy: z
     .enum(LOCATOR_STRATEGIES)
     .optional()
-    .describe(`Locator strategy. Required for: scroll_to_element.`),
+    .describe(
+      `Locator strategy. Required for: scroll_to_element. ` +
+        `Priority: accessibility id > id > platform-native (-ios predicate string / -ios class chain on iOS, -android uiautomator on Android) > xpath (LAST RESORT — slow on iOS XCUITest, brittle) > name > class name > css selector (webview only). ` +
+        `Same ranking as appium_find_element.`
+    ),
   selector: z
     .string()
     .optional()

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -47,6 +47,8 @@ import screenRecording from './interactions/screen-recording.js';
 import app from './app-management/app.js';
 import mobilePermissions from './app-management/permissions.js';
 import context from './context/context.js';
+import ai from './ai/ai.js';
+import { isAIEnabled, assertAIConfig } from './ai/config.js';
 
 type RegisteredTool = Parameters<FastMCP['addTool']>[0];
 
@@ -188,6 +190,18 @@ export default function registerTools(server: FastMCP): void {
   // Documentation
   answerAppium(server);
   appiumSkills(server);
+
+  // AI (vision-based fallback) — gated; only registered when explicitly enabled.
+  assertAIConfig();
+  if (isAIEnabled()) {
+    ai(server);
+    log.info('appium_ai tool registered (AI_VISION_ENABLED=true)');
+  } else {
+    log.info(
+      'appium_ai tool NOT registered (set AI_VISION_ENABLED=true to enable)'
+    );
+  }
+
   log.info('All tools registered');
 }
 

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -1,9 +1,5 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
-import { getScreenshot } from '../../command.js';
-import { imageUtil } from '@appium/support';
-import { AIVisionFinder } from '../../ai-finder/vision-finder.js';
-import log from '../../logger.js';
 import {
   resolveDriver,
   textResultWithPrimaryElementId,
@@ -11,16 +7,6 @@ import {
   toolErrorMessage,
   readWebElementId,
 } from '../tool-response.js';
-
-// Module-level singleton: ensures the LRU cache persists across tool calls.
-// Creating a new AIVisionFinder() on every call would reset the cache each time.
-let _finderInstance: AIVisionFinder | null = null;
-function getAIVisionFinder(): AIVisionFinder {
-  if (!_finderInstance) {
-    _finderInstance = new AIVisionFinder();
-  }
-  return _finderInstance;
-}
 
 export const findElementSchema = z.object({
   strategy: z.enum([
@@ -33,22 +19,8 @@ export const findElementSchema = z.object({
     '-android uiautomator',
     '-ios predicate string',
     '-ios class chain',
-    'ai_instruction', // NEW: AI-based natural language finding
   ]),
-  selector: z
-    .string()
-    .optional()
-    .describe(
-      'The selector to find the element. ' +
-        'REQUIRED for all traditional strategies (xpath, id, name, class name, accessibility id, css selector, -android uiautomator, -ios predicate string, -ios class chain). ' +
-        'NOT required when strategy is "ai_instruction" — use ai_instruction field instead.'
-    ),
-  ai_instruction: z
-    .string()
-    .optional()
-    .describe(
-      'Natural language instruction for AI-based element finding (required when strategy is ai_instruction)'
-    ),
+  selector: z.string().describe('The selector to find the element.'),
   sessionId: z
     .string()
     .optional()
@@ -60,21 +32,7 @@ export default function findElement(server: FastMCP): void {
     name: 'appium_find_element',
     description: `Find a specific element by strategy and selector which will return a uuid that can be used for interactions.
 
-**Traditional Mode**: Use strategy + selector (xpath, id, accessibility id, etc.)
-**AI Mode**: Use strategy='ai_instruction' + ai_instruction="natural language description"
-
 [PRIORITY 2: Use this to search for a target element by xpath, id, accessibility id, etc.]
-
-**AI Mode Examples**:
-- ai_instruction: "yellow search hotel button"
-- ai_instruction: "username input field at top"
-- ai_instruction: "settings icon in top-right corner"
-
-**Environment Variables Required for AI Mode**:
-- AI_VISION_API_BASE_URL: Vision model API endpoint (required)
-- AI_VISION_API_KEY: API authentication key (required)
-- AI_VISION_MODEL: Model name (optional, defaults to Qwen3-VL-235B-A22B-Instruct)
-- AI_VISION_COORD_TYPE: Coordinate type (optional, defaults to normalized)
 
 **Scrolling until an element appears**: use \`appium_gesture\` with \`action=scroll_to_element\` (same strategy + selector), not this tool.`,
     parameters: findElementSchema,
@@ -93,77 +51,17 @@ export default function findElement(server: FastMCP): void {
       const { driver } = resolved;
 
       try {
-        // Route 1: Traditional locator strategy
-        if (args.strategy !== 'ai_instruction') {
-          if (!args.selector) {
-            throw new Error(
-              'selector is required for traditional locator strategies'
-            );
-          }
-          const element = await driver.findElement(
-            args.strategy,
-            args.selector
-          );
-          const elementId = readWebElementId(element);
-          if (!elementId) {
-            throw new Error('Element was returned without a valid element ID');
-          }
-          return textResultWithPrimaryElementId(
-            elementId,
-            `Successfully found element ${args.selector} with strategy ${args.strategy}.`
-          );
+        const element = await driver.findElement(args.strategy, args.selector);
+        const elementId = readWebElementId(element);
+        if (!elementId) {
+          throw new Error('Element was returned without a valid element ID');
         }
-
-        // Route 2: AI vision-based finding
-        if (!args.ai_instruction) {
-          throw new Error(
-            'ai_instruction is required when strategy is ai_instruction. ' +
-              'Example: { strategy: "ai_instruction", ai_instruction: "yellow search button at bottom" }'
-          );
-        }
-
-        log.info(
-          `Finding element using AI with instruction: "${args.ai_instruction}"`
+        return textResultWithPrimaryElementId(
+          elementId,
+          `Successfully found element ${args.selector} with strategy ${args.strategy}.`
         );
-
-        // Step 1: Capture screenshot
-        const screenshotBase64 = await getScreenshot(driver);
-
-        // Step 2: Get image dimensions using @appium/support
-        const imageBuffer = Buffer.from(screenshotBase64, 'base64');
-        const sharp = imageUtil.requireSharp();
-        const metadata = await sharp(imageBuffer).metadata();
-
-        if (!metadata.width || !metadata.height) {
-          throw new Error('Failed to get image dimensions from screenshot');
-        }
-
-        const { width, height } = metadata;
-
-        // Step 3: Find element using AI (singleton to preserve LRU cache across calls)
-        const finder = getAIVisionFinder();
-        const result = await finder.findElement(
-          screenshotBase64,
-          args.ai_instruction,
-          width,
-          height
-        );
-
-        // Step 4: Create special elementUUID containing coordinates
-        // Format: "ai-element:{x},{y}:{bbox}"
-        const elementUUID = `ai-element:${result.center.x},${result.center.y}:${result.bbox.join(',')}`;
-
-        // Step 5: Build response text with optional annotated image path
-        let detail = `Successfully found "${result.target}" at coordinates (${result.center.x}, ${result.center.y}) using AI vision.`;
-
-        if (result.annotatedImagePath) {
-          detail += ` Vision image: ${result.annotatedImagePath}`;
-        }
-
-        return textResultWithPrimaryElementId(elementUUID, detail);
       } catch (err: unknown) {
         const errorMessage = toolErrorMessage(err);
-        log.error('Failed to find element:', errorMessage);
         return errorResult(`Failed to find element. Error: ${errorMessage}`);
       }
     },

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -9,17 +9,31 @@ import {
 } from '../tool-response.js';
 
 export const findElementSchema = z.object({
-  strategy: z.enum([
-    'xpath',
-    'id',
-    'name',
-    'class name',
-    'accessibility id',
-    'css selector',
-    '-android uiautomator',
-    '-ios predicate string',
-    '-ios class chain',
-  ]),
+  strategy: z
+    .enum([
+      'accessibility id',
+      'id',
+      '-ios predicate string',
+      '-ios class chain',
+      '-android uiautomator',
+      'xpath',
+      'name',
+      'class name',
+      'css selector',
+    ])
+    .describe(
+      `Locator strategy. Try in priority order: ` +
+        `(1) accessibility id [cross-platform, fastest, most stable], ` +
+        `(2) id [Android resource-id; iOS aliases accessibility id], ` +
+        `(3) -ios predicate string [iOS native, fast], ` +
+        `(4) -ios class chain [iOS native, hierarchy queries], ` +
+        `(5) -android uiautomator [Android native, expressive UiSelector], ` +
+        `(6) xpath [LAST RESORT — slow on iOS XCUITest, brittle to layout changes], ` +
+        `(7) name [legacy; often aliased on iOS], ` +
+        `(8) class name [too generic, usually multi-match], ` +
+        `(9) css selector [webview/hybrid contexts only]. ` +
+        `Platform tips: iOS prefer (1)→(3)→(4); Android prefer (1)→(2)→(5); xpath last on both.`
+    ),
   selector: z.string().describe('The selector to find the element.'),
   sessionId: z
     .string()
@@ -32,7 +46,9 @@ export default function findElement(server: FastMCP): void {
     name: 'appium_find_element',
     description: `Find a specific element by strategy and selector which will return a uuid that can be used for interactions.
 
-[PRIORITY 2: Use this to search for a target element by xpath, id, accessibility id, etc.]
+[PRIORITY 2: Use this to search for a target element.]
+
+**Strategy priority**: accessibility id > id > platform-native (\`-ios predicate string\` / \`-ios class chain\` on iOS, \`-android uiautomator\` on Android) > xpath (last resort — slow & brittle). See the \`strategy\` parameter for the full ranking.
 
 **Scrolling until an element appears**: use \`appium_gesture\` with \`action=scroll_to_element\` (same strategy + selector), not this tool.`,
     parameters: findElementSchema,

--- a/src/tools/test-generation/generate-tests.ts
+++ b/src/tools/test-generation/generate-tests.ts
@@ -18,7 +18,7 @@ export default function generateTest(server: FastMCP): void {
       `2. prepare_ios_simulator or appium_prepare_ios_real_device — only when iOS local setup requires it; otherwise skip.`,
       `3. appium_session_management with action=create — start a driver session (match platform to select_device unless using remote server mode).`,
       `4. appium_app_lifecycle or other session tools as needed (e.g. activate app, deep link) — only if the scenario requires it.`,
-      `5. Discover the target element — prefer appium_get_active_element when the focused field is enough; otherwise appium_find_element (strategy + selector, or ai_instruction when appropriate). Use generate_locators only for broad inspection/debugging, not for every step.`,
+      `5. Discover the target element — prefer appium_get_active_element when the focused field is enough; otherwise appium_find_element (strategy + selector). If the appium_ai tool is registered (vision-based fallback, opt-in via AI_VISION_ENABLED), use it only when no stable locator works. Use generate_locators only for broad inspection/debugging, not for every step.`,
       `6. Interact using the same tool names the server exposes, for example:`,
       `   - appium_gesture with action=tap (or double_tap, long_press, scroll, swipe, scroll_to_element, pinch_zoom) — use the element id from appium_find_element when required`,
       `   - appium_set_value — type into an element; optionally appium_mobile_press_key for special keys`,


### PR DESCRIPTION
Avoids unintended switching to `ai_instruction` in find elements tool when passing natural language instructions.

This adds a new tool for ai operations which is enabled only when `AI_VISION_ENABLED` is set and the required API keys are set too - `AI_VISION_API_BASE_URL` and `AI_VISION_API_KEY`, else it will fail fast.
We could add future ai actions to this tool when needed.

Additional fixes:
1. Add a priority order for locator strategy, prefer accessibility id over xpath when applicable.
	