### PR TITLE
fix(interactions): reject ai-element tokens in get and set tools

### DIFF
--- a/src/tests/tools/gestures/ai-element.test.ts
+++ b/src/tests/tools/gestures/ai-element.test.ts
@@ -13,9 +13,11 @@ jest.unstable_mockModule('../../../command', () => ({
 
 const {
   AI_ELEMENT_PREFIX,
+  AI_WEBDRIVER_REJECTION,
   isAiElementUUID,
   parseAiElement,
   resolveTargetRect,
+  aiElementWebDriverRejectionIfNeeded,
 } = await import('../../../tools/gestures/handlers/ai-element.js');
 
 const fakeDriver = {} as DriverInstance;
@@ -30,6 +32,24 @@ describe('isAiElementUUID', () => {
     expect(isAiElementUUID('11111111-2222-3333-4444-555555555555')).toBe(false);
     expect(isAiElementUUID('')).toBe(false);
     expect(isAiElementUUID(undefined)).toBe(false);
+  });
+});
+
+describe('aiElementWebDriverRejectionIfNeeded', () => {
+  test('returns isError for ai-element UUIDs', () => {
+    const result = aiElementWebDriverRejectionIfNeeded(
+      'ai-element:100,200:50,150,150,250'
+    );
+    expect(result?.isError).toBe(true);
+    const block = result?.content[0];
+    expect(block && 'text' in block && block.text).toBe(AI_WEBDRIVER_REJECTION);
+  });
+
+  test('returns undefined for real element ids and missing values', () => {
+    expect(
+      aiElementWebDriverRejectionIfNeeded('aaaaaaaa-bbbb-cccc-dddd')
+    ).toBeUndefined();
+    expect(aiElementWebDriverRejectionIfNeeded(undefined)).toBeUndefined();
   });
 });
 

--- a/src/tests/tools/interactions/webdriver-ai-element-rejection.test.ts
+++ b/src/tests/tools/interactions/webdriver-ai-element-rejection.test.ts
@@ -5,6 +5,7 @@ jest.unstable_mockModule('../../../session-store.js', () => ({
 }));
 
 jest.unstable_mockModule('../../../command.js', () => ({
+  getElementRect: jest.fn(),
   setValue: jest.fn(),
   getElementText: jest.fn(),
   getElementAttribute: jest.fn(),

--- a/src/tests/tools/interactions/webdriver-ai-element-rejection.test.ts
+++ b/src/tests/tools/interactions/webdriver-ai-element-rejection.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../../../session-store.js', () => ({
+  getDriver: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../../command.js', () => ({
+  setValue: jest.fn(),
+  getElementText: jest.fn(),
+  getElementAttribute: jest.fn(),
+}));
+
+const { getDriver } = await import('../../../session-store.js');
+const { setValue, getElementText, getElementAttribute } =
+  await import('../../../command.js');
+const { AI_WEBDRIVER_REJECTION } =
+  await import('../../../tools/gestures/handlers/ai-element.js');
+
+const mockGetDriver = getDriver as jest.MockedFunction<typeof getDriver>;
+const mockSetValue = setValue as jest.MockedFunction<typeof setValue>;
+const mockGetElementText = getElementText as jest.MockedFunction<
+  typeof getElementText
+>;
+const mockGetElementAttribute = getElementAttribute as jest.MockedFunction<
+  typeof getElementAttribute
+>;
+
+const AI_UUID = 'ai-element:100,200:50,150,150,250';
+const REAL_UUID = '11111111-2222-3333-4444-555555555555';
+
+function textFromResult(result: {
+  content: Array<{ type: string; text?: string }>;
+}): string | undefined {
+  const block = result.content[0];
+  return block && 'text' in block ? block.text : undefined;
+}
+
+describe('interaction tools and ai-element tokens', () => {
+  const mockServer = { addTool: jest.fn() } as any;
+
+  beforeEach(() => {
+    mockGetDriver.mockReturnValue({} as any);
+    mockSetValue.mockReset();
+    mockGetElementText.mockReset();
+    mockGetElementAttribute.mockReset();
+  });
+
+  async function loadTool(
+    modulePath: string
+  ): Promise<{ execute: (...args: any[]) => Promise<any> }> {
+    const mod = await import(modulePath);
+    mod.default(mockServer);
+    return (mockServer.addTool as jest.MockedFunction<any>).mock.calls.at(
+      -1
+    )?.[0];
+  }
+
+  async function runTool(
+    tool: { execute: (...args: any[]) => Promise<any> },
+    args: Record<string, unknown>
+  ) {
+    return tool.execute(args, undefined);
+  }
+
+  test('set_value rejects ai-element without w3cActions', async () => {
+    const tool = await loadTool('../../../tools/interactions/set-value.js');
+    const result = await runTool(tool, { elementUUID: AI_UUID, text: 'hello' });
+
+    expect(result.isError).toBe(true);
+    expect(textFromResult(result)).toBe(AI_WEBDRIVER_REJECTION);
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+
+  test('set_value still works with w3cActions', async () => {
+    const tool = await loadTool('../../../tools/interactions/set-value.js');
+    mockSetValue.mockResolvedValueOnce(undefined);
+    const result = await runTool(tool, {
+      elementUUID: AI_UUID,
+      text: 'hello',
+      w3cActions: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockSetValue).toHaveBeenCalled();
+  });
+
+  test('set_value accepts a normal element id', async () => {
+    const tool = await loadTool('../../../tools/interactions/set-value.js');
+    mockSetValue.mockResolvedValueOnce(undefined);
+    const result = await runTool(tool, {
+      elementUUID: REAL_UUID,
+      text: 'hello',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockSetValue).toHaveBeenCalledWith(
+      expect.anything(),
+      REAL_UUID,
+      'hello',
+      undefined
+    );
+  });
+
+  test('get_text rejects ai-element', async () => {
+    const tool = await loadTool('../../../tools/interactions/get-text.js');
+    const result = await runTool(tool, { elementUUID: AI_UUID });
+
+    expect(result.isError).toBe(true);
+    expect(textFromResult(result)).toBe(AI_WEBDRIVER_REJECTION);
+    expect(mockGetElementText).not.toHaveBeenCalled();
+  });
+
+  test('get_element_attribute rejects ai-element', async () => {
+    const tool = await loadTool(
+      '../../../tools/interactions/get-element-attribute.js'
+    );
+    const result = await runTool(tool, {
+      elementUUID: AI_UUID,
+      attribute: 'enabled',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textFromResult(result)).toBe(AI_WEBDRIVER_REJECTION);
+    expect(mockGetElementAttribute).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/gestures/handlers/ai-element.ts
+++ b/src/tools/gestures/handlers/ai-element.ts
@@ -31,6 +31,11 @@ export const AI_DISABLED_REJECTION =
   `(AI_VISION_ENABLED is not set to true). Use appium_find_element to get a real ` +
   `element UUID, or enable AI_VISION_ENABLED=true with the required AI_VISION_* keys.`;
 
+export const AI_WEBDRIVER_REJECTION =
+  `That is an ai-element token from appium_ai, not a WebDriver element id. ` +
+  `Use appium_gesture to tap it, or appium_find_element for a real id. ` +
+  `To type after a tap, use appium_set_value with w3cActions on the focused field.`;
+
 export type ParsedAiElement = {
   center: { x: number; y: number };
   rect: Rect;
@@ -126,6 +131,19 @@ export async function resolveTargetRect(
 
 export function aiDisabledResult(): ContentResult {
   return errorResult(AI_DISABLED_REJECTION);
+}
+
+export function aiElementWebDriverRejectedResult(): ContentResult {
+  return errorResult(AI_WEBDRIVER_REJECTION);
+}
+
+export function aiElementWebDriverRejectionIfNeeded(
+  elementUUID: string | undefined
+): ContentResult | undefined {
+  if (isAiElementUUID(elementUUID)) {
+    return aiElementWebDriverRejectedResult();
+  }
+  return undefined;
 }
 
 function rectAroundCenter(cx: number, cy: number): Rect {

--- a/src/tools/interactions/get-element-attribute.ts
+++ b/src/tools/interactions/get-element-attribute.ts
@@ -8,6 +8,7 @@ import {
   errorResult,
   toolErrorMessage,
 } from '../tool-response.js';
+import { aiElementWebDriverRejectionIfNeeded } from '../gestures/handlers/ai-element.js';
 
 export default function getElementAttributeTool(server: FastMCP): void {
   const schema = z.object({
@@ -41,6 +42,11 @@ export default function getElementAttributeTool(server: FastMCP): void {
         return resolved.result;
       }
       const { driver } = resolved;
+
+      const aiRejection = aiElementWebDriverRejectionIfNeeded(args.elementUUID);
+      if (aiRejection) {
+        return aiRejection;
+      }
 
       try {
         const value = await getElementAttribute(

--- a/src/tools/interactions/get-text.ts
+++ b/src/tools/interactions/get-text.ts
@@ -8,6 +8,7 @@ import {
   errorResult,
   toolErrorMessage,
 } from '../tool-response.js';
+import { aiElementWebDriverRejectionIfNeeded } from '../gestures/handlers/ai-element.js';
 
 export default function getText(server: FastMCP): void {
   const getTextSchema = z.object({
@@ -35,6 +36,11 @@ export default function getText(server: FastMCP): void {
         return resolved.result;
       }
       const { driver } = resolved;
+
+      const aiRejection = aiElementWebDriverRejectionIfNeeded(args.elementUUID);
+      if (aiRejection) {
+        return aiRejection;
+      }
 
       try {
         const text = await getElementText(driver, args.elementUUID);

--- a/src/tools/interactions/set-value.ts
+++ b/src/tools/interactions/set-value.ts
@@ -9,6 +9,7 @@ import {
   errorResult,
   toolErrorMessage,
 } from '../tool-response.js';
+import { aiElementWebDriverRejectionIfNeeded } from '../gestures/handlers/ai-element.js';
 
 export default function setValue(server: FastMCP): void {
   const setValueSchema = z
@@ -49,6 +50,15 @@ export default function setValue(server: FastMCP): void {
         return resolved.result;
       }
       const { driver } = resolved;
+
+      if (!args.w3cActions) {
+        const aiRejection = aiElementWebDriverRejectionIfNeeded(
+          args.elementUUID
+        );
+        if (aiRejection) {
+          return aiRejection;
+        }
+      }
 
       try {
         await _setValue(


### PR DESCRIPTION
block ai-element vision tokens in appium_set_value, appium_get_text, and appium_get_element_attribute before they hit WebDriver APIs, return a short error that tells the agent to tap with appium_gesture, find a real id, or use w3cActions after focus
set_value with w3cActions still works