### PR TITLE
chore(tools): add next-step hints on find and gesture errors

### DIFF
--- a/src/tools/gestures/handlers/pinch.ts
+++ b/src/tools/gestures/handlers/pinch.ts
@@ -83,7 +83,7 @@ export async function handlePinchZoom(
 ): Promise<ContentResult> {
   if (args.scale === undefined) {
     return errorResult(
-      'pinch_zoom requires a scale value (e.g. 0.5 to zoom out, 2.0 to zoom in).'
+      'pinch_zoom requires a scale value (e.g. 0.5 to zoom out, 2.0 to zoom in). Next: pass scale in the allowed range from the tool schema.'
     );
   }
   const scale = args.scale;
@@ -91,7 +91,7 @@ export async function handlePinchZoom(
 
   if (!args.elementUUID && (args.x !== undefined) !== (args.y !== undefined)) {
     return errorResult(
-      'pinch_zoom requires both x and y when using custom coordinates.'
+      'pinch_zoom requires both x and y when using custom coordinates. Next: set both x and y, or use elementUUID for pinch on an element.'
     );
   }
   const useCustomCoords =
@@ -232,9 +232,10 @@ export async function handlePinchZoom(
     return textResult(
       `Successfully pinched ${direction} (scale=${scale}) on ${target}.`
     );
-  } catch (err) {
+  } catch (err: unknown) {
     return errorResult(
-      `Failed to perform pinch_zoom. ${toolErrorMessage(err)}`
+      `Failed to perform pinch_zoom. ${toolErrorMessage(err)} ` +
+        'Next: ensure the target is visible, scale/velocity are valid, and retry after animations finish.'
     );
   }
 }
@@ -280,7 +281,10 @@ function resolveCoordinatePinchTarget(
   const bottom = top + windowRect.height;
 
   if (x < left || x >= right || y < top || y >= bottom) {
-    return `pinch_zoom coordinates (${x}, ${y}) are outside window bounds (${windowRect.width}x${windowRect.height}).`;
+    return (
+      `pinch_zoom coordinates (${x}, ${y}) are outside window bounds (${windowRect.width}x${windowRect.height}). ` +
+      'Next: use coordinates inside the visible window or pinch on an elementUUID.'
+    );
   }
 
   const desired = Math.floor(

--- a/src/tools/gestures/handlers/scroll-to-element.ts
+++ b/src/tools/gestures/handlers/scroll-to-element.ts
@@ -25,7 +25,8 @@ export async function handleScrollToElement(
 ): Promise<ContentResult> {
   if (!args.strategy || !args.selector) {
     return errorResult(
-      'scroll_to_element requires both strategy and selector.'
+      'scroll_to_element requires both strategy and selector. ' +
+        'Next: use the same strategy and selector you would pass to appium_find_element.'
     );
   }
   const direction: 'up' | 'down' =
@@ -55,7 +56,8 @@ export async function handleScrollToElement(
         await performVerticalScroll(driver, { direction, distance });
       } catch (scrollErr: unknown) {
         return errorResult(
-          `Scroll failed during scroll_to_element: ${toolErrorMessage(scrollErr)}`
+          `Scroll failed during scroll_to_element: ${toolErrorMessage(scrollErr)} ` +
+            'Next: confirm direction and scrollDistance, dismiss overlays, or try a smaller scrollDistancePreset.'
         );
       }
       const xmlAfter = await getPageSource(driver);
@@ -69,16 +71,21 @@ export async function handleScrollToElement(
 
       if (xmlBefore === xmlAfter) {
         return errorResult(
-          `Element not found; page source did not change after scroll (likely end of scrollable content). selector=${args.selector}`
+          `Element not found; page source did not change after scroll (likely end of scrollable content). selector=${args.selector} ` +
+            'Next: try the opposite direction, a nested scroller, or appium_find_element with a different locator.'
         );
       }
     }
 
     return errorResult(
-      `Element ${args.selector} not found after ${maxScroll} scroll(s) in direction '${direction}'.`
+      `Element ${args.selector} not found after ${maxScroll} scroll(s) in direction '${direction}'. ` +
+        'Next: increase maxScrollAttempts, verify strategy/selector, scroll the parent list first, or use appium_gesture scroll with a different area.'
     );
-  } catch (err) {
-    return errorResult(`Failed to scroll_to_element. ${toolErrorMessage(err)}`);
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to scroll_to_element. ${toolErrorMessage(err)} ` +
+        'Next: ensure session is active, locator matches the current screen, and try scroll_to_element from the top of the list.'
+    );
   }
 }
 

--- a/src/tools/gestures/handlers/swipe-scroll.ts
+++ b/src/tools/gestures/handlers/swipe-scroll.ts
@@ -141,8 +141,11 @@ export async function handleScroll(
         ? `Successfully scrolled ${args.direction}.`
         : `Successfully scrolled from (${coords.startX}, ${coords.startY}) to (${coords.endX}, ${coords.endY}).`
     );
-  } catch (err) {
-    return errorResult(`Failed to scroll. ${toolErrorMessage(err)}`);
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to scroll. ${toolErrorMessage(err)} ` +
+        'Next: confirm direction or x/y/endX/endY, session is active, and the scrollable area is not blocked by an overlay.'
+    );
   }
 }
 
@@ -193,8 +196,11 @@ export async function handleSwipe(
         ? `Successfully swiped ${args.direction} (speed=${speed}).`
         : `Successfully swiped from (${coords.startX}, ${coords.startY}) to (${coords.endX}, ${coords.endY}) (speed=${speed}).`
     );
-  } catch (err) {
-    return errorResult(`Failed to swipe. ${toolErrorMessage(err)}`);
+  } catch (err: unknown) {
+    return errorResult(
+      `Failed to swipe. ${toolErrorMessage(err)} ` +
+        'Next: try speed=fast for pull-to-refresh, adjust direction, or use explicit coordinates if the gesture missed the target.'
+    );
   }
 }
 
@@ -267,7 +273,8 @@ async function resolveCoords(
 
   return {
     error:
-      'Either direction OR custom coordinates (x, y, endX, endY) must be provided.',
+      'Either direction OR custom coordinates (x, y, endX, endY) must be provided for scroll/swipe. ' +
+      'Next: set direction (up|down|left|right) or provide all four coordinates.',
   };
 }
 

--- a/src/tools/gestures/handlers/tap.ts
+++ b/src/tools/gestures/handlers/tap.ts
@@ -52,7 +52,8 @@ export async function handleTap(
 
     if (args.x === undefined || args.y === undefined) {
       return errorResult(
-        'tap requires either elementUUID, or both x and y coordinates.'
+        'tap requires either elementUUID, or both x and y coordinates. ' +
+          'Next: pass elementId from appium_find_element as elementUUID, or set both x and y.'
       );
     }
     await performActions(driver, w3cTapAt(args.x, args.y));
@@ -60,7 +61,10 @@ export async function handleTap(
       `Successfully tapped at coordinates (${args.x}, ${args.y}).`
     );
   } catch (err: unknown) {
-    return errorResult(`Failed to perform tap. ${toolErrorMessage(err)}`);
+    return errorResult(
+      `Failed to perform tap. ${toolErrorMessage(err)} ` +
+        'Next: re-run appium_find_element if elementUUID may be stale, or retry after the UI settles.'
+    );
   }
 }
 
@@ -91,7 +95,8 @@ export async function handleDoubleTap(
       y = args.y;
     } else {
       return errorResult(
-        'double_tap requires either elementUUID, or both x and y coordinates.'
+        'double_tap requires either elementUUID, or both x and y coordinates. ' +
+          'Next: pass elementId from appium_find_element, or set both x and y.'
       );
     }
 
@@ -115,7 +120,8 @@ export async function handleDoubleTap(
     return textResult(`Successfully double tapped at (${x}, ${y}).`);
   } catch (err: unknown) {
     return errorResult(
-      `Failed to perform double_tap. ${toolErrorMessage(err)}`
+      `Failed to perform double_tap. ${toolErrorMessage(err)} ` +
+        'Next: re-run appium_find_element if the target moved, or retry on iOS with a visible element.'
     );
   }
 }
@@ -128,7 +134,7 @@ export async function handleLongPress(
     const duration = args.duration ?? 2000;
     if (duration < 500 || duration > 10000) {
       return errorResult(
-        'long_press duration must be between 500 and 10000 ms.'
+        'long_press duration must be between 500 and 10000 ms. Next: pass duration within that range or omit it for the default.'
       );
     }
 
@@ -159,7 +165,8 @@ export async function handleLongPress(
       y = args.y;
     } else {
       return errorResult(
-        'long_press requires either elementUUID, or both x and y coordinates.'
+        'long_press requires either elementUUID, or both x and y coordinates. ' +
+          'Next: pass elementId from appium_find_element, or set both x and y.'
       );
     }
 
@@ -181,7 +188,8 @@ export async function handleLongPress(
     );
   } catch (err: unknown) {
     return errorResult(
-      `Failed to perform long_press. ${toolErrorMessage(err)}`
+      `Failed to perform long_press. ${toolErrorMessage(err)} ` +
+        'Next: ensure duration is 500–10000 ms, the element is visible, and retry if a system animation is running.'
     );
   }
 }
@@ -191,16 +199,25 @@ function parseAiElementCoords(
 ): { x: number; y: number } | { error: string } {
   const parts = uuid.split(':');
   if (parts.length < 2) {
-    return { error: 'Invalid AI element UUID format.' };
+    return {
+      error:
+        'Invalid AI element UUID format. Next: use the elementId line from appium_find_element (ai-element:x,y:...).',
+    };
   }
   const coords = parts[1].split(',');
   if (coords.length < 2) {
-    return { error: 'Invalid AI element coordinates format.' };
+    return {
+      error:
+        'Invalid AI element coordinates format. Next: call appium_find_element again and pass the returned ai-element token unchanged.',
+    };
   }
   const x = parseInt(coords[0], 10);
   const y = parseInt(coords[1], 10);
   if (isNaN(x) || isNaN(y)) {
-    return { error: 'Invalid AI element coordinates: not numbers.' };
+    return {
+      error:
+        'Invalid AI element coordinates: not numbers. Next: re-run appium_find_element to obtain a fresh ai-element id.',
+    };
   }
   return { x, y };
 }

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -78,7 +78,11 @@ export default function findElement(server: FastMCP): void {
         );
       } catch (err: unknown) {
         const errorMessage = toolErrorMessage(err);
-        return errorResult(`Failed to find element. Error: ${errorMessage}`);
+        return errorResult(
+          `Failed to find element. ${errorMessage} ` +
+            'Next: try a more stable locator (accessibility id / resource-id), reveal the control with appium_gesture ' +
+            '(scroll or scroll_to_element), or tune waits via appium_driver_settings.'
+        );
       }
     },
   });


### PR DESCRIPTION
- extend error strings with short Next: lines where retries usually help (CONTRIBUTING).
- covers find catch plus tap, scroll/swipe, pinch, scroll_to_element handlers.