### PR TITLE
fix(app-management): use resolveDriver and errorResult for lifecycle tools

### DIFF
--- a/src/tools/app-management/app.ts
+++ b/src/tools/app-management/app.ts
@@ -1,5 +1,4 @@
 import type { ContentResult, FastMCP } from 'fastmcp';
-import { errorResult } from '../tool-response.js';
 import { z } from 'zod';
 import { resolveAppId, resolveId } from './resolve-app-id.js';
 import { activate } from './activate-app.js';
@@ -12,6 +11,7 @@ import { queryState } from './query-app-state.js';
 import { background, DEFAULT_BACKGROUND_SECONDS } from './background-app.js';
 import { clear } from './clear-app.js';
 import { deepLink } from './deep-link.js';
+import { errorResult, toolErrorMessage } from '../tool-response.js';
 
 const APP_ACTIONS = [
   'activate',
@@ -124,23 +124,41 @@ export default function app(server: FastMCP): void {
       }
       if (action === 'install') {
         if (!args.path) {
-          return errorResult('path is required for install');
+          return {
+            content: [{ type: 'text', text: 'path is required for install' }],
+          };
         }
         return install(args.path, sessionId);
       }
 
       if (action === 'deep_link') {
         if (!args.url) {
-          return errorResult('url is required for deep_link');
+          return {
+            content: [{ type: 'text', text: 'url is required for deep_link' }],
+          };
         }
-        const appId =
-          args.id ??
-          (args.name ? await resolveAppId(args.name, sessionId) : undefined);
+        let appId: string | undefined;
+        try {
+          appId =
+            args.id ??
+            (args.name ? await resolveAppId(args.name, sessionId) : undefined);
+        } catch (err: unknown) {
+          return errorResult(
+            `Failed to resolve app id for deep_link: ${toolErrorMessage(err)}`
+          );
+        }
         return deepLink(args.url, appId, args.waitForLaunch, sessionId);
       }
 
       // activate, terminate, uninstall, is_installed, query_state, clear — all require id or name
-      const id = await resolveId(args.id, args.name, sessionId);
+      let id: string;
+      try {
+        id = await resolveId(args.id, args.name, sessionId);
+      } catch (err: unknown) {
+        return errorResult(
+          `Failed to resolve app id for ${action}: ${toolErrorMessage(err)}`
+        );
+      }
 
       if (action === 'activate') {
         return activate(id, sessionId);
@@ -160,7 +178,9 @@ export default function app(server: FastMCP): void {
       if (action === 'clear') {
         return clear(id, sessionId);
       }
-      return errorResult(`Unknown action: ${action}`);
+      return {
+        content: [{ type: 'text', text: `Unknown action: ${action}` }],
+      };
     },
   });
 }

--- a/src/tools/app-management/app.ts
+++ b/src/tools/app-management/app.ts
@@ -124,18 +124,14 @@ export default function app(server: FastMCP): void {
       }
       if (action === 'install') {
         if (!args.path) {
-          return {
-            content: [{ type: 'text', text: 'path is required for install' }],
-          };
+          return errorResult('path is required for install');
         }
         return install(args.path, sessionId);
       }
 
       if (action === 'deep_link') {
         if (!args.url) {
-          return {
-            content: [{ type: 'text', text: 'url is required for deep_link' }],
-          };
+          return errorResult('url is required for deep_link');
         }
         let appId: string | undefined;
         try {
@@ -178,9 +174,7 @@ export default function app(server: FastMCP): void {
       if (action === 'clear') {
         return clear(id, sessionId);
       }
-      return {
-        content: [{ type: 'text', text: `Unknown action: ${action}` }],
-      };
+      return errorResult(`Unknown action: ${action}`);
     },
   });
 }

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -1,8 +1,8 @@
 import type { ContentResult } from 'fastmcp';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
+import type { DriverInstance } from '../../session-store.js';
 import {
-  getDriver,
   getPlatformName,
   isRemoteDriverSession,
   isAndroidUiautomator2DriverSession,
@@ -17,19 +17,19 @@ import {
 import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
 import { execute } from '../../command.js';
-import { textResult, errorResult, toolErrorMessage } from '../tool-response.js';
+import {
+  resolveDriver,
+  textResult,
+  errorResult,
+  toolErrorMessage,
+} from '../tool-response.js';
 
 const execAsync = promisify(exec);
 
 export async function listAppsFromDevice(
-  applicationType: 'User' | 'System' = 'User',
-  sessionId?: string
+  driver: DriverInstance,
+  applicationType: 'User' | 'System' = 'User'
 ): Promise<{ packageName: string; appName: string }[]> {
-  const driver = getDriver(sessionId);
-  if (!driver) {
-    throw new Error('No driver found');
-  }
-
   const platform = getPlatformName(driver);
 
   if (isRemoteDriverSession(driver)) {
@@ -86,8 +86,15 @@ export async function list(
   applicationType?: 'User' | 'System',
   sessionId?: string
 ): Promise<ContentResult> {
+  const resolved = resolveDriver(sessionId);
+  if (!resolved.ok) {
+    return resolved.result;
+  }
   try {
-    const apps = await listAppsFromDevice(applicationType, sessionId);
+    const apps = await listAppsFromDevice(
+      resolved.driver,
+      applicationType ?? 'User'
+    );
     const textResponse = textResult(
       `Installed apps: ${JSON.stringify(apps, null, 2)}`
     );
@@ -116,9 +123,23 @@ function normalizeListAppsResult(
 ): { packageName: string; appName: string }[] {
   return Object.entries(result).map(([id, attrs]) => ({
     packageName: id,
-    appName: (attrs?.CFBundleDisplayName ||
-      attrs?.CFBundleName ||
-      (attrs as any)?.name ||
-      '') as string,
+    appName: pickDisplayName(attrs),
   }));
+}
+
+/**
+ * Pick the first non-empty string from the well-known iOS metadata fields.
+ * `||` keeps the original fall-through behavior when a field is `""`.
+ */
+function pickDisplayName(attrs: Record<string, unknown> | undefined): string {
+  const display =
+    readString(attrs?.CFBundleDisplayName) ||
+    readString(attrs?.CFBundleName) ||
+    readString(attrs?.name) ||
+    '';
+  return display;
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
 }

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -123,16 +123,9 @@ function normalizeListAppsResult(
 ): { packageName: string; appName: string }[] {
   return Object.entries(result).map(([id, attrs]) => ({
     packageName: id,
-    appName: pickDisplayName(attrs),
-  }));
-}
-
-/** First non-empty iOS display field; `||` skips empty strings like the legacy path. */
-function pickDisplayName(attrs: Record<string, unknown> | undefined): string {
-  return (
-    (attrs?.CFBundleDisplayName ||
+    appName: (attrs?.CFBundleDisplayName ||
       attrs?.CFBundleName ||
-      attrs?.name ||
-      '') as string
-  );
+      (attrs as any)?.name ||
+      '') as string,
+  }));
 }

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -127,19 +127,12 @@ function normalizeListAppsResult(
   }));
 }
 
-/**
- * Pick the first non-empty string from the well-known iOS metadata fields.
- * `||` keeps the original fall-through behavior when a field is `""`.
- */
+/** First non-empty iOS display field; `||` skips empty strings like the legacy path. */
 function pickDisplayName(attrs: Record<string, unknown> | undefined): string {
-  const display =
-    readString(attrs?.CFBundleDisplayName) ||
-    readString(attrs?.CFBundleName) ||
-    readString(attrs?.name) ||
-    '';
-  return display;
-}
-
-function readString(value: unknown): string {
-  return typeof value === 'string' ? value : '';
+  return (
+    (attrs?.CFBundleDisplayName ||
+      attrs?.CFBundleName ||
+      attrs?.name ||
+      '') as string
+  );
 }

--- a/src/tools/app-management/resolve-app-id.ts
+++ b/src/tools/app-management/resolve-app-id.ts
@@ -103,20 +103,26 @@ async function getInstalledApps(
   }
 
   const driver = getDriver(sessionId);
-  const platform = driver ? getPlatformName(driver) : null;
+  if (!driver) {
+    const ctx = sessionId ? ` for session '${sessionId}'` : '';
+    throw new Error(
+      `No active driver session${ctx}. Call create_session first or pass a valid sessionId.`
+    );
+  }
+
+  const platform = getPlatformName(driver);
 
   let apps: { packageName: string; appName: string }[];
-  const isSimulator =
-    driver && isXCUITestDriverSession(driver)
-      ? (driver as XCUITestDriver).isSimulator()
-      : false;
+  const isSimulator = isXCUITestDriverSession(driver)
+    ? (driver as XCUITestDriver).isSimulator()
+    : false;
 
   if (platform === PLATFORM.ios && !isSimulator) {
     // Real iOS device: User and System app lists are separate — fetch both in parallel.
     // Use allSettled so a failure on one type (e.g. System) doesn't discard the other.
     const results = await Promise.allSettled([
-      listAppsFromDevice('User', sessionId),
-      listAppsFromDevice('System', sessionId),
+      listAppsFromDevice(driver, 'User'),
+      listAppsFromDevice(driver, 'System'),
     ]);
     const seen = new Set<string>();
     apps = [];
@@ -132,7 +138,7 @@ async function getInstalledApps(
     }
   } else {
     // Android or iOS Simulator: single call returns all apps
-    apps = await listAppsFromDevice('User', sessionId);
+    apps = await listAppsFromDevice(driver, 'User');
   }
 
   appListCache.set(key, { apps, timestamp: Date.now() });

--- a/src/tools/app-management/resolve-app-id.ts
+++ b/src/tools/app-management/resolve-app-id.ts
@@ -7,6 +7,7 @@ import {
 } from '../../session-store.js';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
 import { listAppsFromDevice } from './list-apps.js';
+import { noActiveDriverSessionMessage } from '../tool-response.js';
 
 interface CacheEntry {
   apps: { packageName: string; appName: string }[];
@@ -81,7 +82,7 @@ export async function resolveAppId(
 
   if (scored.length === 0) {
     throw new Error(
-      `No installed app matched the name "${name}". Use appium_app_lifecycle with action=list" action to see available apps.`
+      `No installed app matched the name "${name}". Use appium_app_lifecycle with action=list to see available apps.`
     );
   }
 
@@ -104,10 +105,7 @@ async function getInstalledApps(
 
   const driver = getDriver(sessionId);
   if (!driver) {
-    const ctx = sessionId ? ` for session '${sessionId}'` : '';
-    throw new Error(
-      `No active driver session${ctx}. Call create_session first or pass a valid sessionId.`
-    );
+    throw new Error(noActiveDriverSessionMessage(sessionId));
   }
 
   const platform = getPlatformName(driver);

--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -59,15 +59,18 @@ export function errorResult(text: string): ContentResult {
   return { content: [{ type: 'text', text }], isError: true };
 }
 
+/** Message body for {@link noActiveDriverSessionResult} (shared when throwing from helpers). */
+export function noActiveDriverSessionMessage(sessionId?: string): string {
+  const ctx = sessionId ? ` for session '${sessionId}'` : '';
+  return `No active driver session${ctx}. Use appium_session_management (action=create or action=attach), or pass a valid sessionId.`;
+}
+
 /**
  * Standard tool-execution error when no driver is active for the given session.
  * Keeps copy aligned with the registered `appium_session_management` tool.
  */
 export function noActiveDriverSessionResult(sessionId?: string): ContentResult {
-  const ctx = sessionId ? ` for session '${sessionId}'` : '';
-  return errorResult(
-    `No active driver session${ctx}. Use appium_session_management (action=create or action=attach), or pass a valid sessionId.`
-  );
+  return errorResult(noActiveDriverSessionMessage(sessionId));
 }
 
 /**


### PR DESCRIPTION
list action uses resolveDriver; listAppsFromDevice takes a DriverInstance; getInstalledApps resolves the driver up front; app id resolution failures return errorResult instead of throwing