### PR TITLE
fix(session): point stale create_session prompts to appium_session_management

### DIFF
--- a/src/tools/ios/prepare-ios-real-device.ts
+++ b/src/tools/ios/prepare-ios-real-device.ts
@@ -9,9 +9,9 @@
  *    version; the signed IPA is rebuilt every call so profile/cert changes never
  *    serve a stale signature.
  *
- * After a successful run, create_session calls should pass the returned
- * `capabilitiesHint` so Appium installs and launches the signed prebuilt WDA
- * bundle instead of rebuilding it.
+ * After a successful run, appium_session_management (action=create) calls
+ * should pass the returned `capabilitiesHint` so Appium installs and launches
+ * the signed prebuilt WDA bundle instead of rebuilding it.
  */
 import type { ContentResult, FastMCP } from 'fastmcp';
 import { z } from 'zod';
@@ -472,7 +472,7 @@ export default function prepareIosRealDevice(server: FastMCP): void {
       '(2) Call again with the chosen UUID to download the matching WebDriverAgent release, package it as an IPA, ' +
       'and resign it with the chosen profile (wildcard "*" profiles are supported — a concrete WDA bundle ID is substituted at sign time). ' +
       'WDA download and unsigned IPA are cached per WDA version; the signed IPA is rebuilt every call. ' +
-      'Pass the returned capabilitiesHint to create_session so Appium installs and launches the signed prebuilt WDA instead of rebuilding. ' +
+      'Pass the returned capabilitiesHint to appium_session_management (action=create) so Appium installs and launches the signed prebuilt WDA instead of rebuilding. ' +
       'Requires macOS, Xcode 16+, and a paired developer-mode device.',
     parameters: prepareRealDeviceSchema,
     annotations: {

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -201,34 +201,26 @@ export function validateRemoteServerUrl(
 }
 
 /**
- * Registers a tool for creating a new mobile session with Android or iOS devices.
+ * Create a new mobile session with Android or iOS device.
  *
- * This function adds a 'create_session' tool to the provided server that handles
- * mobile session creation with support for both local and remote Appium servers.
+ * Backs the `appium_session_management` tool when called with `action=create`.
+ * Requires prior platform selection via the `select_device` tool for local
+ * servers. Supports both local and remote Appium server connections.
  *
- * @param server - The server instance to which the create_session tool will be added
- *
- * @tool create_session
- * @description Creates a new mobile session with Android or iOS device. Requires prior
- * platform selection via the select_device tool. Supports both local and remote
- * Appium server connections.
- *
- * @param {Object} args - Tool execution arguments
- * @param {'ios' | 'android'} args.platform - REQUIRED. The target platform, must match
- * the platform explicitly selected via select_device tool
- * @param {Object} [args.capabilities] - Optional custom W3C format capabilities
+ * @param {Object} args - Action arguments
+ * @param {'ios' | 'android' | 'general'} args.platform - REQUIRED. The target
+ * platform. For local servers, must match the platform explicitly selected via
+ * `select_device`. Use 'general' only with `remoteServerUrl` for non-Android/iOS
+ * drivers.
+ * @param {Object} [args.capabilities] - Optional custom W3C-format capabilities
  * @param {string} [args.remoteServerUrl] - Optional remote Appium server URL
- * (e.g., http://localhost:4723). If not provided, uses local Appium server
+ * (e.g., http://localhost:4723). If not provided, uses the local embedded driver.
  *
  * @returns {Promise<Object>} Response object containing:
  * - text: Success message with session ID and device details
  * - ui: Interactive session dashboard UI component
  *
  * @throws {Error} If session creation fails or platform capabilities cannot be loaded
- *
- * @example
- * // Register the tool
- * createSession(server);
  */
 export async function createSessionAction(args: {
   platform: 'ios' | 'android' | 'general';

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -43,12 +43,12 @@ export default function selectDevice(server: any): void {
       WORKFLOW FOR LOCAL SERVERS:
       1. ASK THE USER which platform they want (Android or iOS) - do not assume
       2. Call this tool with the chosen platform (and iosDeviceType for iOS)
-      3. If only one device is found, it is auto-selected - proceed to create_session (or prepare_ios_simulator for iOS simulators)
+      3. If only one device is found, it is auto-selected - proceed to appium_session_management (action=create) (or prepare_ios_simulator for iOS simulators)
       4. If multiple devices are found, ask the user which one they want, then call this tool again with deviceUdid
-      5. After selection, proceed to create_session (or prepare_ios_simulator for iOS simulators, then create_session)
+      5. After selection, proceed to appium_session_management (action=create) (or prepare_ios_simulator for iOS simulators, then appium_session_management with action=create)
       WORKFLOW FOR REMOTE SERVERS:
       - SKIP this tool entirely
-      - Device selection should be handled via capabilities in create_session (e.g., appium:deviceName, appium:udid)
+      - Device selection should be handled via capabilities on appium_session_management (action=create) (e.g., appium:deviceName, appium:udid)
       - The remote Appium server is already configured for specific device(s)
       `,
     parameters: z
@@ -144,7 +144,7 @@ function formatAndroidSelectionResponse(deviceUdid: string): any {
       {
         message: `✅ Device selected: ${deviceUdid}`,
         instructions:
-          '🚀 You can now create a session using the create_session tool with:',
+          '🚀 You can now create a session by calling appium_session_management with action=create and:',
         platform: 'android',
         capabilities: {
           'appium:udid': deviceUdid,


### PR DESCRIPTION
some session facing prompts and docs were still telling users/LLMs to call create_session, but that is not a registered tool anymore **(the registered tool is appium_session_management with action=create)**,  this is a contract/copy fix to prevent tool-name mismatch and reduce LLM miscalls.