### PR TITLE
feat(rag): upgrade to BGE-small-v1.5 + add retrieval eval harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 ./test-results
 .DS_Store
 src/tools/robot.ts
+src/scripts/eval-results/
 package-lock.json
 .idea
 .vscode

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "rimraf dist tsconfig.tsbuildinfo && tsc -b && chmod +x dist/index.js && npm run copy-docs",
-    "copy-docs": "mkdir -p dist/tools/documentation/uploads && cp -f src/tools/documentation/uploads/documents.json dist/tools/documentation/uploads/documents.json 2>/dev/null || true",
+    "copy-docs": "mkdir -p dist/tools/documentation/uploads dist/scripts && cp -f src/tools/documentation/uploads/documents.json dist/tools/documentation/uploads/documents.json 2>/dev/null || true && cp -f src/scripts/rag-eval-dataset.json dist/scripts/rag-eval-dataset.json 2>/dev/null || true",
     "start": "node dist/index.js",
     "start:stdio": "node dist/index.js",
     "start:httpStream": "node dist/index.js --httpStream",
@@ -35,6 +35,8 @@
     "check": "npm run lint && npm run format:check",
     "index-docs": "node dist/scripts/simple-index-documentation.js",
     "query-docs": "node dist/scripts/simple-query-documentation.js",
+    "eval-docs": "node dist/scripts/eval-documentation-rag.js",
+    "eval-docs:save": "node dist/scripts/eval-documentation-rag.js --save",
     "sync-version": "node scripts/sync-version.mjs",
     "version": "npm run sync-version",
     "zip-assets": "node scripts/zip-assets.mjs zip",

--- a/src/scripts/eval-documentation-rag.ts
+++ b/src/scripts/eval-documentation-rag.ts
@@ -1,0 +1,310 @@
+/**
+ * RAG retrieval eval harness for the Appium documentation tool.
+ *
+ * Usage (after `npm run build`):
+ *   node dist/scripts/eval-documentation-rag.js [--quiet] [--save] [--top-chunks=N]
+ *
+ * What it does:
+ *   1. Loads the eval dataset (src/scripts/rag-eval-dataset.json).
+ *   2. For each query, calls the existing queryVectorStore() with `topChunks`
+ *      chunks (default 30), dedupes by source (preserving rank), and matches
+ *      the resulting source list against expectedSources.
+ *   3. Reports Recall@{1,3,5,10} and MRR, broken down by difficulty.
+ *   4. Persists results to src/scripts/eval-results/<ISO>.json plus a
+ *      `latest.json` so successive runs can be diffed.
+ *
+ * Notes:
+ *   - The first run after a server restart pays the embedding cold start
+ *     (~30-60s for the current corpus).
+ *   - Match strategy: a retrieved source matches an expected source if its
+ *     `relativePath` ends with the expected path (case-sensitive).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { queryVectorStore } from '../tools/documentation/simple-pdf-indexer.js';
+
+interface EvalQuery {
+  id: string;
+  query: string;
+  expectedSources: string[];
+  difficulty: 'easy' | 'medium' | 'vague';
+  category?: string;
+}
+
+interface EvalDataset {
+  version: number;
+  description: string;
+  matchMode?: 'endsWith' | 'exact';
+  queries: EvalQuery[];
+}
+
+interface PerQueryResult {
+  id: string;
+  query: string;
+  difficulty: EvalQuery['difficulty'];
+  category?: string;
+  expectedSources: string[];
+  retrievedSources: string[];
+  matchedAtRank: number | null;
+  matchedSource: string | null;
+  recallAt1: 0 | 1;
+  recallAt3: 0 | 1;
+  recallAt5: 0 | 1;
+  recallAt10: 0 | 1;
+  reciprocalRank: number;
+}
+
+interface AggregateMetrics {
+  count: number;
+  recallAt1: number;
+  recallAt3: number;
+  recallAt5: number;
+  recallAt10: number;
+  mrr: number;
+}
+
+interface EvalRun {
+  timestamp: string;
+  datasetVersion: number;
+  topChunks: number;
+  overall: AggregateMetrics;
+  byDifficulty: Record<string, AggregateMetrics>;
+  perQuery: PerQueryResult[];
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const args = new Set(process.argv.slice(2));
+const QUIET = args.has('--quiet');
+const NO_SAVE = !args.has('--save');
+const topChunksArg = process.argv.find((a) => a.startsWith('--top-chunks='));
+const TOP_CHUNKS = topChunksArg ? Number(topChunksArg.split('=')[1]) : 30;
+
+function resolveDatasetPath(): string {
+  // When compiled, this file lives in dist/scripts/. We look for the dataset
+  // beside it first (copy-docs build step), then fall back to src/scripts/.
+  const candidates = [
+    path.resolve(__dirname, 'rag-eval-dataset.json'),
+    path.resolve(__dirname, '../../src/scripts/rag-eval-dataset.json'),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+  throw new Error(
+    `Could not find rag-eval-dataset.json in any of: ${candidates.join(', ')}`
+  );
+}
+
+function resolveResultsDir(): string {
+  // Always write results into the source tree so they're easy to diff/commit.
+  const candidates = [
+    path.resolve(__dirname, '../../src/scripts/eval-results'),
+    path.resolve(__dirname, 'eval-results'),
+  ];
+  const dir = candidates[0];
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function matches(retrievedRelPath: string, expected: string): boolean {
+  return retrievedRelPath === expected || retrievedRelPath.endsWith(expected);
+}
+
+function dedupeBySource(
+  chunks: Array<{ relativePath: string | undefined }>
+): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const c of chunks) {
+    const src = c.relativePath;
+    if (!src || seen.has(src)) {
+      continue;
+    }
+    seen.add(src);
+    ordered.push(src);
+  }
+  return ordered;
+}
+
+function evalQuery(
+  retrievedSources: string[],
+  expectedSources: string[]
+): {
+  matchedAtRank: number | null;
+  matchedSource: string | null;
+} {
+  for (let i = 0; i < retrievedSources.length; i++) {
+    const hit = expectedSources.find((e) => matches(retrievedSources[i], e));
+    if (hit) {
+      return { matchedAtRank: i + 1, matchedSource: retrievedSources[i] };
+    }
+  }
+  return { matchedAtRank: null, matchedSource: null };
+}
+
+function aggregate(results: PerQueryResult[]): AggregateMetrics {
+  if (results.length === 0) {
+    return {
+      count: 0,
+      recallAt1: 0,
+      recallAt3: 0,
+      recallAt5: 0,
+      recallAt10: 0,
+      mrr: 0,
+    };
+  }
+  const n = results.length;
+  const sum = (k: keyof PerQueryResult): number =>
+    results.reduce((acc, r) => acc + (r[k] as number), 0);
+  return {
+    count: n,
+    recallAt1: sum('recallAt1') / n,
+    recallAt3: sum('recallAt3') / n,
+    recallAt5: sum('recallAt5') / n,
+    recallAt10: sum('recallAt10') / n,
+    mrr: sum('reciprocalRank') / n,
+  };
+}
+
+function fmt(n: number): string {
+  return n.toFixed(3);
+}
+
+function rankStr(rank: number | null): string {
+  return rank === null ? ' - ' : String(rank).padStart(3, ' ');
+}
+
+function printPerQueryTable(results: PerQueryResult[]): void {
+  const rows = results.map((r) => ({
+    id: r.id,
+    diff: r.difficulty,
+    rank: rankStr(r.matchedAtRank),
+    query: r.query.length > 56 ? r.query.slice(0, 53) + '...' : r.query,
+    matched: r.matchedSource ?? '(none of expected found in top results)',
+  }));
+
+  const widths = {
+    id: 4,
+    diff: 7,
+    rank: 4,
+    query: Math.max(...rows.map((r) => r.query.length), 5),
+    matched: Math.max(...rows.map((r) => r.matched.length), 7),
+  };
+
+  const header = `${'id'.padEnd(widths.id)} | ${'diff'.padEnd(widths.diff)} | ${'rank'.padStart(widths.rank)} | ${'query'.padEnd(widths.query)} | matched`;
+  const sep = '-'.repeat(header.length + 10);
+
+  console.log(sep);
+  console.log(header);
+  console.log(sep);
+  for (const r of rows) {
+    console.log(
+      `${r.id.padEnd(widths.id)} | ${r.diff.padEnd(widths.diff)} | ${r.rank.padStart(widths.rank)} | ${r.query.padEnd(widths.query)} | ${r.matched}`
+    );
+  }
+  console.log(sep);
+}
+
+function printAggregate(label: string, m: AggregateMetrics): void {
+  const tag = `${label} (n=${m.count})`.padEnd(20);
+  console.log(
+    `${tag}  R@1=${fmt(m.recallAt1)}  R@3=${fmt(m.recallAt3)}  R@5=${fmt(m.recallAt5)}  R@10=${fmt(m.recallAt10)}  MRR=${fmt(m.mrr)}`
+  );
+}
+
+async function runEval(): Promise<void> {
+  const datasetPath = resolveDatasetPath();
+  const dataset: EvalDataset = JSON.parse(
+    fs.readFileSync(datasetPath, 'utf-8')
+  );
+
+  if (!QUIET) {
+    console.log(`\n=== Appium RAG eval ===`);
+    console.log(`Dataset: ${datasetPath}`);
+    console.log(
+      `Queries: ${dataset.queries.length}   |   topChunks: ${TOP_CHUNKS}   |   match: endsWith\n`
+    );
+  }
+
+  const perQuery: PerQueryResult[] = [];
+
+  for (const q of dataset.queries) {
+    const docs = await queryVectorStore(q.query, TOP_CHUNKS);
+    const retrievedSources = dedupeBySource(
+      docs.map((d) => ({
+        relativePath:
+          (d.metadata?.relativePath as string | undefined) ??
+          (d.metadata?.filename as string | undefined) ??
+          (d.metadata?.source as string | undefined),
+      }))
+    );
+
+    const { matchedAtRank, matchedSource } = evalQuery(
+      retrievedSources,
+      q.expectedSources
+    );
+
+    perQuery.push({
+      id: q.id,
+      query: q.query,
+      difficulty: q.difficulty,
+      category: q.category,
+      expectedSources: q.expectedSources,
+      retrievedSources,
+      matchedAtRank,
+      matchedSource,
+      recallAt1: matchedAtRank !== null && matchedAtRank <= 1 ? 1 : 0,
+      recallAt3: matchedAtRank !== null && matchedAtRank <= 3 ? 1 : 0,
+      recallAt5: matchedAtRank !== null && matchedAtRank <= 5 ? 1 : 0,
+      recallAt10: matchedAtRank !== null && matchedAtRank <= 10 ? 1 : 0,
+      reciprocalRank: matchedAtRank !== null ? 1 / matchedAtRank : 0,
+    });
+  }
+
+  if (!QUIET) {
+    printPerQueryTable(perQuery);
+  }
+
+  const overall = aggregate(perQuery);
+  const byDifficulty: Record<string, AggregateMetrics> = {};
+  for (const d of ['easy', 'medium', 'vague'] as const) {
+    byDifficulty[d] = aggregate(perQuery.filter((r) => r.difficulty === d));
+  }
+
+  console.log('');
+  printAggregate('overall', overall);
+  for (const d of ['easy', 'medium', 'vague'] as const) {
+    printAggregate(d, byDifficulty[d]);
+  }
+  console.log('');
+
+  if (!NO_SAVE) {
+    const run: EvalRun = {
+      timestamp: new Date().toISOString(),
+      datasetVersion: dataset.version,
+      topChunks: TOP_CHUNKS,
+      overall,
+      byDifficulty,
+      perQuery,
+    };
+    const dir = resolveResultsDir();
+    const stamp = run.timestamp.replace(/[:.]/g, '-');
+    const outPath = path.join(dir, `${stamp}.json`);
+    const latestPath = path.join(dir, 'latest.json');
+    fs.writeFileSync(outPath, JSON.stringify(run, null, 2));
+    fs.writeFileSync(latestPath, JSON.stringify(run, null, 2));
+    console.log(`Saved: ${path.relative(process.cwd(), outPath)}`);
+    console.log(`       ${path.relative(process.cwd(), latestPath)}\n`);
+  }
+}
+
+runEval().catch((err) => {
+  console.error('Eval failed:', err);
+  process.exit(1);
+});

--- a/src/scripts/eval-documentation-rag.ts
+++ b/src/scripts/eval-documentation-rag.ts
@@ -304,7 +304,9 @@ async function runEval(): Promise<void> {
   }
 }
 
-runEval().catch((err) => {
+try {
+  await runEval();
+} catch (err) {
   console.error('Eval failed:', err);
   process.exit(1);
-});
+}

--- a/src/scripts/rag-eval-dataset.json
+++ b/src/scripts/rag-eval-dataset.json
@@ -1,0 +1,218 @@
+{
+  "version": 1,
+  "description": "Realistic user queries for the Appium documentation RAG tool. Each query maps to one or more source files that should appear in the retrieved sources (substring match against the chunk's relativePath metadata). Difficulty buckets: easy (specific terms that should be near-trivial to retrieve), medium (real-world phrasing), vague (natural human phrasing with less direct cues).",
+  "matchMode": "endsWith",
+  "queries": [
+    {
+      "id": "q01",
+      "query": "How do I install Appium?",
+      "expectedSources": ["appium/quickstart/install.md"],
+      "difficulty": "easy",
+      "category": "setup"
+    },
+    {
+      "id": "q02",
+      "query": "What capabilities does the XCUITest driver support?",
+      "expectedSources": ["appium-xcuitest-driver/reference/capabilities.md"],
+      "difficulty": "easy",
+      "category": "capabilities"
+    },
+    {
+      "id": "q03",
+      "query": "how to run iOS tests in parallel",
+      "expectedSources": ["appium-xcuitest-driver/guides/parallel-tests.md"],
+      "difficulty": "easy",
+      "category": "ios"
+    },
+    {
+      "id": "q04",
+      "query": "push and pull files from an iOS device",
+      "expectedSources": ["appium-xcuitest-driver/guides/file-transfer.md"],
+      "difficulty": "easy",
+      "category": "ios"
+    },
+    {
+      "id": "q05",
+      "query": "read and write the clipboard on iOS",
+      "expectedSources": ["appium-xcuitest-driver/guides/clipboard.md"],
+      "difficulty": "easy",
+      "category": "ios"
+    },
+    {
+      "id": "q06",
+      "query": "what locator strategies are supported by XCUITest",
+      "expectedSources": [
+        "appium-xcuitest-driver/reference/locator-strategies.md"
+      ],
+      "difficulty": "easy",
+      "category": "locators"
+    },
+    {
+      "id": "q07",
+      "query": "how do I use iOS predicate strings to find elements",
+      "expectedSources": ["appium-xcuitest-driver/reference/ios-predicate.md"],
+      "difficulty": "easy",
+      "category": "locators"
+    },
+    {
+      "id": "q08",
+      "query": "uiautomator2 driver capabilities",
+      "expectedSources": ["appium-uiautomator2-driver/capability-sets.md"],
+      "difficulty": "easy",
+      "category": "android"
+    },
+    {
+      "id": "q09",
+      "query": "Appium server command line arguments",
+      "expectedSources": ["appium/cli/args.md"],
+      "difficulty": "easy",
+      "category": "cli"
+    },
+    {
+      "id": "q10",
+      "query": "install a root certificate on an iOS device",
+      "expectedSources": [
+        "appium-xcuitest-driver/guides/install-certificate.md"
+      ],
+      "difficulty": "easy",
+      "category": "ios"
+    },
+
+    {
+      "id": "q11",
+      "query": "I'm new to Appium, where should I start?",
+      "expectedSources": [
+        "appium/quickstart/index.md",
+        "appium/intro/index.md",
+        "appium/quickstart/requirements.md"
+      ],
+      "difficulty": "medium",
+      "category": "intro"
+    },
+    {
+      "id": "q12",
+      "query": "which driver should I use to automate android",
+      "expectedSources": [
+        "appium/quickstart/uiauto2-driver.md",
+        "appium/intro/drivers.md",
+        "appium/ecosystem/drivers.md"
+      ],
+      "difficulty": "medium",
+      "category": "android"
+    },
+    {
+      "id": "q13",
+      "query": "how do I switch to a webview in an iOS hybrid app",
+      "expectedSources": [
+        "appium-xcuitest-driver/guides/hybrid.md",
+        "appium/guides/context.md"
+      ],
+      "difficulty": "medium",
+      "category": "hybrid"
+    },
+    {
+      "id": "q14",
+      "query": "how to set up code signing for real iPhone testing",
+      "expectedSources": [
+        "appium-xcuitest-driver/preparation/real-device-config.md",
+        "appium-xcuitest-driver/preparation/prov-profile-basic-auto.md",
+        "appium-xcuitest-driver/preparation/prov-profile-basic-manual.md"
+      ],
+      "difficulty": "medium",
+      "category": "ios-real-device"
+    },
+    {
+      "id": "q15",
+      "query": "swipe gesture on android",
+      "expectedSources": [
+        "appium-uiautomator2-driver/android-mobile-gestures.md"
+      ],
+      "difficulty": "medium",
+      "category": "gestures"
+    },
+    {
+      "id": "q16",
+      "query": "running tests against an .aab Android App Bundle",
+      "expectedSources": ["appium-uiautomator2-driver/android-appbundle.md"],
+      "difficulty": "medium",
+      "category": "android"
+    },
+    {
+      "id": "q17",
+      "query": "differences between Appium 1 and Appium 2",
+      "expectedSources": ["appium/guides/migrating-1-to-2.md"],
+      "difficulty": "medium",
+      "category": "migration"
+    },
+    {
+      "id": "q18",
+      "query": "enable Touch ID in an iOS simulator test",
+      "expectedSources": ["appium-xcuitest-driver/guides/touch-id.md"],
+      "difficulty": "medium",
+      "category": "ios"
+    },
+    {
+      "id": "q19",
+      "query": "use a custom WebDriverAgent server",
+      "expectedSources": [
+        "appium-xcuitest-driver/guides/wda-custom-server.md",
+        "appium-xcuitest-driver/guides/run-prebuilt-wda.md"
+      ],
+      "difficulty": "medium",
+      "category": "wda"
+    },
+    {
+      "id": "q20",
+      "query": "setting up Appium on a CI server",
+      "expectedSources": ["appium-xcuitest-driver/guides/ci-setup.md"],
+      "difficulty": "medium",
+      "category": "ci"
+    },
+
+    {
+      "id": "q21",
+      "query": "my tests are super slow on iOS, what's going on",
+      "expectedSources": [
+        "appium-xcuitest-driver/guides/wda-slowness.md",
+        "appium-xcuitest-driver/guides/troubleshooting.md"
+      ],
+      "difficulty": "vague",
+      "category": "troubleshooting"
+    },
+    {
+      "id": "q22",
+      "query": "appium can't find my button",
+      "expectedSources": [
+        "appium-xcuitest-driver/guides/elements-lookup-troubleshooting.md",
+        "appium-xcuitest-driver/reference/locator-strategies.md"
+      ],
+      "difficulty": "vague",
+      "category": "troubleshooting"
+    },
+    {
+      "id": "q23",
+      "query": "I switched xcode versions and now nothing works",
+      "expectedSources": [
+        "appium-xcuitest-driver/guides/multiple-xcode-versions.md"
+      ],
+      "difficulty": "vague",
+      "category": "troubleshooting"
+    },
+    {
+      "id": "q24",
+      "query": "can I reuse a WebDriverAgent that's already running",
+      "expectedSources": [
+        "appium-xcuitest-driver/guides/attach-to-running-wda.md"
+      ],
+      "difficulty": "vague",
+      "category": "wda"
+    },
+    {
+      "id": "q25",
+      "query": "show me how to write a test in python",
+      "expectedSources": ["appium/quickstart/test-py.md"],
+      "difficulty": "vague",
+      "category": "clients"
+    }
+  ]
+}

--- a/src/tools/documentation/sentence-transformers-embeddings.ts
+++ b/src/tools/documentation/sentence-transformers-embeddings.ts
@@ -13,16 +13,20 @@ import log from '../../logger.js';
 export class SentenceTransformersEmbeddings {
   private model: any = null;
   private modelName: string;
+  private queryInstruction: string;
   private isInitialized: boolean = false;
   private transformers: any = null;
 
-  constructor(options: { modelName?: string } = {}) {
-    // Use a lightweight, fast model by default
+  constructor(options: { modelName?: string; queryInstruction?: string } = {}) {
     this.modelName = options.modelName || 'Xenova/all-MiniLM-L6-v2';
+    // Optional prefix prepended only to queries (not documents).
+    // BGE models use this to close the question/passage style gap.
+    this.queryInstruction = options.queryInstruction ?? '';
   }
 
   /**
-   * Generate embeddings for a single text (LangChain interface)
+   * Generate embeddings for a single text (LangChain interface).
+   * Applies queryInstruction prefix when set.
    */
   async embedQuery(text: string): Promise<number[]> {
     await this.initializeModel();
@@ -32,7 +36,10 @@ export class SentenceTransformersEmbeddings {
     }
 
     try {
-      const result = await this.model(text, {
+      const input = this.queryInstruction
+        ? `${this.queryInstruction}${text}`
+        : text;
+      const result = await this.model(input, {
         pooling: 'mean',
         normalize: true,
       });

--- a/src/tools/documentation/simple-pdf-indexer.ts
+++ b/src/tools/documentation/simple-pdf-indexer.ts
@@ -33,8 +33,17 @@ function getEmbeddings(): SentenceTransformersEmbeddings {
     // Use local sentence-transformers (no API key required)
     log.info('Using local sentence-transformers embeddings');
     const modelName =
-      process.env.SENTENCE_TRANSFORMERS_MODEL || 'Xenova/all-MiniLM-L6-v2';
-    embeddings = new SentenceTransformersEmbeddings({ modelName });
+      process.env.SENTENCE_TRANSFORMERS_MODEL || 'Xenova/bge-small-en-v1.5';
+    // BGE models benefit from a query instruction prefix to align the
+    // embedding space between short questions and longer document passages.
+    // Applied to embedQuery() only; embedDocuments() is unchanged.
+    const queryInstruction = modelName.includes('bge')
+      ? 'Represent this sentence for searching relevant passages: '
+      : '';
+    embeddings = new SentenceTransformersEmbeddings({
+      modelName,
+      queryInstruction,
+    });
     log.info(`Using sentence-transformers model: ${modelName}`);
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
### 1. **RAG eval harness**:

Adds a script to measure retrieval quality before/after RAG changes so improvements are measurable.
- `src/scripts/rag-eval-dataset.json` - 25 realistic user queries (10 easy / 10 medium / 5 vague) mapped to expected source files from the indexed MD files
- `src/scripts/eval-documentation-rag.ts` - runner that queries the existing vector store, deduplicates chunks by source preserving rank, and reports Recall@1/3/5/10 and MRR broken down by difficulty
- To run - `npm run eval-docs` or `npm run eval-docs:save` to save the results


### 2. **Embedding model upgrade**:

Switches the default embedding model from `all-MiniLM-L6-v2` to `Xenova/bge-small-en-v1.5`. BGE was trained specifically on retrieval tasks (asymmetric short-query → long-passage) with hard negatives, making it a better fit than the general-purpose MiniLM.
It increases the initial embedding generation time by 80% but we are planning to cache the embeddings to improve experience, so it should not be an issue.

Eval comparison for these 2 models:

| Bucket        | MiniLM-L6 | BGE-small-v1.5 | Delta |
|----------------|------------|----------------|-------|
| overall R@1    | 0.440      | 0.520          | +0.08 |
| overall R@3    | 0.640      | 0.840          | +0.20 |
| overall R@5    | 0.760      | 0.880          | +0.12 |
| overall MRR    | 0.560      | 0.679          | +0.12 |
| easy MRR       | 0.630      | 0.783          | +0.15 |
| medium MRR     | 0.608      | 0.715          | +0.11 |
| vague MRR      | 0.325      | 0.395          | +0.07 |

To check evals for different models, set the `SENTENCE_TRANSFORMERS_MODEL` env var to that model and run `npm run eval-docs`.

The evals will be useful to compare future changes/additions to the RAG pipeline and documentation query tool.