### PR TITLE
fix(gestures): clamp direction gestures to window for ai-element targets

### DIFF
--- a/src/tests/tools/gestures/swipe-scroll.test.ts
+++ b/src/tests/tools/gestures/swipe-scroll.test.ts
@@ -1,9 +1,28 @@
-import { describe, test, expect } from '@jest/globals';
-import { parseAiElement } from '../../../tools/gestures/handlers/ai-element.js';
-import {
-  clampDirectionCoordsToWindow,
-  rectVisibleWithinWindow,
-} from '../../../tools/gestures/handlers/swipe-scroll.js';
+import { describe, test, expect, jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../../session-store', () => ({
+  getDriver: jest.fn(),
+  getPlatformName: jest.fn(),
+  PLATFORM: { ios: 'iOS', android: 'Android' },
+}));
+
+jest.unstable_mockModule('../../../command', () => ({
+  execute: jest.fn(),
+  getElementRect: jest.fn(),
+  getWindowRect: jest.fn(),
+  performActions: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../../tools/ai/config', () => ({
+  isAIEnabled: jest.fn(() => false),
+}));
+
+const { parseAiElement } = await import(
+  '../../../tools/gestures/handlers/ai-element.js'
+);
+const { clampDirectionCoordsToWindow, rectVisibleWithinWindow } = await import(
+  '../../../tools/gestures/handlers/swipe-scroll.js'
+);
 
 const PHONE_WINDOW = { x: 0, y: 0, width: 400, height: 800 };
 
@@ -19,7 +38,9 @@ describe('rectVisibleWithinWindow', () => {
     expect(visible.x).toBeGreaterThanOrEqual(0);
     expect(visible.y).toBeGreaterThanOrEqual(0);
     expect(visible.x + visible.width).toBeLessThanOrEqual(PHONE_WINDOW.width);
-    expect(visible.y + visible.height).toBeLessThanOrEqual(PHONE_WINDOW.height);
+    expect(visible.y + visible.height).toBeLessThanOrEqual(
+      PHONE_WINDOW.height
+    );
     expect(visible.width).toBeGreaterThan(0);
     expect(visible.height).toBeGreaterThan(0);
   });

--- a/src/tests/tools/gestures/swipe-scroll.test.ts
+++ b/src/tests/tools/gestures/swipe-scroll.test.ts
@@ -17,12 +17,10 @@ jest.unstable_mockModule('../../../tools/ai/config', () => ({
   isAIEnabled: jest.fn(() => false),
 }));
 
-const { parseAiElement } = await import(
-  '../../../tools/gestures/handlers/ai-element.js'
-);
-const { clampDirectionCoordsToWindow, rectVisibleWithinWindow } = await import(
-  '../../../tools/gestures/handlers/swipe-scroll.js'
-);
+const { parseAiElement } =
+  await import('../../../tools/gestures/handlers/ai-element.js');
+const { clampDirectionCoordsToWindow, rectVisibleWithinWindow } =
+  await import('../../../tools/gestures/handlers/swipe-scroll.js');
 
 const PHONE_WINDOW = { x: 0, y: 0, width: 400, height: 800 };
 
@@ -38,9 +36,7 @@ describe('rectVisibleWithinWindow', () => {
     expect(visible.x).toBeGreaterThanOrEqual(0);
     expect(visible.y).toBeGreaterThanOrEqual(0);
     expect(visible.x + visible.width).toBeLessThanOrEqual(PHONE_WINDOW.width);
-    expect(visible.y + visible.height).toBeLessThanOrEqual(
-      PHONE_WINDOW.height
-    );
+    expect(visible.y + visible.height).toBeLessThanOrEqual(PHONE_WINDOW.height);
     expect(visible.width).toBeGreaterThan(0);
     expect(visible.height).toBeGreaterThan(0);
   });

--- a/src/tests/tools/gestures/swipe-scroll.test.ts
+++ b/src/tests/tools/gestures/swipe-scroll.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from '@jest/globals';
+import { parseAiElement } from '../../../tools/gestures/handlers/ai-element.js';
+import {
+  clampDirectionCoordsToWindow,
+  rectVisibleWithinWindow,
+} from '../../../tools/gestures/handlers/swipe-scroll.js';
+
+const PHONE_WINDOW = { x: 0, y: 0, width: 400, height: 800 };
+
+describe('rectVisibleWithinWindow', () => {
+  test('clips ai-element fallback rect that extends past the left edge', () => {
+    const parsed = parseAiElement('ai-element:42,84');
+    expect('error' in parsed).toBe(false);
+    if ('error' in parsed) {
+      return;
+    }
+
+    const visible = rectVisibleWithinWindow(parsed.rect, PHONE_WINDOW);
+    expect(visible.x).toBeGreaterThanOrEqual(0);
+    expect(visible.y).toBeGreaterThanOrEqual(0);
+    expect(visible.x + visible.width).toBeLessThanOrEqual(PHONE_WINDOW.width);
+    expect(visible.y + visible.height).toBeLessThanOrEqual(PHONE_WINDOW.height);
+    expect(visible.width).toBeGreaterThan(0);
+    expect(visible.height).toBeGreaterThan(0);
+  });
+
+  test('returns a 1x1 rect at clamped centre when fully outside the window', () => {
+    const offScreen = { x: 500, y: 900, width: 100, height: 100 };
+    const visible = rectVisibleWithinWindow(offScreen, PHONE_WINDOW);
+    expect(visible).toEqual({ x: 399, y: 799, width: 1, height: 1 });
+  });
+});
+
+describe('clampDirectionCoordsToWindow', () => {
+  test('clamps swipe endpoints into inclusive window pixel bounds', () => {
+    const clamped = clampDirectionCoordsToWindow(
+      { startX: -20, startY: 900, endX: 500, endY: -10 },
+      PHONE_WINDOW
+    );
+    expect(clamped).toEqual({
+      startX: 0,
+      startY: 799,
+      endX: 399,
+      endY: 0,
+    });
+  });
+
+  test('preserves in-bounds directional coords', () => {
+    const coords = { startX: 200, startY: 600, endX: 200, endY: 200 };
+    expect(clampDirectionCoordsToWindow(coords, PHONE_WINDOW)).toEqual(coords);
+  });
+});

--- a/src/tools/gestures/handlers/swipe-scroll.ts
+++ b/src/tools/gestures/handlers/swipe-scroll.ts
@@ -316,24 +316,24 @@ async function resolveCoords(
       if ('error' in rect) {
         return rect;
       }
-      let targetRect: Rect = {
+      const targetRect: Rect = {
         x: rect.x,
         y: rect.y,
         width: rect.width,
         height: rect.height,
       };
-      if (isAiElementUUID(args.elementUUID)) {
-        const window = await getWindowRect(driver);
-        targetRect = rectVisibleWithinWindow(targetRect, {
-          x: 0,
-          y: 0,
-          width: window.width,
-          height: window.height,
-        });
-        const coords = coordsForDirection(args.direction, targetRect);
-        return clampDirectionCoordsToWindow(coords, window);
+      if (!isAiElementUUID(args.elementUUID)) {
+        return coordsForDirection(args.direction, targetRect);
       }
-      return coordsForDirection(args.direction, targetRect);
+      const window = await getWindowRect(driver);
+      const clippedRect = rectVisibleWithinWindow(targetRect, {
+        x: 0,
+        y: 0,
+        width: window.width,
+        height: window.height,
+      });
+      const coords = coordsForDirection(args.direction, clippedRect);
+      return clampDirectionCoordsToWindow(coords, window);
     }
     const window = await getWindowRect(driver);
     return coordsForDirection(args.direction, {

--- a/src/tools/gestures/handlers/swipe-scroll.ts
+++ b/src/tools/gestures/handlers/swipe-scroll.ts
@@ -218,6 +218,56 @@ export async function handleSwipe(
   }
 }
 
+/**
+ * Clip an element rect to the visible window. Used for ai-element targets whose
+ * bbox or fallback rect can extend past the screenshot edges.
+ */
+export function rectVisibleWithinWindow(elementRect: Rect, window: Rect): Rect {
+  const windowLeft = window.x ?? 0;
+  const windowTop = window.y ?? 0;
+  const windowRight = windowLeft + window.width;
+  const windowBottom = windowTop + window.height;
+
+  const visibleLeft = Math.max(windowLeft, elementRect.x);
+  const visibleTop = Math.max(windowTop, elementRect.y);
+  const visibleRight = Math.min(windowRight, elementRect.x + elementRect.width);
+  const visibleBottom = Math.min(
+    windowBottom,
+    elementRect.y + elementRect.height
+  );
+
+  const width = Math.max(0, visibleRight - visibleLeft);
+  const height = Math.max(0, visibleBottom - visibleTop);
+
+  if (width > 0 && height > 0) {
+    return { x: visibleLeft, y: visibleTop, width, height };
+  }
+
+  const cx = elementRect.x + elementRect.width / 2;
+  const cy = elementRect.y + elementRect.height / 2;
+  return {
+    x: Math.floor(clamp(cx, windowLeft, windowRight - 1)),
+    y: Math.floor(clamp(cy, windowTop, windowBottom - 1)),
+    width: 1,
+    height: 1,
+  };
+}
+
+/** Keep swipe/scroll pointer coords inside the window (inclusive pixel indices). */
+export function clampDirectionCoordsToWindow(
+  coords: Coords,
+  window: { width: number; height: number }
+): Coords {
+  const maxX = Math.max(0, window.width - 1);
+  const maxY = Math.max(0, window.height - 1);
+  return {
+    startX: Math.floor(clamp(coords.startX, 0, maxX)),
+    startY: Math.floor(clamp(coords.startY, 0, maxY)),
+    endX: Math.floor(clamp(coords.endX, 0, maxX)),
+    endY: Math.floor(clamp(coords.endY, 0, maxY)),
+  };
+}
+
 function coordsForDirection(direction: Direction, rect: Rect): Coords {
   const centerX = Math.floor(rect.x + rect.width / 2);
   const centerY = Math.floor(rect.y + rect.height / 2);
@@ -266,12 +316,24 @@ async function resolveCoords(
       if ('error' in rect) {
         return rect;
       }
-      return coordsForDirection(args.direction, {
+      let targetRect: Rect = {
         x: rect.x,
         y: rect.y,
         width: rect.width,
         height: rect.height,
-      });
+      };
+      if (isAiElementUUID(args.elementUUID)) {
+        const window = await getWindowRect(driver);
+        targetRect = rectVisibleWithinWindow(targetRect, {
+          x: 0,
+          y: 0,
+          width: window.width,
+          height: window.height,
+        });
+        const coords = coordsForDirection(args.direction, targetRect);
+        return clampDirectionCoordsToWindow(coords, window);
+      }
+      return coordsForDirection(args.direction, targetRect);
     }
     const window = await getWindowRect(driver);
     return coordsForDirection(args.direction, {
@@ -295,6 +357,10 @@ async function resolveCoords(
     error:
       'Either direction OR custom coordinates (x, y, endX, endY) must be provided.',
   };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 async function performW3CDrag(


### PR DESCRIPTION
directional scroll and swipe on ai-element targets could compute start and end points outside the window when the vision bbox or 100px fallback straddles an edge, this clips the target rect to the window first, then clamps the gesture coordinates
