### PR TITLE
chore(tools): tighten error contract for app-management + appium_ai schema

### DIFF
--- a/src/tools/ai/handlers/find-element.ts
+++ b/src/tools/ai/handlers/find-element.ts
@@ -25,17 +25,12 @@ export async function handleFindElement(
   driver: DriverInstance,
   args: AIArgs
 ): Promise<ContentResult> {
-  if (!args.instruction) {
-    return errorResult(
-      'instruction is required for action=find_element. ' +
-        'Example: { action: "find_element", instruction: "yellow search button at bottom" }'
-    );
-  }
+  // `instruction` presence/non-emptiness is enforced at schema level via
+  // `aiSchema.superRefine`. Narrow the optional type here for downstream calls.
+  const instruction = args.instruction as string;
 
   try {
-    log.info(
-      `Finding element using AI with instruction: "${args.instruction}"`
-    );
+    log.info(`Finding element using AI with instruction: "${instruction}"`);
 
     const screenshotBase64 = await getScreenshot(driver);
 
@@ -52,7 +47,7 @@ export async function handleFindElement(
     const finder = getAIVisionFinder();
     const result = await finder.findElement(
       screenshotBase64,
-      args.instruction,
+      instruction,
       width,
       height
     );

--- a/src/tools/ai/schema.ts
+++ b/src/tools/ai/schema.ts
@@ -3,28 +3,41 @@ import { z } from 'zod';
 export const AI_ACTIONS = ['find_element'] as const;
 export type AIAction = (typeof AI_ACTIONS)[number];
 
-export const aiSchema = z.object({
-  action: z
-    .enum(AI_ACTIONS)
-    .describe(
-      `AI capability to invoke. ` +
-        `find_element: locate an element from a natural-language description using a vision model. ` +
-        `Returns a coordinate UUID (format: ai-element:x,y:bbox) usable with appium_gesture (tap/double_tap/long_press).`
-    ),
+export const aiSchema = z
+  .object({
+    action: z
+      .enum(AI_ACTIONS)
+      .describe(
+        `AI capability to invoke. ` +
+          `find_element: locate an element from a natural-language description using a vision model. ` +
+          `Returns a coordinate UUID (format: ai-element:x,y:bbox) usable with appium_gesture (tap/double_tap/long_press).`
+      ),
 
-  instruction: z
-    .string()
-    .optional()
-    .describe(
-      `Natural-language description of the target element. ` +
-        `Required for: find_element. ` +
-        `Examples: "yellow search button at bottom", "username input field at top", "settings icon in top-right corner".`
-    ),
+    instruction: z
+      .string()
+      .optional()
+      .describe(
+        `Natural-language description of the target element. ` +
+          `Required for: find_element. ` +
+          `Examples: "yellow search button at bottom", "username input field at top", "settings icon in top-right corner".`
+      ),
 
-  sessionId: z
-    .string()
-    .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
-});
+    sessionId: z
+      .string()
+      .optional()
+      .describe('Session ID to target. If omitted, uses the active session.'),
+  })
+  .superRefine((data, ctx) => {
+    if (data.action === 'find_element') {
+      if (!data.instruction?.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'instruction is required and must be non-empty when action is find_element',
+          path: ['instruction'],
+        });
+      }
+    }
+  });
 
 export type AIArgs = z.infer<typeof aiSchema>;

--- a/src/tools/app-management/app.ts
+++ b/src/tools/app-management/app.ts
@@ -11,6 +11,7 @@ import { queryState } from './query-app-state.js';
 import { background, DEFAULT_BACKGROUND_SECONDS } from './background-app.js';
 import { clear } from './clear-app.js';
 import { deepLink } from './deep-link.js';
+import { errorResult, toolErrorMessage } from '../tool-response.js';
 
 const APP_ACTIONS = [
   'activate',
@@ -136,14 +137,28 @@ export default function app(server: FastMCP): void {
             content: [{ type: 'text', text: 'url is required for deep_link' }],
           };
         }
-        const appId =
-          args.id ??
-          (args.name ? await resolveAppId(args.name, sessionId) : undefined);
+        let appId: string | undefined;
+        try {
+          appId =
+            args.id ??
+            (args.name ? await resolveAppId(args.name, sessionId) : undefined);
+        } catch (err: unknown) {
+          return errorResult(
+            `Failed to resolve app id for deep_link: ${toolErrorMessage(err)}`
+          );
+        }
         return deepLink(args.url, appId, args.waitForLaunch, sessionId);
       }
 
       // activate, terminate, uninstall, is_installed, query_state, clear — all require id or name
-      const id = await resolveId(args.id, args.name, sessionId);
+      let id: string;
+      try {
+        id = await resolveId(args.id, args.name, sessionId);
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to resolve app id for ${action}: ${toolErrorMessage(err)}`
+        );
+      }
 
       if (action === 'activate') {
         return activate(id, sessionId);

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -1,8 +1,8 @@
 import type { ContentResult } from 'fastmcp';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
+import type { DriverInstance } from '../../session-store.js';
 import {
-  getDriver,
   getPlatformName,
   isRemoteDriverSession,
   isAndroidUiautomator2DriverSession,
@@ -17,19 +17,19 @@ import {
 import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
 import { execute } from '../../command.js';
-import { textResult, errorResult, toolErrorMessage } from '../tool-response.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const execAsync = promisify(exec);
 
 export async function listAppsFromDevice(
-  applicationType: 'User' | 'System' = 'User',
-  sessionId?: string
+  driver: DriverInstance,
+  applicationType: 'User' | 'System' = 'User'
 ): Promise<{ packageName: string; appName: string }[]> {
-  const driver = getDriver(sessionId);
-  if (!driver) {
-    throw new Error('No driver found');
-  }
-
   const platform = getPlatformName(driver);
 
   if (isRemoteDriverSession(driver)) {
@@ -86,8 +86,15 @@ export async function list(
   applicationType?: 'User' | 'System',
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
   try {
-    const apps = await listAppsFromDevice(applicationType, sessionId);
+    const apps = await listAppsFromDevice(
+      resolved.driver,
+      applicationType ?? 'User'
+    );
     const textResponse = textResult(
       `Installed apps: ${JSON.stringify(apps, null, 2)}`
     );
@@ -116,9 +123,23 @@ function normalizeListAppsResult(
 ): { packageName: string; appName: string }[] {
   return Object.entries(result).map(([id, attrs]) => ({
     packageName: id,
-    appName: (attrs?.CFBundleDisplayName ||
-      attrs?.CFBundleName ||
-      (attrs as any)?.name ||
-      '') as string,
+    appName: pickDisplayName(attrs),
   }));
+}
+
+/**
+ * Pick the first non-empty string from the well-known iOS metadata fields.
+ * `||` keeps the original fall-through behavior when a field is `""`.
+ */
+function pickDisplayName(attrs: Record<string, unknown> | undefined): string {
+  const display =
+    readString(attrs?.CFBundleDisplayName) ||
+    readString(attrs?.CFBundleName) ||
+    readString(attrs?.name) ||
+    '';
+  return display;
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
 }

--- a/src/tools/app-management/resolve-app-id.ts
+++ b/src/tools/app-management/resolve-app-id.ts
@@ -103,20 +103,26 @@ async function getInstalledApps(
   }
 
   const driver = getDriver(sessionId);
-  const platform = driver ? getPlatformName(driver) : null;
+  if (!driver) {
+    const ctx = sessionId ? ` for session '${sessionId}'` : '';
+    throw new Error(
+      `No active driver session${ctx}. Call create_session first or pass a valid sessionId.`
+    );
+  }
+
+  const platform = getPlatformName(driver);
 
   let apps: { packageName: string; appName: string }[];
-  const isSimulator =
-    driver && isXCUITestDriverSession(driver)
-      ? (driver as XCUITestDriver).isSimulator()
-      : false;
+  const isSimulator = isXCUITestDriverSession(driver)
+    ? (driver as XCUITestDriver).isSimulator()
+    : false;
 
   if (platform === PLATFORM.ios && !isSimulator) {
     // Real iOS device: User and System app lists are separate — fetch both in parallel.
     // Use allSettled so a failure on one type (e.g. System) doesn't discard the other.
     const results = await Promise.allSettled([
-      listAppsFromDevice('User', sessionId),
-      listAppsFromDevice('System', sessionId),
+      listAppsFromDevice(driver, 'User'),
+      listAppsFromDevice(driver, 'System'),
     ]);
     const seen = new Set<string>();
     apps = [];
@@ -132,7 +138,7 @@ async function getInstalledApps(
     }
   } else {
     // Android or iOS Simulator: single call returns all apps
-    apps = await listAppsFromDevice('User', sessionId);
+    apps = await listAppsFromDevice(driver, 'User');
   }
 
   appListCache.set(key, { apps, timestamp: Date.now() });


### PR DESCRIPTION

- appium_app_lifecycle list: route through resolveDriver so a missing session returns the standard errorResult instead of a thrown 'No driver found'.
- listAppsFromDevice now takes a DriverInstance; getInstalledApps in resolve-app-id resolves the driver up front with the same actionable message as resolveDriver.
- appium_app_lifecycle: wrap resolveAppId/resolveId in try/catch so app id resolution failures (e.g. no installed app match) come back as a clean errorResult instead of a FastMCP-prefixed throw.
- list-apps: drop 'as any' from normalizeListAppsResult; preserve the empty-string fall-through across CFBundleDisplayName / CFBundleName / name.
- appium_ai schema: superRefine 'instruction' is required and non-whitespace when action=find_element, moving validation to schema level. Drop the now-redundant runtime guard in handleFindElement.