### PR TITLE
chore(lint): fix preserve-caught-error and type-only imports across src/

### DIFF
--- a/src/ai-finder/vision-finder.ts
+++ b/src/ai-finder/vision-finder.ts
@@ -376,7 +376,9 @@ Parameters: {"target": "Search", "bbox_2d": [100, 200, 300, 280]}
       if (error instanceof Error && error.name === 'AbortError') {
         const errorMessage = `HTTP timeout after ${timeoutMs}ms`;
         log.error(`AI Vision: API call failed: ${errorMessage}`);
-        throw new Error(`Vision API call failed: ${errorMessage}`);
+        throw new Error(`Vision API call failed: ${errorMessage}`, {
+          cause: error,
+        });
       }
       throw error;
     } finally {
@@ -425,7 +427,9 @@ Parameters: {"target": "Search", "bbox_2d": [100, 200, 300, 280]}
     } catch (error) {
       log.error('AI Vision: Failed to parse bbox:', error);
       log.error('AI Vision: Response was:', response);
-      throw new Error('Failed to parse bbox from vision model response');
+      throw new Error('Failed to parse bbox from vision model response', {
+        cause: error,
+      });
     }
   }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -303,9 +303,7 @@ export async function getElementRect(
  * @param driver - The driver instance to query.
  * @returns A `Rect` describing the window bounds.
  */
-export async function getWindowRect(
-  driver: DriverInstance
-): Promise<Rect> {
+export async function getWindowRect(driver: DriverInstance): Promise<Rect> {
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getWindowRect();
   } else if (isXCUITestDriverSession(driver)) {

--- a/src/command.ts
+++ b/src/command.ts
@@ -9,7 +9,12 @@ import {
   getSessionInfo,
 } from './session-store.js';
 import type { DriverInstance } from './session-store.js';
-import type { StringRecord, Element as AppiumElement } from '@appium/types';
+import type {
+  ActionSequence,
+  Element as AppiumElement,
+  Rect,
+  StringRecord,
+} from '@appium/types';
 import { util } from '@appium/support';
 import type {
   IOSRecordingOptions,
@@ -283,7 +288,7 @@ export async function elementClick(
 export async function getElementRect(
   driver: DriverInstance,
   elementUUID: string
-): Promise<import('@appium/types').Rect> {
+): Promise<Rect> {
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getElementRect(elementUUID);
   } else if (isXCUITestDriverSession(driver)) {
@@ -300,7 +305,7 @@ export async function getElementRect(
  */
 export async function getWindowRect(
   driver: DriverInstance
-): Promise<import('@appium/types').Rect> {
+): Promise<Rect> {
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.getWindowRect();
   } else if (isXCUITestDriverSession(driver)) {
@@ -317,14 +322,12 @@ export async function getWindowRect(
  */
 export async function performActions(
   driver: DriverInstance,
-  operation: StringRecord<any>[] | import('@appium/types').ActionSequence[]
+  operation: StringRecord<any>[] | ActionSequence[]
 ): Promise<void> {
   if (isAndroidUiautomator2DriverSession(driver)) {
     return await driver.performActions(operation);
   } else if (isXCUITestDriverSession(driver)) {
-    return await driver.performActions(
-      operation as import('@appium/types').ActionSequence[]
-    );
+    return await driver.performActions(operation as ActionSequence[]);
   }
   return await driver.performActions(operation);
 }

--- a/src/devicemanager/adb-manager.ts
+++ b/src/devicemanager/adb-manager.ts
@@ -133,7 +133,7 @@ export class ADBManager {
       return adb;
     } catch (error) {
       log.error(`Failed to create ADB instance: ${error}`);
-      throw new Error(`ADB initialization failed: ${error}`);
+      throw new Error(`ADB initialization failed: ${error}`, { cause: error });
     }
   }
 }

--- a/src/locators/element-filter.ts
+++ b/src/locators/element-filter.ts
@@ -1,4 +1,4 @@
-import { JSONElement } from './source-parsing.js';
+import type { JSONElement } from './source-parsing.js';
 
 export interface FilterOptions {
   includeTagNames?: string[];

--- a/src/locators/generate-all-locators.ts
+++ b/src/locators/generate-all-locators.ts
@@ -2,8 +2,10 @@
 // Using existing functions from src/locators directory
 
 import { getSuggestedLocators } from './locator-generation.js';
-import { xmlToJSON, JSONElement } from './source-parsing.js';
-import { shouldIncludeElement, FilterOptions } from './element-filter.js';
+import { xmlToJSON } from './source-parsing.js';
+import type { JSONElement } from './source-parsing.js';
+import { shouldIncludeElement } from './element-filter.js';
+import type { FilterOptions } from './element-filter.js';
 import log from '../logger.js';
 
 export interface ElementWithLocators {

--- a/src/locators/locator-generation.ts
+++ b/src/locators/locator-generation.ts
@@ -8,10 +8,12 @@ import {
   domToXML,
   findDOMNodeByPath,
   xmlToDOM,
+} from './source-parsing.js';
+import type {
   JSONElement,
   ElementAttributes,
 } from './source-parsing.js';
-import {
+import type {
   Document as XMLDocument,
   Node as XMLNode,
   Element as XMLElement,
@@ -555,7 +557,7 @@ function determineXpathUniqueness(
   doc: XMLDocument,
   domNode: XMLNode
 ): [boolean, number?] {
-  let othersWithAttr: XMLNode[] = [];
+  let othersWithAttr: XMLNode[];
 
   // If the XPath does not parse, move to the next unique attribute
   try {

--- a/src/locators/locator-generation.ts
+++ b/src/locators/locator-generation.ts
@@ -9,10 +9,7 @@ import {
   findDOMNodeByPath,
   xmlToDOM,
 } from './source-parsing.js';
-import type {
-  JSONElement,
-  ElementAttributes,
-} from './source-parsing.js';
+import type { JSONElement, ElementAttributes } from './source-parsing.js';
 import type {
   Document as XMLDocument,
   Node as XMLNode,

--- a/src/locators/source-parsing.ts
+++ b/src/locators/source-parsing.ts
@@ -1,7 +1,5 @@
-import {
-  DOMParser,
-  MIME_TYPE,
-  XMLSerializer,
+import { DOMParser, MIME_TYPE, XMLSerializer } from '@xmldom/xmldom';
+import type {
   Document as XMLDocument,
   Node as XMLNode,
   Element as XMLElement,

--- a/src/scripts/simple-query-documentation.ts
+++ b/src/scripts/simple-query-documentation.ts
@@ -24,7 +24,7 @@ async function main(): Promise<void> {
   console.log('process.argv:', process.argv);
   const args = process.argv.slice(2);
   console.log('args:', args);
-  let query = '';
+  let query: string;
 
   if (args.length > 0) {
     query = args.join(' ');

--- a/src/tests/benchmark_model/benchmark_model.ts
+++ b/src/tests/benchmark_model/benchmark_model.ts
@@ -171,7 +171,7 @@ async function postChatCompletions(
     };
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(`HTTP timeout after ${timeoutMs}ms`);
+      throw new Error(`HTTP timeout after ${timeoutMs}ms`, { cause: error });
     }
     throw error;
   } finally {

--- a/src/tools/documentation/reasoning-rag.ts
+++ b/src/tools/documentation/reasoning-rag.ts
@@ -6,7 +6,7 @@
  * It can perform summarization, question-answering, and analysis on retrieved chunks.
  */
 
-import { Document } from '@langchain/core/documents';
+import type { Document } from '@langchain/core/documents';
 import { queryVectorStore } from './simple-pdf-indexer.js';
 import log from '../../logger.js';
 
@@ -180,7 +180,8 @@ export class ReasoningRAG {
     } catch (error) {
       log.error('Error in reasoning-enhanced RAG:', error);
       throw new Error(
-        `Reasoning-enhanced RAG failed: ${error instanceof Error ? error.message : String(error)}`
+        `Reasoning-enhanced RAG failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
       );
     }
   }
@@ -234,7 +235,8 @@ export class ReasoningRAG {
     } catch (error) {
       log.error('Error importing @xenova/transformers:', error);
       throw new Error(
-        `Failed to import @xenova/transformers: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to import @xenova/transformers: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
       );
     }
   }
@@ -264,7 +266,8 @@ export class ReasoningRAG {
     } catch (error) {
       log.error(`Error loading model ${config.modelName}:`, error);
       throw new Error(
-        `Failed to load model: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to load model: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
       );
     }
   }

--- a/src/tools/documentation/sentence-transformers-embeddings.ts
+++ b/src/tools/documentation/sentence-transformers-embeddings.ts
@@ -43,7 +43,8 @@ export class SentenceTransformersEmbeddings {
     } catch (error) {
       log.error('Error generating embeddings:', error);
       throw new Error(
-        `Failed to generate embeddings: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to generate embeddings: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
       );
     }
   }
@@ -87,7 +88,8 @@ export class SentenceTransformersEmbeddings {
     } catch (error) {
       log.error('Error generating document embeddings:', error);
       throw new Error(
-        `Failed to generate document embeddings: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to generate document embeddings: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
       );
     }
   }
@@ -109,7 +111,8 @@ export class SentenceTransformersEmbeddings {
     } catch (error) {
       log.error('Error importing @xenova/transformers:', error);
       throw new Error(
-        `Failed to import @xenova/transformers: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to import @xenova/transformers: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
       );
     }
   }
@@ -137,7 +140,8 @@ export class SentenceTransformersEmbeddings {
     } catch (error) {
       log.error('Error initializing sentence-transformers model:', error);
       throw new Error(
-        `Failed to initialize sentence-transformers model: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to initialize sentence-transformers model: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
       );
     }
   }

--- a/src/tools/documentation/simple-pdf-indexer.ts
+++ b/src/tools/documentation/simple-pdf-indexer.ts
@@ -40,7 +40,8 @@ function getEmbeddings(): SentenceTransformersEmbeddings {
     throw new Error(
       `Failed to initialize embeddings: ${
         error instanceof Error ? error.message : String(error)
-      }`
+      }`,
+      { cause: error }
     );
   }
 
@@ -443,7 +444,8 @@ async function extractTextFromMarkdown(markdownPath: string): Promise<string> {
     throw new Error(
       `Failed to extract text from Markdown: ${
         error instanceof Error ? error.message : String(error)
-      }`
+      }`,
+      { cause: error }
     );
   }
 }

--- a/src/tools/interactions/handle-alert.ts
+++ b/src/tools/interactions/handle-alert.ts
@@ -1,11 +1,8 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
 import { generateAllElementLocators } from '../../locators/generate-all-locators.js';
-import {
-  DriverInstance,
-  getPlatformName,
-  PLATFORM,
-} from '../../session-store.js';
+import { getPlatformName, PLATFORM } from '../../session-store.js';
+import type { DriverInstance } from '../../session-store.js';
 import { elementClick, execute, getPageSource } from '../../command.js';
 import {
   resolveDriver,

--- a/src/tools/interactions/screenshot.ts
+++ b/src/tools/interactions/screenshot.ts
@@ -1,4 +1,4 @@
-import { FastMCP } from 'fastmcp';
+import type { FastMCP } from 'fastmcp';
 import { getDriver } from '../../session-store.js';
 import { elementUUIDScheme } from '../../schema.js';
 import type { NullableDriverInstance } from '../../session-store.js';

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -338,7 +338,9 @@ export async function createSessionAction(args: {
     return addUIResourceToResponse(textResponse, uiResource);
   } catch (error: any) {
     log.error('Error creating session:', error);
-    throw new Error(`Failed to create session: ${error.message}`);
+    throw new Error(`Failed to create session: ${error.message}`, {
+      cause: error,
+    });
   }
 }
 

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -98,7 +98,9 @@ export default function selectDevice(server: any): void {
         }
       } catch (error: any) {
         log.error('Error selecting device:', error);
-        throw new Error(`Failed to select device: ${error.message}`);
+        throw new Error(`Failed to select device: ${error.message}`, {
+          cause: error,
+        });
       }
     },
   });


### PR DESCRIPTION
CI lint was failing on main with 17 errors + 13 auto-fixable warnings, picked up by every PR even when the PR doesn't touch the offending files. Cleaning it up so the lint job goes green again.

**Three rules, all mechanical fixes:**
- preserve-caught-error --> added { cause: error } to every throw new Error(...) inside a catch (error) so the original symptom isn't dropped. Touches vision-finder.ts, adb-manager.ts, benchmark_model.ts, reasoning-rag.ts (3x), sentence-transformers-embeddings.ts (4x), simple-pdf-indexer.ts (2x), create-session.ts, select-device.ts.
- @typescript-eslint/consistent-type-imports --> converted type-only imports to import type and pulled inline import('@appium/types').Rect / .ActionSequence annotations into the existing top-of-file type import block in command.ts. Also splits value/type imports in element-filter.ts, generate-all-locators.ts, locator-generation.ts, source-parsing.ts, reasoning-rag.ts, handle-alert.ts, screenshot.ts.
- no-useless-assignment --> dropped two dead initializers (let othersWithAttr: XMLNode[] = [] in locator-generation.ts:558 and let query = '' in simple-query-documentation.ts:27); both are reassigned in every reachable branch before they're read.