### PR TITLE
fix: confusing result message

### DIFF
--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -39,7 +39,7 @@ export function textResult(text: string): ContentResult {
 }
 
 /**
- * Canonical first line: machine-parseable `elementId:<value>`, then human-readable detail.
+ * Canonical first line: machine-parseable `elementId '<value>'`, then human-readable detail.
  * Strips newlines from elementId so the first line stays one logical field for parsers.
  */
 export function textResultWithPrimaryElementId(
@@ -48,7 +48,7 @@ export function textResultWithPrimaryElementId(
 ): ContentResult {
   const safeId = sanitizePrimaryElementIdLine(elementId);
   const d = detail.replace(/^\s+/, '');
-  return textResult(`elementId:${safeId}\n${d}`);
+  return textResult(`elementId '${safeId}'\n${d}`);
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/appium/appium-mcp/issues/343

When I played with LLM, LLM confused the `elementId:${safeId}`. So LLM started using the format as "element id" while only the `safeId` part is the element id. This is because the `:` can be used in separator etc as a common use case, so LLM confused that it was also part of such as "element id".

This drops that kind of confusing syntax