### PR TITLE
fix: correct the order of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,9 +407,9 @@ The supported plugin API is intentionally small:
 
 `McpRegistry` methods delegate to the matching FastMCP registration APIs, so their object shapes follow FastMCP's documented tool, prompt, resource, and resource-template definitions. Appium MCP wraps registered tools with plugin call hooks, but prompts and resources are registered directly with FastMCP.
 
-Each plugin name should be unique within the server. If two plugins use the same `name`, Appium MCP keeps the first plugin registered for that name and skips later duplicates with a warning. Use a stable, package-style or organization-prefixed name, such as `acme-checkout-plugin`, to avoid collisions when composing plugins from multiple teams.
+Each plugin name should be unique within the server. If two plugins use the same `name`, Appium MCP keeps the first plugin registered for that name and skips later plugins with a warning. Use a stable, package-style or organization-prefixed name, such as `acme-checkout-plugin`, to avoid collisions when composing plugins from multiple teams.
 
-Each tool name should also be unique across all plugins and the core server. FastMCP registers the latest tool definition for a name, so a duplicate name can replace an earlier tool definition. Appium MCP registers plugin tools before built-in tools, which means a plugin tool that uses the same name as a built-in tool can be replaced by the built-in tool. Appium MCP tools usually have an `appium_` prefix, so plugin tool names should avoid that pattern to reduce the chance of collisions with future core tools.
+Each tool name should also be unique across all plugins and the core server. Tool names follow FastMCP behavior, not plugin-name behavior: when a tool is registered with the same `name` as an existing tool, FastMCP replaces the earlier tool definition with the later one. Appium MCP registers built-in tools before plugin tools, which means a plugin tool that uses the same name as a built-in tool replaces the built-in tool. Appium MCP tools usually have an `appium_` prefix, so plugin tool names should use that pattern only when they intentionally override a core tool.
 
 ### Verify plugin and tool names
 
@@ -430,7 +430,7 @@ console.log(formatVerificationReport(report));
 process.exit(report.ok ? 0 : 1);
 ```
 
-When you provide multiple plugins, order is preserved. Plugins are verified in array order. This matters because Appium MCP keeps the first plugin for a duplicate plugin name and skips later plugins with the same name. Tool names still need to be unique across all loaded plugins and `appium-mcp core`; the verifier reports any collisions it finds.
+When you provide multiple plugins, order is preserved. Plugins are verified in array order after the `appium-mcp core` tools. This matters because Appium MCP keeps the first plugin for a duplicate plugin name and skips later plugins with the same name, while duplicate tool names follow FastMCP's later-registration-wins behavior. Tool names still need to be unique across all loaded plugins and `appium-mcp core`; the verifier reports any collisions it finds.
 
 The report labels this package's own shipped tools as `appium-mcp core`. Plugin sources are labeled as `plugin:<name>` with the plugin version.
 

--- a/src/create-server.ts
+++ b/src/create-server.ts
@@ -117,16 +117,16 @@ export function createAppiumMcpServer(
   }
 
   // -------------------------------------------------------------------------
-  // 2. Register plugin tools (before built-ins so plugins appear first in the
-  //    tool list, but either order is fine – adjust if needed).
-  // -------------------------------------------------------------------------
-  manager.registerPluginCapabilities();
-
-  // -------------------------------------------------------------------------
-  // 3. Register built-in Appium MCP resources and tools.
+  // 2. Register built-in Appium MCP resources and tools.
   // -------------------------------------------------------------------------
   registerResources(server);
   registerTools(server);
+
+  // -------------------------------------------------------------------------
+  // 3. Register plugin capabilities after built-ins. FastMCP replaces tools by
+  //    name, so plugin tools can intentionally override built-in tools.
+  // -------------------------------------------------------------------------
+  manager.registerPluginCapabilities();
 
   // -------------------------------------------------------------------------
   // 4. Initialize plugins (after all tools are registered so plugins can look

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -72,7 +72,9 @@ export interface AppiumMcpPlugin {
    * Unique plugin identifier within a server instance.
    *
    * Duplicate plugin names are skipped with a warning, so prefer stable
-   * package-style or organization-prefixed names.
+   * package-style or organization-prefixed names. This differs from MCP tool
+   * names: FastMCP replaces an existing tool when another tool is registered
+   * with the same name.
    */
   readonly name: string;
   readonly version: string;
@@ -152,7 +154,8 @@ export class McpRegistry {
   /**
    * Register one MCP tool. Tool calls are wrapped by plugin call hooks.
    *
-   * Delegates to FastMCP `addTool`.
+   * Delegates to FastMCP `addTool`. If a tool with the same name was already
+   * registered, FastMCP replaces the earlier tool with this definition.
    *
    * @see https://github.com/punkpeye/fastmcp#tools
    */
@@ -169,6 +172,7 @@ export class McpRegistry {
    * Register multiple MCP tools.
    *
    * Delegates to FastMCP `addTool` for each definition.
+   * Duplicate tool names are therefore last-registration-wins.
    *
    * @see https://github.com/punkpeye/fastmcp#tools
    */
@@ -473,6 +477,16 @@ export function verifyAppiumMcpNames(
   const registry = new McpRegistry(collector as never);
   const core = new AppiumMcpCore();
 
+  currentSource = CORE_SOURCE;
+  try {
+    withSuppressedRegistrationLogs(() => registerTools(collector as never));
+  } catch (err: unknown) {
+    errors.push({
+      source: currentSource,
+      message: errorMessage(err),
+    });
+  }
+
   for (const plugin of plugins) {
     if (seenPluginNames.has(plugin.name)) {
       continue;
@@ -490,16 +504,6 @@ export function verifyAppiumMcpNames(
         message: errorMessage(err),
       });
     }
-  }
-
-  currentSource = CORE_SOURCE;
-  try {
-    withSuppressedRegistrationLogs(() => registerTools(collector as never));
-  } catch (err: unknown) {
-    errors.push({
-      source: currentSource,
-      message: errorMessage(err),
-    });
   }
   duplicates.push(...findDuplicates('tool', toolEntries));
 

--- a/src/tests/create-server.test.ts
+++ b/src/tests/create-server.test.ts
@@ -52,11 +52,23 @@ class MockFastMCP {
   }
 
   addTool(toolDef: ToolDef): void {
+    const existingIndex = this.tools.findIndex(
+      (tool) => tool.name === toolDef.name
+    );
+    if (existingIndex !== -1) {
+      this.tools.splice(existingIndex, 1);
+    }
     this.tools.push(toolDef);
   }
 
   addTools(toolDefs: ToolDef[]): void {
     this.addToolsCallCount += 1;
+    const newToolNames = new Set(toolDefs.map((tool) => tool.name));
+    for (let index = this.tools.length - 1; index >= 0; index -= 1) {
+      if (newToolNames.has(this.tools[index].name)) {
+        this.tools.splice(index, 1);
+      }
+    }
     this.tools.push(...toolDefs);
   }
 
@@ -272,9 +284,48 @@ describe('createAppiumMcpServer plugin lifecycle', () => {
     }) as unknown as MockFastMCP;
 
     expect(server.tools.map((tool) => tool.name)).toEqual([
+      'builtin_tool',
       'plugin_allowed',
+    ]);
+  });
+
+  test('allows plugin tools to override built-in tools by name', async () => {
+    const plugin: AppiumMcpPlugin = {
+      name: 'override-plugin',
+      version: '1.0.0',
+      register(registry) {
+        registry.addTool(
+          'builtin_tool',
+          'Plugin override for built-in test tool',
+          testToolParameters,
+          async () => ({
+            content: [{ type: 'text', text: 'plugin override result' }],
+          })
+        );
+      },
+    };
+
+    const server = createAppiumMcpServer({
+      plugins: [plugin],
+    }) as unknown as MockFastMCP;
+
+    expect(server.tools.map((tool) => tool.name)).toEqual([
+      'blocked_tool',
       'builtin_tool',
     ]);
+
+    const overriddenTool = server.tools.find(
+      (tool) => tool.name === 'builtin_tool'
+    );
+    expect(overriddenTool?.description).toBe(
+      'Plugin override for built-in test tool'
+    );
+
+    const result = (await overriddenTool?.execute({}, {})) as ToolCallResult;
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: 'plugin override result',
+    });
   });
 
   test('applies policy to batch tool and resource registration methods', () => {

--- a/src/tests/plugin.test.ts
+++ b/src/tests/plugin.test.ts
@@ -52,6 +52,12 @@ function makeMockServer() {
   const registeredResourceTemplates: unknown[] = [];
   const server: any = {
     addTool(toolDef: ToolDef) {
+      const existingIndex = registeredTools.findIndex(
+        (tool) => tool.name === toolDef.name
+      );
+      if (existingIndex !== -1) {
+        registeredTools.splice(existingIndex, 1);
+      }
       registeredTools.push(toolDef);
     },
     addPrompt(promptDef: unknown) {
@@ -89,6 +95,26 @@ describe('McpRegistry', () => {
 
     expect(mockServer._tools).toHaveLength(1);
     expect(mockServer._tools[0].name).toBe('my_tool');
+  });
+
+  test('uses FastMCP replacement behavior for duplicate tool names', async () => {
+    const mockServer = makeMockServer();
+    const registry = new McpRegistry(mockServer);
+
+    registry.addTool('same_tool', 'first tool', {} as any, async () => ({
+      content: [{ type: 'text', text: 'first' }],
+    }));
+    registry.addTool('same_tool', 'second tool', {} as any, async () => ({
+      content: [{ type: 'text', text: 'second' }],
+    }));
+
+    expect(mockServer._tools).toHaveLength(1);
+    expect(mockServer._tools[0].description).toBe('second tool');
+
+    const result = (await mockServer._tools[0].execute({}, {})) as {
+      content: Array<{ text: string }>;
+    };
+    expect(result.content[0].text).toBe('second');
   });
 
   test('delegates prompt and resource registration to server methods', () => {

--- a/src/tests/verify.test.ts
+++ b/src/tests/verify.test.ts
@@ -97,8 +97,8 @@ describe('verifyAppiumMcpNames', () => {
         kind: 'tool',
         name: 'builtin_tool',
         entries: [
-          { name: 'builtin_tool', source: 'plugin:conflicting-plugin' },
           { name: 'builtin_tool', source: 'appium-mcp core' },
+          { name: 'builtin_tool', source: 'plugin:conflicting-plugin' },
         ],
       },
     ]);


### PR DESCRIPTION
After some testing, I noticed that the FastMCP overrides tools come later. So, i have updated the documentation, and allow plugins to override existing ones. This behavior should be flexible.

So, the original motivation is to let users define their own business logic for tools, etc., since the MCP server is not a single webdriver client.

So, if a user defines the same name of tools, for example, the name will behave as the user defines.