### PR TITLE
fix(app-lifecycle): send appId on remote Android query_state

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -68,10 +68,12 @@ export async function queryAppState(
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.queryAppState(appId);
   }
+  const params =
+    getPlatformName(driver) === PLATFORM.android
+      ? { appId }
+      : { bundleId: appId };
   return Number(
-    await (driver as Client).executeScript('mobile: queryAppState', [
-      { bundleId: appId },
-    ])
+    await (driver as Client).executeScript('mobile: queryAppState', [params])
   );
 }
 


### PR DESCRIPTION
The remote-WebDriver fallback in `queryAppState` hardcoded `{ bundleId: appId }` — the iOS XCUITest parameter name. UiAutomator2's `mobile: queryAppState` requires `appId`, so `appium_app_lifecycle action=query_state` always failed on remote Android sessions with `["appId"]` missing.

Branch on `getPlatformName(driver)` to send `{ appId }` for Android and `{ bundleId }` for iOS, mirroring the pattern in `clear-app.ts` and `terminate-app.ts`. Embedded driver paths are unchanged.

Closes #330