### PR TITLE
feat(rag): update evals to use answer spans

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "index-docs": "node dist/scripts/simple-index-documentation.js",
     "query-docs": "node dist/scripts/simple-query-documentation.js",
     "eval-docs": "node dist/scripts/eval-documentation-rag.js",
-    "eval-docs:save": "node dist/scripts/eval-documentation-rag.js --save",
     "generate-cache": "node dist/scripts/generate-embeddings-cache.js",
     "prepublishOnly": "npm run build && npm run generate-cache",
     "sync-version": "node scripts/sync-version.mjs",

--- a/src/scripts/eval-documentation-rag.ts
+++ b/src/scripts/eval-documentation-rag.ts
@@ -1,23 +1,50 @@
 /**
- * RAG retrieval eval harness for the Appium documentation tool.
+ * Answer-grounded RAG eval for the Appium documentation tool.
+ *
+ * Runs the documentation_query retrieval pipeline against a fixed set of
+ * realistic queries and asks the only question that matters downstream:
+ * "did the answer text actually land in the chunks an LLM would see?"
+ *
+ * What we measure:
+ *
+ *   1. answerSpanRecall@K
+ *      For each query, the dataset declares short verbatim phrases lifted
+ *      from the docs (`answerSpans`). We concatenate the top-K retrieved
+ *      chunks and check what fraction of the spans appears in that text.
+ *      "anyOf" semantics: a query that finds at least one span counts as a
+ *      hit. Spans are 30-140 chars and chosen so any reasonable chunk
+ *      containing the answer will include them, regardless of chunk
+ *      boundaries -- so the metric is splitter-neutral.
+ *
+ *   2. hit@{1,3,5,10}
+ *      Did any chunk at rank <= K carry any answerSpan? Direct measure of
+ *      "does the LLM see the answer" at different context budgets.
+ *
+ *   3. MRR
+ *      Mean reciprocal rank of the *first* chunk that carries an answerSpan.
+ *      MRR-equivalent on content, not on file paths -- a chunk from the
+ *      right file but wrong section is worth nothing here.
+ *
+ *   4. contextEfficiency
+ *      For queries we hit, 1000 * spansCovered / totalChars(topK). Spans-per-
+ *      kchar density. Low = lots of noise around the answer.
+ *
+ *   5. fileRecall@{5,10} (diagnostic only)
+ *      Did the right *file* appear in top-K? Kept so we can spot the
+ *      "right-file wrong-chunk" failure mode (right file present but no
+ *      answerSpan landed).
+ *
+ * Match semantics: lowercase + collapse whitespace, then substring check.
  *
  * Usage (after `npm run build`):
- *   node dist/scripts/eval-documentation-rag.js [--quiet] [--save] [--top-chunks=N]
+ *   node dist/scripts/eval-documentation-rag.js \
+ *        [--top-k=10] [--label=NAME] [--quiet] [--no-save]
  *
- * What it does:
- *   1. Loads the eval dataset (src/scripts/rag-eval-dataset.json).
- *   2. For each query, calls the existing queryVectorStore() with `topChunks`
- *      chunks (default 30), dedupes by source (preserving rank), and matches
- *      the resulting source list against expectedSources.
- *   3. Reports Recall@{1,3,5,10} and MRR, broken down by difficulty.
- *   4. Persists results to src/scripts/eval-results/<ISO>.json plus a
- *      `latest.json` so successive runs can be diffed.
- *
- * Notes:
- *   - The first run after a server restart pays the embedding cold start
- *     (~30-60s for the current corpus).
- *   - Match strategy: a retrieved source matches an expected source if its
- *     `relativePath` ends with the expected path (case-sensitive).
+ *   --top-k=N    number of chunks to retrieve & evaluate (default 10)
+ *   --label=N    label written into the saved run, useful for comparing
+ *                index variants (e.g. --label=before, --label=after)
+ *   --quiet      suppress the per-query log lines and table
+ *   --no-save    don't persist results JSON to disk
  */
 
 import * as fs from 'node:fs';
@@ -30,6 +57,7 @@ interface EvalQuery {
   id: string;
   query: string;
   expectedSources: string[];
+  answerSpans: string[];
   difficulty: 'easy' | 'medium' | 'vague';
   category?: string;
 }
@@ -37,8 +65,16 @@ interface EvalQuery {
 interface EvalDataset {
   version: number;
   description: string;
-  matchMode?: 'endsWith' | 'exact';
+  matchMode: string;
+  spanMatch?: { normalize: string; anyOf: boolean };
   queries: EvalQuery[];
+}
+
+interface RetrievedChunk {
+  rank: number;
+  text: string;
+  source: string | undefined;
+  charCount: number;
 }
 
 interface PerQueryResult {
@@ -47,46 +83,78 @@ interface PerQueryResult {
   difficulty: EvalQuery['difficulty'];
   category?: string;
   expectedSources: string[];
+  answerSpans: string[];
   retrievedSources: string[];
-  matchedAtRank: number | null;
-  matchedSource: string | null;
-  recallAt1: 0 | 1;
-  recallAt3: 0 | 1;
-  recallAt5: 0 | 1;
-  recallAt10: 0 | 1;
+  topKChunks: number;
+  topKChars: number;
+  uniqueFiles: number;
+
+  // Per-rank tracking: which ranks contain at least one answerSpan, and which
+  // chunk first carried each individual span. Lets us derive recall@K cheaply.
+  hitRanks: number[];
+  firstHitRank: number | null;
+  spansCovered: string[];
+  spansMissing: string[];
+
+  // Aggregates: per definitions in module docstring.
+  answerSpanRecall: number;
+  hitAnyAt1: 0 | 1;
+  hitAnyAt3: 0 | 1;
+  hitAnyAt5: 0 | 1;
+  hitAnyAt10: 0 | 1;
   reciprocalRank: number;
+  contextEfficiency: number; // spans/kchar; only meaningful when hitAny=1
+
+  // Diagnostic: right-file recall (independent of whether the answer span
+  // actually landed). Useful for spotting "right file, wrong section" cases.
+  fileRecallAt5: 0 | 1;
+  fileRecallAt10: 0 | 1;
 }
 
 interface AggregateMetrics {
   count: number;
-  recallAt1: number;
-  recallAt3: number;
-  recallAt5: number;
-  recallAt10: number;
+  answerSpanRecall: number;
+  hitAnyAt1: number;
+  hitAnyAt3: number;
+  hitAnyAt5: number;
+  hitAnyAt10: number;
   mrr: number;
+  contextEfficiency: number; // averaged over queries with a hit
+  fileRecallAt5: number;
+  fileRecallAt10: number;
 }
 
 interface EvalRun {
   timestamp: string;
+  label: string;
   datasetVersion: number;
-  topChunks: number;
+  topK: number;
   overall: AggregateMetrics;
   byDifficulty: Record<string, AggregateMetrics>;
   perQuery: PerQueryResult[];
 }
 
+// -- arg parsing ----------------------------------------------------------
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const args = new Set(process.argv.slice(2));
-const QUIET = args.has('--quiet');
-const NO_SAVE = !args.has('--save');
-const topChunksArg = process.argv.find((a) => a.startsWith('--top-chunks='));
-const TOP_CHUNKS = topChunksArg ? Number(topChunksArg.split('=')[1]) : 30;
+const args = process.argv.slice(2);
+const flagSet = new Set(args);
+const QUIET = flagSet.has('--quiet');
+const NO_SAVE = flagSet.has('--no-save');
+
+function flagValue(name: string, dflt: string): string {
+  const a = args.find((x) => x.startsWith(`${name}=`));
+  return a ? a.split('=').slice(1).join('=') : dflt;
+}
+
+const TOP_K = Number(flagValue('--top-k', '10'));
+const LABEL = flagValue('--label', 'default');
+
+// -- paths ----------------------------------------------------------------
 
 function resolveDatasetPath(): string {
-  // When compiled, this file lives in dist/scripts/. We look for the dataset
-  // beside it first (copy-docs build step), then fall back to src/scripts/.
   const candidates = [
     path.resolve(__dirname, 'rag-eval-dataset.json'),
     path.resolve(__dirname, '../../src/scripts/rag-eval-dataset.json'),
@@ -97,126 +165,134 @@ function resolveDatasetPath(): string {
     }
   }
   throw new Error(
-    `Could not find rag-eval-dataset.json in any of: ${candidates.join(', ')}`
+    `rag-eval-dataset.json not found in: ${candidates.join(', ')}`
   );
 }
 
 function resolveResultsDir(): string {
-  // Always write results into the source tree so they're easy to diff/commit.
-  const candidates = [
-    path.resolve(__dirname, '../../src/scripts/eval-results'),
-    path.resolve(__dirname, 'eval-results'),
-  ];
-  const dir = candidates[0];
+  const dir = path.resolve(__dirname, '../../src/scripts/eval-results');
   fs.mkdirSync(dir, { recursive: true });
   return dir;
 }
 
-function matches(retrievedRelPath: string, expected: string): boolean {
+// -- matching helpers -----------------------------------------------------
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function chunkContainsSpan(chunkText: string, span: string): boolean {
+  return normalize(chunkText).includes(normalize(span));
+}
+
+function endsWithExpected(retrievedRelPath: string, expected: string): boolean {
   return retrievedRelPath === expected || retrievedRelPath.endsWith(expected);
 }
 
-function dedupeBySource(
-  chunks: Array<{ relativePath: string | undefined }>
-): string[] {
-  const seen = new Set<string>();
-  const ordered: string[] = [];
-  for (const c of chunks) {
-    const src = c.relativePath;
-    if (!src || seen.has(src)) {
-      continue;
+// -- per-query evaluation -------------------------------------------------
+
+function evaluateQuery(
+  q: EvalQuery,
+  chunks: RetrievedChunk[]
+): {
+  hitRanks: number[];
+  firstHitRank: number | null;
+  spansCovered: string[];
+  spansMissing: string[];
+} {
+  const hitRanks: number[] = [];
+  const spansCovered = new Set<string>();
+
+  for (const chunk of chunks) {
+    let chunkHadHit = false;
+    for (const span of q.answerSpans) {
+      if (chunkContainsSpan(chunk.text, span)) {
+        spansCovered.add(span);
+        chunkHadHit = true;
+      }
     }
-    seen.add(src);
-    ordered.push(src);
+    if (chunkHadHit) {
+      hitRanks.push(chunk.rank);
+    }
   }
-  return ordered;
+  const firstHitRank = hitRanks.length > 0 ? hitRanks[0] : null;
+  const spansMissing = q.answerSpans.filter((s) => !spansCovered.has(s));
+  return {
+    hitRanks,
+    firstHitRank,
+    spansCovered: [...spansCovered],
+    spansMissing,
+  };
 }
 
-function evalQuery(
-  retrievedSources: string[],
-  expectedSources: string[]
-): {
-  matchedAtRank: number | null;
-  matchedSource: string | null;
-} {
-  for (let i = 0; i < retrievedSources.length; i++) {
-    const hit = expectedSources.find((e) => matches(retrievedSources[i], e));
-    if (hit) {
-      return { matchedAtRank: i + 1, matchedSource: retrievedSources[i] };
-    }
-  }
-  return { matchedAtRank: null, matchedSource: null };
-}
+// -- aggregation ----------------------------------------------------------
 
 function aggregate(results: PerQueryResult[]): AggregateMetrics {
   if (results.length === 0) {
     return {
       count: 0,
-      recallAt1: 0,
-      recallAt3: 0,
-      recallAt5: 0,
-      recallAt10: 0,
+      answerSpanRecall: 0,
+      hitAnyAt1: 0,
+      hitAnyAt3: 0,
+      hitAnyAt5: 0,
+      hitAnyAt10: 0,
       mrr: 0,
+      contextEfficiency: 0,
+      fileRecallAt5: 0,
+      fileRecallAt10: 0,
     };
   }
   const n = results.length;
-  const sum = (k: keyof PerQueryResult): number =>
-    results.reduce((acc, r) => acc + (r[k] as number), 0);
+  const mean = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const hitResults = results.filter((r) => r.hitAnyAt10 === 1);
   return {
     count: n,
-    recallAt1: sum('recallAt1') / n,
-    recallAt3: sum('recallAt3') / n,
-    recallAt5: sum('recallAt5') / n,
-    recallAt10: sum('recallAt10') / n,
-    mrr: sum('reciprocalRank') / n,
+    answerSpanRecall: mean(results.map((r) => r.answerSpanRecall)),
+    hitAnyAt1: mean(results.map((r) => r.hitAnyAt1)),
+    hitAnyAt3: mean(results.map((r) => r.hitAnyAt3)),
+    hitAnyAt5: mean(results.map((r) => r.hitAnyAt5)),
+    hitAnyAt10: mean(results.map((r) => r.hitAnyAt10)),
+    mrr: mean(results.map((r) => r.reciprocalRank)),
+    contextEfficiency: hitResults.length
+      ? mean(hitResults.map((r) => r.contextEfficiency))
+      : 0,
+    fileRecallAt5: mean(results.map((r) => r.fileRecallAt5)),
+    fileRecallAt10: mean(results.map((r) => r.fileRecallAt10)),
   };
 }
 
-function fmt(n: number): string {
-  return n.toFixed(3);
-}
-
-function rankStr(rank: number | null): string {
-  return rank === null ? ' - ' : String(rank).padStart(3, ' ');
-}
-
-function printPerQueryTable(results: PerQueryResult[]): void {
-  const rows = results.map((r) => ({
-    id: r.id,
-    diff: r.difficulty,
-    rank: rankStr(r.matchedAtRank),
-    query: r.query.length > 56 ? r.query.slice(0, 53) + '...' : r.query,
-    matched: r.matchedSource ?? '(none of expected found in top results)',
-  }));
-
-  const widths = {
-    id: 4,
-    diff: 7,
-    rank: 4,
-    query: Math.max(...rows.map((r) => r.query.length), 5),
-    matched: Math.max(...rows.map((r) => r.matched.length), 7),
-  };
-
-  const header = `${'id'.padEnd(widths.id)} | ${'diff'.padEnd(widths.diff)} | ${'rank'.padStart(widths.rank)} | ${'query'.padEnd(widths.query)} | matched`;
-  const sep = '-'.repeat(header.length + 10);
-
-  console.log(sep);
-  console.log(header);
-  console.log(sep);
-  for (const r of rows) {
-    console.log(
-      `${r.id.padEnd(widths.id)} | ${r.diff.padEnd(widths.diff)} | ${r.rank.padStart(widths.rank)} | ${r.query.padEnd(widths.query)} | ${r.matched}`
-    );
-  }
-  console.log(sep);
+function fmt(n: number, dp: number = 3): string {
+  return n.toFixed(dp);
 }
 
 function printAggregate(label: string, m: AggregateMetrics): void {
   const tag = `${label} (n=${m.count})`.padEnd(20);
   console.log(
-    `${tag}  R@1=${fmt(m.recallAt1)}  R@3=${fmt(m.recallAt3)}  R@5=${fmt(m.recallAt5)}  R@10=${fmt(m.recallAt10)}  MRR=${fmt(m.mrr)}`
+    `${tag}  spanRecall=${fmt(m.answerSpanRecall)}  hit@1=${fmt(m.hitAnyAt1)}  hit@3=${fmt(m.hitAnyAt3)}  hit@5=${fmt(m.hitAnyAt5)}  hit@10=${fmt(m.hitAnyAt10)}  MRR=${fmt(m.mrr)}  ctxEff=${fmt(m.contextEfficiency, 2)}  fileR@5=${fmt(m.fileRecallAt5)}`
   );
 }
+
+function printPerQueryTable(results: PerQueryResult[]): void {
+  const header = 'id   | diff   | fhr | spans  | hit@5 | unique | sources';
+  const sep = '-'.repeat(110);
+  console.log(sep);
+  console.log(header);
+  console.log(sep);
+  for (const r of results) {
+    const fhr =
+      r.firstHitRank === null ? ' - ' : String(r.firstHitRank).padStart(3, ' ');
+    const spans = `${r.spansCovered.length}/${r.answerSpans.length}`;
+    const matched = r.retrievedSources[0]
+      ? r.retrievedSources.slice(0, 2).join(', ')
+      : '(empty)';
+    console.log(
+      `${r.id.padEnd(4)} | ${r.difficulty.padEnd(6)} | ${fhr} | ${spans.padEnd(6)} | ${String(r.hitAnyAt5).padEnd(5)} | ${String(r.uniqueFiles).padEnd(6)} | ${matched}`
+    );
+  }
+  console.log(sep);
+}
+
+// -- main -----------------------------------------------------------------
 
 async function runEval(): Promise<void> {
   const datasetPath = resolveDatasetPath();
@@ -224,31 +300,55 @@ async function runEval(): Promise<void> {
     fs.readFileSync(datasetPath, 'utf-8')
   );
 
-  if (!QUIET) {
-    console.log(`\n=== Appium RAG eval ===`);
-    console.log(`Dataset: ${datasetPath}`);
-    console.log(
-      `Queries: ${dataset.queries.length}   |   topChunks: ${TOP_CHUNKS}   |   match: endsWith\n`
-    );
-  }
+  console.log(`\n=== Appium RAG eval (answer-grounded) ===`);
+  console.log(`Dataset: ${datasetPath}`);
+  console.log(
+    `Queries: ${dataset.queries.length}   topK: ${TOP_K}   label: ${LABEL}\n`
+  );
 
   const perQuery: PerQueryResult[] = [];
 
   for (const q of dataset.queries) {
-    const docs = await queryVectorStore(q.query, TOP_CHUNKS);
-    const retrievedSources = dedupeBySource(
-      docs.map((d) => ({
-        relativePath:
-          (d.metadata?.relativePath as string | undefined) ??
-          (d.metadata?.filename as string | undefined) ??
-          (d.metadata?.source as string | undefined),
-      }))
-    );
+    const docs = await queryVectorStore(q.query, TOP_K);
+    const chunks: RetrievedChunk[] = docs.map((d, i) => ({
+      rank: i + 1,
+      text: d.pageContent,
+      source:
+        (d.metadata?.relativePath as string | undefined) ??
+        (d.metadata?.filename as string | undefined),
+      charCount: d.pageContent.length,
+    }));
 
-    const { matchedAtRank, matchedSource } = evalQuery(
-      retrievedSources,
-      q.expectedSources
-    );
+    const retrievedSources = chunks
+      .map((c) => c.source)
+      .filter((s): s is string => !!s);
+
+    const topKChars = chunks.reduce((a, c) => a + c.charCount, 0);
+    const uniqueFiles = new Set(retrievedSources).size;
+
+    const { hitRanks, firstHitRank, spansCovered, spansMissing } =
+      evaluateQuery(q, chunks);
+
+    const answerSpanRecall =
+      q.answerSpans.length === 0
+        ? 0
+        : spansCovered.length / q.answerSpans.length;
+    const hitAnyAt = (k: number): 0 | 1 =>
+      hitRanks.some((r) => r <= k) ? 1 : 0;
+    const reciprocalRank = firstHitRank ? 1 / firstHitRank : 0;
+    const contextEfficiency =
+      firstHitRank !== null && topKChars > 0
+        ? (1000 * spansCovered.length) / topKChars
+        : 0;
+
+    const fileMatched = (k: number): 0 | 1 => {
+      const top = retrievedSources.slice(0, k);
+      return top.some((rs) =>
+        q.expectedSources.some((es) => endsWithExpected(rs, es))
+      )
+        ? 1
+        : 0;
+    };
 
     perQuery.push({
       id: q.id,
@@ -256,15 +356,32 @@ async function runEval(): Promise<void> {
       difficulty: q.difficulty,
       category: q.category,
       expectedSources: q.expectedSources,
+      answerSpans: q.answerSpans,
       retrievedSources,
-      matchedAtRank,
-      matchedSource,
-      recallAt1: matchedAtRank !== null && matchedAtRank <= 1 ? 1 : 0,
-      recallAt3: matchedAtRank !== null && matchedAtRank <= 3 ? 1 : 0,
-      recallAt5: matchedAtRank !== null && matchedAtRank <= 5 ? 1 : 0,
-      recallAt10: matchedAtRank !== null && matchedAtRank <= 10 ? 1 : 0,
-      reciprocalRank: matchedAtRank !== null ? 1 / matchedAtRank : 0,
+      topKChunks: chunks.length,
+      topKChars,
+      uniqueFiles,
+      hitRanks,
+      firstHitRank,
+      spansCovered,
+      spansMissing,
+      answerSpanRecall,
+      hitAnyAt1: hitAnyAt(1),
+      hitAnyAt3: hitAnyAt(3),
+      hitAnyAt5: hitAnyAt(5),
+      hitAnyAt10: hitAnyAt(10),
+      reciprocalRank,
+      contextEfficiency,
+      fileRecallAt5: fileMatched(5),
+      fileRecallAt10: fileMatched(10),
     });
+
+    if (!QUIET) {
+      const status = hitAnyAt(5) ? 'OK' : 'MISS';
+      console.log(
+        `${status.padEnd(4)} ${q.id}  spans=${spansCovered.length}/${q.answerSpans.length}  fhr=${firstHitRank ?? '-'}`
+      );
+    }
   }
 
   if (!QUIET) {
@@ -287,19 +404,23 @@ async function runEval(): Promise<void> {
   if (!NO_SAVE) {
     const run: EvalRun = {
       timestamp: new Date().toISOString(),
+      label: LABEL,
       datasetVersion: dataset.version,
-      topChunks: TOP_CHUNKS,
+      topK: TOP_K,
       overall,
       byDifficulty,
       perQuery,
     };
     const dir = resolveResultsDir();
     const stamp = run.timestamp.replace(/[:.]/g, '-');
-    const outPath = path.join(dir, `${stamp}.json`);
+    const outPath = path.join(dir, `${LABEL}-${stamp}.json`);
+    const labelLatestPath = path.join(dir, `${LABEL}-latest.json`);
     const latestPath = path.join(dir, 'latest.json');
     fs.writeFileSync(outPath, JSON.stringify(run, null, 2));
+    fs.writeFileSync(labelLatestPath, JSON.stringify(run, null, 2));
     fs.writeFileSync(latestPath, JSON.stringify(run, null, 2));
     console.log(`Saved: ${path.relative(process.cwd(), outPath)}`);
+    console.log(`       ${path.relative(process.cwd(), labelLatestPath)}`);
     console.log(`       ${path.relative(process.cwd(), latestPath)}\n`);
   }
 }

--- a/src/scripts/rag-eval-dataset.json
+++ b/src/scripts/rag-eval-dataset.json
@@ -1,40 +1,76 @@
 {
   "version": 1,
-  "description": "Realistic user queries for the Appium documentation RAG tool. Each query maps to one or more source files that should appear in the retrieved sources (substring match against the chunk's relativePath metadata). Difficulty buckets: easy (specific terms that should be near-trivial to retrieve), medium (real-world phrasing), vague (natural human phrasing with less direct cues).",
-  "matchMode": "endsWith",
+  "description": "Answer-grounded RAG eval dataset for the Appium documentation tool. Each query has (a) expectedSources: file paths kept for diagnostic file-level recall, and (b) answerSpans: short verbatim phrases lifted from the docs; if ANY one appears in the retrieved top-K chunk text, the query counts as the answer reaching the LLM context. Whitespace is normalized (runs collapse to single space; case-insensitive) before matching. Spans are deliberately short (30-140 chars) so any reasonable chunk containing the answer will include at least one.",
+  "matchMode": "answerSpan",
+  "spanMatch": {
+    "normalize": "lowercase+collapse-whitespace",
+    "anyOf": true
+  },
   "queries": [
     {
       "id": "q01",
       "query": "How do I install Appium?",
-      "expectedSources": ["appium/quickstart/install.md"],
+      "expectedSources": ["en/quickstart/install.md"],
+      "answerSpans": [
+        "Appium can be installed globally using `npm`",
+        "npm install -g appium"
+      ],
       "difficulty": "easy",
       "category": "setup"
     },
     {
       "id": "q02",
       "query": "What capabilities does the XCUITest driver support?",
-      "expectedSources": ["appium-xcuitest-driver/reference/capabilities.md"],
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/reference/capabilities.md"
+      ],
+      "answerSpans": [
+        "platformName",
+        "appium:automationName",
+        "appium:deviceName",
+        "appium:platformVersion"
+      ],
       "difficulty": "easy",
       "category": "capabilities"
     },
     {
       "id": "q03",
       "query": "how to run iOS tests in parallel",
-      "expectedSources": ["appium-xcuitest-driver/guides/parallel-tests.md"],
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/guides/parallel-tests.md"
+      ],
+      "answerSpans": [
+        "It is possible to execute tests in parallel using XCUITest driver",
+        "wdaLocalPort` must be a unique port number for each parallel session",
+        "must be a unique device UDID for each parallel session"
+      ],
       "difficulty": "easy",
       "category": "ios"
     },
     {
       "id": "q04",
       "query": "push and pull files from an iOS device",
-      "expectedSources": ["appium-xcuitest-driver/guides/file-transfer.md"],
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/guides/file-transfer.md"
+      ],
+      "answerSpans": [
+        "mobile: pullFile",
+        "mobile: pushFile",
+        "mobile: pullFolder"
+      ],
       "difficulty": "easy",
       "category": "ios"
     },
     {
       "id": "q05",
       "query": "read and write the clipboard on iOS",
-      "expectedSources": ["appium-xcuitest-driver/guides/clipboard.md"],
+      "expectedSources": ["appium-xcuitest-driver/docs/guides/clipboard.md"],
+      "answerSpans": [
+        "WebDriverAgentRunner application must be in foreground",
+        "mobile: getPasteboard",
+        "mobile: setPasteboard",
+        "driver.get_clipboard"
+      ],
       "difficulty": "easy",
       "category": "ios"
     },
@@ -42,7 +78,13 @@
       "id": "q06",
       "query": "what locator strategies are supported by XCUITest",
       "expectedSources": [
-        "appium-xcuitest-driver/reference/locator-strategies.md"
+        "appium-xcuitest-driver/docs/reference/locator-strategies.md"
+      ],
+      "answerSpans": [
+        "-ios predicate string",
+        "-ios class chain",
+        "accessibility id",
+        "className"
       ],
       "difficulty": "easy",
       "category": "locators"
@@ -50,21 +92,47 @@
     {
       "id": "q07",
       "query": "how do I use iOS predicate strings to find elements",
-      "expectedSources": ["appium-xcuitest-driver/reference/ios-predicate.md"],
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/reference/ios-predicate.md"
+      ],
+      "answerSpans": [
+        "iOSNsPredicateString",
+        "BEGINSWITH",
+        "CONTAINS",
+        "predicate string example would select all visible elements"
+      ],
       "difficulty": "easy",
       "category": "locators"
     },
     {
       "id": "q08",
       "query": "uiautomator2 driver capabilities",
-      "expectedSources": ["appium-uiautomator2-driver/capability-sets.md"],
+      "expectedSources": [
+        "appium-uiautomator2-driver/docs/capability-sets.md",
+        "appium-uiautomator2-driver/docs/README.md"
+      ],
+      "answerSpans": [
+        "appium:automationName\": \"uiautomator2",
+        "platformName\": \"Android",
+        "appium:appPackage",
+        "appium:appActivity"
+      ],
       "difficulty": "easy",
       "category": "android"
     },
     {
       "id": "q09",
       "query": "Appium server command line arguments",
-      "expectedSources": ["appium/cli/args.md"],
+      "expectedSources": [
+        "en/reference/cli/server.md",
+        "en/reference/cli/index.md"
+      ],
+      "answerSpans": [
+        "--address",
+        "--allow-cors",
+        "--allow-insecure",
+        "--base-path"
+      ],
       "difficulty": "easy",
       "category": "cli"
     },
@@ -72,19 +140,25 @@
       "id": "q10",
       "query": "install a root certificate on an iOS device",
       "expectedSources": [
-        "appium-xcuitest-driver/guides/install-certificate.md"
+        "appium-xcuitest-driver/docs/guides/install-certificate.md"
       ],
+      "answerSpans": ["mobile: installCertificate", "over-the-air"],
       "difficulty": "easy",
       "category": "ios"
     },
-
     {
       "id": "q11",
       "query": "I'm new to Appium, where should I start?",
       "expectedSources": [
-        "appium/quickstart/index.md",
-        "appium/intro/index.md",
-        "appium/quickstart/requirements.md"
+        "en/quickstart/index.md",
+        "en/intro/index.md",
+        "en/quickstart/requirements.md"
+      ],
+      "answerSpans": [
+        "Quickstart Intro",
+        "install Appium",
+        "install a driver",
+        "first test"
       ],
       "difficulty": "medium",
       "category": "intro"
@@ -93,10 +167,11 @@
       "id": "q12",
       "query": "which driver should I use to automate android",
       "expectedSources": [
-        "appium/quickstart/uiauto2-driver.md",
-        "appium/intro/drivers.md",
-        "appium/ecosystem/drivers.md"
+        "en/quickstart/uiauto2-driver.md",
+        "en/intro/drivers.md",
+        "en/ecosystem/drivers.md"
       ],
+      "answerSpans": ["UiAutomator2", "appium driver install uiautomator2"],
       "difficulty": "medium",
       "category": "android"
     },
@@ -104,8 +179,14 @@
       "id": "q13",
       "query": "how do I switch to a webview in an iOS hybrid app",
       "expectedSources": [
-        "appium-xcuitest-driver/guides/hybrid.md",
-        "appium/guides/context.md"
+        "appium-xcuitest-driver/docs/guides/hybrid.md",
+        "en/guides/context.md"
+      ],
+      "answerSpans": [
+        "WEBVIEW_",
+        "NATIVE_APP",
+        "Retrieve the currently available contexts",
+        "Set the id of the context"
       ],
       "difficulty": "medium",
       "category": "hybrid"
@@ -114,9 +195,14 @@
       "id": "q14",
       "query": "how to set up code signing for real iPhone testing",
       "expectedSources": [
-        "appium-xcuitest-driver/preparation/real-device-config.md",
-        "appium-xcuitest-driver/preparation/prov-profile-basic-auto.md",
-        "appium-xcuitest-driver/preparation/prov-profile-basic-manual.md"
+        "appium-xcuitest-driver/docs/preparation/real-device-config.md",
+        "appium-xcuitest-driver/docs/preparation/prov-profile-basic-auto.md",
+        "appium-xcuitest-driver/docs/preparation/prov-profile-basic-manual.md"
+      ],
+      "answerSpans": [
+        "WDA application must have a valid provisioning profile",
+        "Apple ID",
+        "WebDriverAgent.xcodeproj"
       ],
       "difficulty": "medium",
       "category": "ios-real-device"
@@ -125,29 +211,43 @@
       "id": "q15",
       "query": "swipe gesture on android",
       "expectedSources": [
-        "appium-uiautomator2-driver/android-mobile-gestures.md"
+        "appium-uiautomator2-driver/docs/android-mobile-gestures.md"
       ],
+      "answerSpans": ["mobile: swipeGesture", "direction", "percent"],
       "difficulty": "medium",
       "category": "gestures"
     },
     {
       "id": "q16",
       "query": "running tests against an .aab Android App Bundle",
-      "expectedSources": ["appium-uiautomator2-driver/android-appbundle.md"],
+      "expectedSources": [
+        "appium-uiautomator2-driver/docs/android-appbundle.md"
+      ],
+      "answerSpans": ["bundletool", ".apks", ".aab"],
       "difficulty": "medium",
       "category": "android"
     },
     {
       "id": "q17",
       "query": "differences between Appium 1 and Appium 2",
-      "expectedSources": ["appium/guides/migrating-1-to-2.md"],
+      "expectedSources": ["en/guides/migrating-1-to-2.md"],
+      "answerSpans": [
+        "Drivers Installed Separately",
+        "ecosystem",
+        "uninstall Appium 1 first"
+      ],
       "difficulty": "medium",
       "category": "migration"
     },
     {
       "id": "q18",
       "query": "enable Touch ID in an iOS simulator test",
-      "expectedSources": ["appium-xcuitest-driver/guides/touch-id.md"],
+      "expectedSources": ["appium-xcuitest-driver/docs/guides/touch-id.md"],
+      "answerSpans": [
+        "appium:allowTouchIdEnroll",
+        "mobile: enrollBiometric",
+        "only supported on simulators"
+      ],
       "difficulty": "medium",
       "category": "ios"
     },
@@ -155,26 +255,35 @@
       "id": "q19",
       "query": "use a custom WebDriverAgent server",
       "expectedSources": [
-        "appium-xcuitest-driver/guides/wda-custom-server.md",
-        "appium-xcuitest-driver/guides/run-prebuilt-wda.md"
+        "appium-xcuitest-driver/docs/guides/wda-custom-server.md",
+        "appium-xcuitest-driver/docs/guides/run-prebuilt-wda.md",
+        "appium-xcuitest-driver/docs/guides/run-preinstalled-wda.md",
+        "appium-xcuitest-driver/docs/guides/attach-to-running-wda.md"
       ],
+      "answerSpans": ["appium:webDriverAgentUrl", "WebDriverAgent"],
       "difficulty": "medium",
       "category": "wda"
     },
     {
       "id": "q20",
       "query": "setting up Appium on a CI server",
-      "expectedSources": ["appium-xcuitest-driver/guides/ci-setup.md"],
+      "expectedSources": ["appium-xcuitest-driver/docs/guides/ci-setup.md"],
+      "answerSpans": ["Keychain", "unlock-keychain", "Continuous Integration"],
       "difficulty": "medium",
       "category": "ci"
     },
-
     {
       "id": "q21",
       "query": "my tests are super slow on iOS, what's going on",
       "expectedSources": [
-        "appium-xcuitest-driver/guides/wda-slowness.md",
-        "appium-xcuitest-driver/guides/troubleshooting.md"
+        "appium-xcuitest-driver/docs/guides/wda-slowness.md",
+        "appium-xcuitest-driver/docs/guides/troubleshooting.md"
+      ],
+      "answerSpans": [
+        "WebDriverAgent",
+        "XCTest",
+        "Proxying [",
+        "snapshotMaxDepth"
       ],
       "difficulty": "vague",
       "category": "troubleshooting"
@@ -183,9 +292,10 @@
       "id": "q22",
       "query": "appium can't find my button",
       "expectedSources": [
-        "appium-xcuitest-driver/guides/elements-lookup-troubleshooting.md",
-        "appium-xcuitest-driver/reference/locator-strategies.md"
+        "appium-xcuitest-driver/docs/guides/elements-lookup-troubleshooting.md",
+        "appium-xcuitest-driver/docs/reference/locator-strategies.md"
       ],
+      "answerSpans": ["accessibility", "page source", "Symptom"],
       "difficulty": "vague",
       "category": "troubleshooting"
     },
@@ -193,8 +303,9 @@
       "id": "q23",
       "query": "I switched xcode versions and now nothing works",
       "expectedSources": [
-        "appium-xcuitest-driver/guides/multiple-xcode-versions.md"
+        "appium-xcuitest-driver/docs/guides/multiple-xcode-versions.md"
       ],
+      "answerSpans": ["xcode-select", "DEVELOPER_DIR"],
       "difficulty": "vague",
       "category": "troubleshooting"
     },
@@ -202,17 +313,204 @@
       "id": "q24",
       "query": "can I reuse a WebDriverAgent that's already running",
       "expectedSources": [
-        "appium-xcuitest-driver/guides/attach-to-running-wda.md"
+        "appium-xcuitest-driver/docs/guides/attach-to-running-wda.md"
       ],
+      "answerSpans": ["appium:webDriverAgentUrl", "attach to a running"],
       "difficulty": "vague",
       "category": "wda"
     },
     {
       "id": "q25",
       "query": "show me how to write a test in python",
-      "expectedSources": ["appium/quickstart/test-py.md"],
+      "expectedSources": ["en/quickstart/test-py.md"],
+      "answerSpans": [
+        "Appium-Python-Client",
+        "pip install Appium-Python-Client"
+      ],
       "difficulty": "vague",
       "category": "clients"
+    },
+    {
+      "id": "q26",
+      "query": "long press an element on Android",
+      "expectedSources": [
+        "appium-uiautomator2-driver/docs/android-mobile-gestures.md"
+      ],
+      "answerSpans": ["mobile: longClickGesture", "long click action"],
+      "difficulty": "easy",
+      "category": "gestures"
+    },
+    {
+      "id": "q27",
+      "query": "how do I list available drivers on my machine",
+      "expectedSources": [
+        "en/reference/cli/extensions.md",
+        "en/guides/managing-exts.md"
+      ],
+      "answerSpans": ["appium driver list", "driver install"],
+      "difficulty": "medium",
+      "category": "cli"
+    },
+    {
+      "id": "q28",
+      "query": "what's the difference between appium:app and appium:bundleId",
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/reference/capabilities.md",
+        "en/guides/caps.md"
+      ],
+      "answerSpans": ["bundleId", "appium:app"],
+      "difficulty": "medium",
+      "category": "capabilities"
+    },
+    {
+      "id": "q29",
+      "query": "configure Appium with a JSON config file instead of CLI flags",
+      "expectedSources": ["en/guides/config.md", "en/reference/cli/server.md"],
+      "answerSpans": ["Configuration File", "--config"],
+      "difficulty": "medium",
+      "category": "cli"
+    },
+    {
+      "id": "q30",
+      "query": "how to record video of an iOS test run",
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/reference/execute-methods.md",
+        "appium-xcuitest-driver/docs/guides/audio-capture.md"
+      ],
+      "answerSpans": [
+        "mobile: startRecordingScreen",
+        "mobile: stopRecordingScreen"
+      ],
+      "difficulty": "medium",
+      "category": "ios"
+    },
+    {
+      "id": "q31",
+      "query": "scroll until an element is visible on android",
+      "expectedSources": [
+        "appium-uiautomator2-driver/docs/android-mobile-gestures.md",
+        "appium-uiautomator2-driver/docs/uiautomator-uiselector.md"
+      ],
+      "answerSpans": ["mobile: scrollGesture", "UiScrollable"],
+      "difficulty": "medium",
+      "category": "gestures"
+    },
+    {
+      "id": "q32",
+      "query": "deal with iOS permission dialog for camera or location",
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/guides/troubleshooting.md",
+        "appium-xcuitest-driver/docs/reference/execute-methods.md"
+      ],
+      "answerSpans": ["alert", "permission"],
+      "difficulty": "vague",
+      "category": "ios"
+    },
+    {
+      "id": "q33",
+      "query": "WebDriverAgent build failed with code signing error",
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/preparation/real-device-config.md",
+        "appium-xcuitest-driver/docs/guides/troubleshooting.md",
+        "appium-xcuitest-driver/docs/preparation/prov-profile-basic-manual.md"
+      ],
+      "answerSpans": ["provisioning profile", "code sign", "team"],
+      "difficulty": "vague",
+      "category": "ios-real-device"
+    },
+    {
+      "id": "q34",
+      "query": "what is mobile: activateApp used for",
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/reference/execute-methods.md",
+        "appium-uiautomator2-driver/docs/README.md"
+      ],
+      "answerSpans": ["mobile: activateApp", "bundleId"],
+      "difficulty": "medium",
+      "category": "app-management"
+    },
+    {
+      "id": "q35",
+      "query": "Appium 2 plugin installation",
+      "expectedSources": [
+        "en/guides/managing-exts.md",
+        "en/reference/cli/extensions.md"
+      ],
+      "answerSpans": ["appium plugin install", "plugin"],
+      "difficulty": "easy",
+      "category": "plugins"
+    },
+    {
+      "id": "q36",
+      "query": "how do I write a test in java",
+      "expectedSources": ["en/quickstart/test-java.md"],
+      "answerSpans": ["java-client", "AppiumDriver"],
+      "difficulty": "easy",
+      "category": "clients"
+    },
+    {
+      "id": "q37",
+      "query": "what does the headspin or browserstack driver do",
+      "expectedSources": ["en/ecosystem/drivers.md"],
+      "answerSpans": ["headspin", "BrowserStack"],
+      "difficulty": "vague",
+      "category": "ecosystem"
+    },
+    {
+      "id": "q38",
+      "query": "how do I capture device or app logs",
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/reference/execute-methods.md",
+        "appium-uiautomator2-driver/docs/README.md"
+      ],
+      "answerSpans": ["syslog", "logcat"],
+      "difficulty": "medium",
+      "category": "logging"
+    },
+    {
+      "id": "q39",
+      "query": "tap by x y coordinates on iOS",
+      "expectedSources": [
+        "appium-xcuitest-driver/docs/guides/gestures.md",
+        "appium-xcuitest-driver/docs/reference/execute-methods.md"
+      ],
+      "answerSpans": ["mobile: tap", "x", "y"],
+      "difficulty": "medium",
+      "category": "gestures"
+    },
+    {
+      "id": "q40",
+      "query": "Appium driver doctor command",
+      "expectedSources": [
+        "en/reference/cli/extensions.md",
+        "en/quickstart/uiauto2-driver.md"
+      ],
+      "answerSpans": ["appium driver doctor", "required fixes"],
+      "difficulty": "easy",
+      "category": "cli"
+    },
+    {
+      "id": "q41",
+      "query": "how to install Appium server arguments documentation",
+      "expectedSources": [
+        "en/reference/cli/server.md",
+        "en/reference/cli/index.md"
+      ],
+      "answerSpans": ["appium server", "--port"],
+      "difficulty": "medium",
+      "category": "cli"
+    },
+    {
+      "id": "q42",
+      "query": "what is an Appium plugin",
+      "expectedSources": [
+        "en/intro/index.md",
+        "en/ecosystem/plugins.md",
+        "en/guides/managing-exts.md"
+      ],
+      "answerSpans": ["plugin", "extend"],
+      "difficulty": "easy",
+      "category": "plugins"
     }
   ]
 }


### PR DESCRIPTION
Update evals to use answer spans instead of .md file occurences.

This allows for better evaluations and chunk hit/miss per doc file - right file, wrong section.

Also adds some more eval sets.