### PR TITLE
fix(find-element): steer ai locators to appium_ai

### DIFF
--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -8,38 +8,56 @@ import {
   readWebElementId,
 } from '../tool-response.js';
 
-export const findElementSchema = z.object({
-  strategy: z
-    .enum([
-      'accessibility id',
-      'id',
-      '-ios predicate string',
-      '-ios class chain',
-      '-android uiautomator',
-      'xpath',
-      'name',
-      'class name',
-      'css selector',
-    ])
-    .describe(
-      `Locator strategy. Try in priority order: ` +
-        `(1) accessibility id [cross-platform, fastest, most stable], ` +
-        `(2) id [Android resource-id; iOS aliases accessibility id], ` +
-        `(3) -ios predicate string [iOS native, fast], ` +
-        `(4) -ios class chain [iOS native, hierarchy queries], ` +
-        `(5) -android uiautomator [Android native, expressive UiSelector], ` +
-        `(6) xpath [LAST RESORT — slow on iOS XCUITest, brittle to layout changes], ` +
-        `(7) name [legacy; often aliased on iOS], ` +
-        `(8) class name [too generic, usually multi-match], ` +
-        `(9) css selector [webview/hybrid contexts only]. ` +
-        `Platform tips: iOS prefer (1)→(3)→(4); Android prefer (1)→(2)→(5); xpath last on both.`
-    ),
-  selector: z.string().describe('The selector to find the element.'),
-  sessionId: z
-    .string()
-    .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
-});
+export const findElementSchema = z
+  .object({
+    strategy: z
+      .enum([
+        'accessibility id',
+        'id',
+        '-ios predicate string',
+        '-ios class chain',
+        '-android uiautomator',
+        'xpath',
+        'name',
+        'class name',
+        'css selector',
+      ])
+      .describe(
+        `Locator strategy. Try in priority order: ` +
+          `(1) accessibility id [cross-platform, fastest, most stable], ` +
+          `(2) id [Android resource-id; iOS aliases accessibility id], ` +
+          `(3) -ios predicate string [iOS native, fast], ` +
+          `(4) -ios class chain [iOS native, hierarchy queries], ` +
+          `(5) -android uiautomator [Android native, expressive UiSelector], ` +
+          `(6) xpath [LAST RESORT — slow on iOS XCUITest, brittle to layout changes], ` +
+          `(7) name [legacy; often aliased on iOS], ` +
+          `(8) class name [too generic, usually multi-match], ` +
+          `(9) css selector [webview/hybrid contexts only]. ` +
+          `Platform tips: iOS prefer (1)→(3)→(4); Android prefer (1)→(2)→(5); xpath last on both. ` +
+          `For natural-language / vision-based find, use the appium_ai tool (action=find_element), not this one.`
+      ),
+    selector: z
+      .string()
+      .describe(
+        `Selector string for the chosen strategy. Required and must be non-empty. ` +
+          `Do not pass natural-language descriptions of the target here; use appium_ai (action=find_element) for that.`
+      ),
+    sessionId: z
+      .string()
+      .optional()
+      .describe('Session ID to target. If omitted, uses the active session.'),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.selector.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'selector must be a non-empty string. ' +
+          'For natural-language / vision-based find, use the appium_ai tool (action=find_element), not appium_find_element.',
+        path: ['selector'],
+      });
+    }
+  });
 
 export default function findElement(server: FastMCP): void {
   server.addTool({
@@ -50,7 +68,9 @@ export default function findElement(server: FastMCP): void {
 
 **Strategy priority**: accessibility id > id > platform-native (\`-ios predicate string\` / \`-ios class chain\` on iOS, \`-android uiautomator\` on Android) > xpath (last resort — slow & brittle). See the \`strategy\` parameter for the full ranking.
 
-**Scrolling until an element appears**: use \`appium_gesture\` with \`action=scroll_to_element\` (same strategy + selector), not this tool.`,
+**Scrolling until an element appears**: use \`appium_gesture\` with \`action=scroll_to_element\` (same strategy + selector), not this tool.
+
+**Vision / natural-language find**: use \`appium_ai\` with \`action=find_element\`, not this tool.`,
     parameters: findElementSchema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -74,13 +74,6 @@ export default function findElement(server: FastMCP): void {
       }
       const { driver } = resolved;
 
-      if (!args.selector.trim()) {
-        return errorResult(
-          'selector must be a non-empty string. ' +
-            'For natural-language / vision-based find, use the appium_ai tool (action=find_element), not appium_find_element.'
-        );
-      }
-
       try {
         const element = await driver.findElement(args.strategy, args.selector);
         const elementId = readWebElementId(element);

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -8,56 +8,44 @@ import {
   readWebElementId,
 } from '../tool-response.js';
 
-export const findElementSchema = z
-  .object({
-    strategy: z
-      .enum([
-        'accessibility id',
-        'id',
-        '-ios predicate string',
-        '-ios class chain',
-        '-android uiautomator',
-        'xpath',
-        'name',
-        'class name',
-        'css selector',
-      ])
-      .describe(
-        `Locator strategy. Try in priority order: ` +
-          `(1) accessibility id [cross-platform, fastest, most stable], ` +
-          `(2) id [Android resource-id; iOS aliases accessibility id], ` +
-          `(3) -ios predicate string [iOS native, fast], ` +
-          `(4) -ios class chain [iOS native, hierarchy queries], ` +
-          `(5) -android uiautomator [Android native, expressive UiSelector], ` +
-          `(6) xpath [LAST RESORT — slow on iOS XCUITest, brittle to layout changes], ` +
-          `(7) name [legacy; often aliased on iOS], ` +
-          `(8) class name [too generic, usually multi-match], ` +
-          `(9) css selector [webview/hybrid contexts only]. ` +
-          `Platform tips: iOS prefer (1)→(3)→(4); Android prefer (1)→(2)→(5); xpath last on both. ` +
-          `For natural-language / vision-based find, use the appium_ai tool (action=find_element), not this one.`
-      ),
-    selector: z
-      .string()
-      .describe(
-        `Selector string for the chosen strategy. Required and must be non-empty. ` +
-          `Do not pass natural-language descriptions of the target here; use appium_ai (action=find_element) for that.`
-      ),
-    sessionId: z
-      .string()
-      .optional()
-      .describe('Session ID to target. If omitted, uses the active session.'),
-  })
-  .superRefine((data, ctx) => {
-    if (!data.selector.trim()) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'selector must be a non-empty string. ' +
-          'For natural-language / vision-based find, use the appium_ai tool (action=find_element), not appium_find_element.',
-        path: ['selector'],
-      });
-    }
-  });
+export const findElementSchema = z.object({
+  strategy: z
+    .enum([
+      'accessibility id',
+      'id',
+      '-ios predicate string',
+      '-ios class chain',
+      '-android uiautomator',
+      'xpath',
+      'name',
+      'class name',
+      'css selector',
+    ])
+    .describe(
+      `Locator strategy. Try in priority order: ` +
+        `(1) accessibility id [cross-platform, fastest, most stable], ` +
+        `(2) id [Android resource-id; iOS aliases accessibility id], ` +
+        `(3) -ios predicate string [iOS native, fast], ` +
+        `(4) -ios class chain [iOS native, hierarchy queries], ` +
+        `(5) -android uiautomator [Android native, expressive UiSelector], ` +
+        `(6) xpath [LAST RESORT — slow on iOS XCUITest, brittle to layout changes], ` +
+        `(7) name [legacy; often aliased on iOS], ` +
+        `(8) class name [too generic, usually multi-match], ` +
+        `(9) css selector [webview/hybrid contexts only]. ` +
+        `Platform tips: iOS prefer (1)→(3)→(4); Android prefer (1)→(2)→(5); xpath last on both. ` +
+        `For natural-language / vision-based find, use the appium_ai tool (action=find_element), not this one.`
+    ),
+  selector: z
+    .string()
+    .describe(
+      `Selector string for the chosen strategy. ` +
+        `Do not pass natural-language descriptions of the target here; use appium_ai (action=find_element) for that.`
+    ),
+  sessionId: z
+    .string()
+    .optional()
+    .describe('Session ID to target. If omitted, uses the active session.'),
+});
 
 export default function findElement(server: FastMCP): void {
   server.addTool({
@@ -85,6 +73,13 @@ export default function findElement(server: FastMCP): void {
         return resolved.result;
       }
       const { driver } = resolved;
+
+      if (!args.selector.trim()) {
+        return errorResult(
+          'selector must be a non-empty string. ' +
+            'For natural-language / vision-based find, use the appium_ai tool (action=find_element), not appium_find_element.'
+        );
+      }
 
       try {
         const element = await driver.findElement(args.strategy, args.selector);


### PR DESCRIPTION
- Empty / whitespace-only selectors used to slip through to driver.findElement and surface as generic backend errors, add a superRefine on findElementSchema so MCP clients get a typed Zod rejection on the `selector` field instead.
- tightens the strategy / selector / tool descriptions so natural-language target descriptions go to the appium_ai tool (action=find_element) rather than this one, no behavior change for valid traditional calls; the schema is still exported.