### PR TITLE
chore(tool-response): align "no active session" copy with appium_session_management

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The process keeps one **active** Appium session; tools use it when **`sessionId`
 
 #### Client disconnect
 
-When the MCP **client disconnects**, the server **closes every session** it is tracking (Appium **`deleteSession`** for each). Transports that drop often—**`httpStream`** behind proxies, idle timeouts, or flaky clients—will **wipe automation** in one go. **stdio** is usually safer for a single long-lived operator; if you use **httpStream**, expect reconnects to require **new sessions**.
+When the MCP **client disconnects**, the server **deletes only MCP-owned sessions** it is tracking (Appium **`deleteSession`** for each, via `safeDeleteAllSessions`). **Attached** sessions (`ownership=attached`) are intentionally left on the remote Appium server. Transports that drop often—**`httpStream`** behind proxies, idle timeouts, or flaky clients—can **wipe owned automation** in one go under the default policy. **stdio** is usually safer for a single long-lived operator; if you use **httpStream**, expect reconnects to require **new owned sessions** where applicable.
 
 #### Remote Appium, CI, and device farms
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Before writing or extending a tool, read this section. Tools in MCP Appium are c
 
 1. **One user intent = one tool.** A tool should map to a single, coherent thing the caller wants to accomplish (e.g. "control the device screen", "manage an app's lifecycle", "query device state"). Tools that bundle unrelated intents confuse tool selection.
 2. **Minimal, predictable parameter surface.** Every optional parameter is a potential source of LLM confusion. Prefer ~3–5 required fields and a tight set of optionals. If you need more than ~3 conditional fields (fields that are only valid under a specific `action`), that is a signal to split the tool.
-3. **Errors must teach the LLM what to do next.** The LLM reads error text and uses it to retry with adjusted parameters or to report the failure accurately to the user. `"No driver found"` gives it nothing to work with; `"No active driver session. Call create_session first or pass a valid sessionId."` lets the model recover.
+3. **Errors must teach the LLM what to do next.** The LLM reads error text and uses it to retry with adjusted parameters or to report the failure accurately to the user. `"No driver found"` gives it nothing to work with; `"No active driver session. Use appium_session_management (action=create or action=attach), or pass a valid sessionId."` lets the model recover.
 
 These principles are grounded in the MCP specification (<https://modelcontextprotocol.io/specification/2025-11-25/server/tools>).
 
@@ -65,6 +65,7 @@ import {
   errorResult,     // failure: returns { content: [...], isError: true }
   toolErrorMessage, // normalize unknown error into a string
   resolveDriver,    // returns { ok: true, driver } | { ok: false, result }
+  noActiveDriverSessionResult, // same "no session" copy as resolveDriver's error branch
   platformMismatch, // common "action=X is iOS-only" error helper
 } from '../tool-response.js';
 ```
@@ -142,7 +143,7 @@ The LLM reads your error text and either retries with adjusted parameters or rep
 
 1. **State what failed.** `"Failed to install app"`, not `"Error"`.
 2. **State why.** Include the underlying cause from `toolErrorMessage(err)`.
-3. **State what to try next, when recoverable.** `"Call create_session first"`, `"pass a valid sessionId"`, `"use a string like 'camera' instead of a number"`.
+3. **State what to try next, when recoverable.** `"Use appium_session_management (action=create or action=attach)"`, `"pass a valid sessionId"`, `"use a string like 'camera' instead of a number"`.
 4. **Include the relevant parameter values** when they would help the LLM self-correct: session id, platform name, action name.
 5. **No stack traces.** `toolErrorMessage` strips them; don't re-add them.
 
@@ -150,7 +151,7 @@ The LLM reads your error text and either retries with adjusted parameters or rep
 
 | Bad | Good |
 | --- | --- |
-| `"No driver found"` | `"No active driver session. Call create_session first or pass a valid sessionId."` |
+| `"No driver found"` | `"No active driver session. Use appium_session_management (action=create or action=attach), or pass a valid sessionId."` |
 | `"Unsupported platform"` | `"action=shake is iOS-only. Current session platform is 'Android'."` |
 | `"Failed"` | `"Failed to install app. ${toolErrorMessage(err)}"` |
 | `"Invalid input"` | `"service must be a string name (e.g. 'camera', 'photos'), not a number."` |
@@ -672,7 +673,7 @@ For better readability when descriptions are long, use template literals with pr
 **Bad (hard to read):**
 
 ```typescript
-description: 'REQUIRED: First ASK THE USER which mobile platform they want to use (Android or iOS) before creating a session. DO NOT assume or default to any platform. You MUST explicitly prompt the user to choose between Android or iOS. This is mandatory before proceeding to use the create_session tool.',
+description: 'REQUIRED: First ASK THE USER which mobile platform they want to use (Android or iOS) before creating a session. DO NOT assume or default to any platform. You MUST explicitly prompt the user to choose between Android or iOS. This is mandatory before proceeding to use appium_session_management (action=create).',
 ```
 
 **Good (readable):**
@@ -681,7 +682,7 @@ description: 'REQUIRED: First ASK THE USER which mobile platform they want to us
 description: `REQUIRED: First ASK THE USER which mobile platform they want to use (Android or iOS) before creating a session.
   DO NOT assume or default to any platform.
   You MUST explicitly prompt the user to choose between Android or iOS.
-  This is mandatory before proceeding to use the create_session tool.
+  This is mandatory before proceeding to use appium_session_management (action=create).
   `,
 ```
 

--- a/src/tests/tools/session/device-info.test.ts
+++ b/src/tests/tools/session/device-info.test.ts
@@ -43,7 +43,7 @@ describe('appium_mobile_device_info tool', () => {
       const result = await tool.execute({ action: 'battery' }, undefined);
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toBe(
-        'No active driver session. Call create_session first or pass a valid sessionId.'
+        'No active driver session. Use appium_session_management (action=create or action=attach), or pass a valid sessionId.'
       );
     });
 
@@ -100,7 +100,7 @@ describe('appium_mobile_device_info tool', () => {
       const result = await tool.execute({ action: 'info' }, undefined);
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toBe(
-        'No active driver session. Call create_session first or pass a valid sessionId.'
+        'No active driver session. Use appium_session_management (action=create or action=attach), or pass a valid sessionId.'
       );
     });
 
@@ -141,7 +141,7 @@ describe('appium_mobile_device_info tool', () => {
       const result = await tool.execute({ action: 'time' }, undefined);
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toBe(
-        'No active driver session. Call create_session first or pass a valid sessionId.'
+        'No active driver session. Use appium_session_management (action=create or action=attach), or pass a valid sessionId.'
       );
     });
 

--- a/src/tests/tools/session/file-transfer.test.ts
+++ b/src/tests/tools/session/file-transfer.test.ts
@@ -51,7 +51,7 @@ describe('appium_mobile_file', () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe(
-      'No active driver session. Call create_session first or pass a valid sessionId.'
+      'No active driver session. Use appium_session_management (action=create or action=attach), or pass a valid sessionId.'
     );
   });
 

--- a/src/tools/interactions/screenshot.ts
+++ b/src/tools/interactions/screenshot.ts
@@ -13,7 +13,12 @@ import { getScreenshot } from '../../command.js';
 import z from 'zod';
 import { imageUtil } from '@appium/support';
 import { resolveScreenshotDir } from '../../utils/paths.js';
-import { textResult, errorResult, toolErrorMessage } from '../tool-response.js';
+import {
+  textResult,
+  errorResult,
+  toolErrorMessage,
+  noActiveDriverSessionResult,
+} from '../tool-response.js';
 
 export { resolveScreenshotDir };
 
@@ -43,9 +48,7 @@ export async function executeScreenshot(opts: {
 
   const driver = deps.getDriver(sessionId);
   if (!driver) {
-    return errorResult(
-      `No active driver session. Call create_session first or pass a valid sessionId.`
-    );
+    return noActiveDriverSessionResult(sessionId);
   }
 
   try {

--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -60,19 +60,24 @@ export function errorResult(text: string): ContentResult {
 }
 
 /**
+ * Standard tool-execution error when no driver is active for the given session.
+ * Keeps copy aligned with the registered `appium_session_management` tool.
+ */
+export function noActiveDriverSessionResult(sessionId?: string): ContentResult {
+  const ctx = sessionId ? ` for session '${sessionId}'` : '';
+  return errorResult(
+    `No active driver session${ctx}. Use appium_session_management (action=create or action=attach), or pass a valid sessionId.`
+  );
+}
+
+/**
  * Resolves the driver for a tool call or returns a standardised error result.
  * Does not throw.
  */
 export function resolveDriver(sessionId?: string): DriverOrError {
   const driver = getDriver(sessionId);
   if (!driver) {
-    const ctx = sessionId ? ` for session '${sessionId}'` : '';
-    return {
-      ok: false,
-      result: errorResult(
-        `No active driver session${ctx}. Call create_session first or pass a valid sessionId.`
-      ),
-    };
+    return { ok: false, result: noActiveDriverSessionResult(sessionId) };
   }
   return { ok: true, driver };
 }


### PR DESCRIPTION
The `resolveDriver` error and a hand-rolled copy in screenshot.ts both said `Call create_session first`, but the registered tool is `appium_session_management` (action=create or action=attach). Centralize the message in a new `noActiveDriverSessionResult` helper so it lives in one place, point users at the real tool name, and adopt it in screenshot.ts.
Side effect: the screenshot tool's "no driver" error now includes `for session '<id>'` context when sessionId is provided (matches the shape resolveDriver already emits), instead of the previous static string.

Also updates the docs to match:
- docs/CONTRIBUTING.md: principle, error-message rules, good/bad table, shared-helpers import block, and the formatting example.
- README.md: the "Client disconnect" sentence now reflects what `safeDeleteAllSessions` actually does (deletes MCP-owned sessions only; attached sessions are intentionally left on the remote Appium server).