### PR TITLE
fix: add appId for Android in queryAppState

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -70,7 +70,7 @@ export async function queryAppState(
   }
   return Number(
     await (driver as Client).executeScript('mobile: queryAppState', [
-      { bundleId: appId },
+      { appId, bundleId: appId },
     ])
   );
 }


### PR DESCRIPTION
Instead of https://github.com/appium/appium-mcp/pull/331... as no responses.

Closes https://github.com/appium/appium-mcp/issues/330

Giving both has no issues. The driver will pick up proper one