### PR TITLE
chore: refactor documentation part as a plugin style

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -8,7 +8,7 @@
 export { createAppiumMcpServer } from './create-server.js';
 export type { CreateAppiumMcpServerOptions } from './create-server.js';
 export { evaluatePolicyTarget } from './policy.js';
-export { AppiumDocument } from './tools/documentation/plugin.js';
+export { AppiumDocumentation } from './tools/documentation/plugin.js';
 export type {
   AppiumMcpPolicy,
   PolicyDecision,

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,6 +8,7 @@
 export { createAppiumMcpServer } from './create-server.js';
 export type { CreateAppiumMcpServerOptions } from './create-server.js';
 export { evaluatePolicyTarget } from './policy.js';
+export { AppiumDocument } from './tools/documentation/plugin.js';
 export type {
   AppiumMcpPolicy,
   PolicyDecision,

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,7 +8,6 @@
 export { createAppiumMcpServer } from './create-server.js';
 export type { CreateAppiumMcpServerOptions } from './create-server.js';
 export { evaluatePolicyTarget } from './policy.js';
-export { AppiumDocumentation } from './tools/documentation/plugin.js';
 export type {
   AppiumMcpPolicy,
   PolicyDecision,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,7 @@
 import { createAppiumMcpServer } from './create-server.js';
+import { AppiumDocument } from './tools/documentation/plugin.js';
 
-const server = createAppiumMcpServer();
+const server = createAppiumMcpServer({
+  plugins: [new AppiumDocument()],
+});
 export default server;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import { createAppiumMcpServer } from './create-server.js';
-import { AppiumDocument } from './tools/documentation/plugin.js';
+import { AppiumDocumentation } from './tools/documentation/plugin.js';
 
 const server = createAppiumMcpServer({
-  plugins: [new AppiumDocument()],
+  plugins: [new AppiumDocumentation()],
 });
 export default server;

--- a/src/tests/tools/documentation/appium-skills.test.ts
+++ b/src/tests/tools/documentation/appium-skills.test.ts
@@ -12,9 +12,8 @@ await jest.unstable_mockModule('../../../logger', () => ({
   default: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
 }));
 
-const appiumSkills = (
-  await import('../../../tools/documentation/appium-skills.js')
-).default;
+const { appiumSkillsTool } =
+  await import('../../../tools/documentation/appium-skills.js');
 
 type ToolDef = {
   name: string;
@@ -22,11 +21,7 @@ type ToolDef = {
 };
 
 function getRegisteredTool(): ToolDef {
-  const addTool = jest.fn();
-  const server = { addTool } as any;
-  appiumSkills(server);
-  expect(addTool).toHaveBeenCalledTimes(1);
-  return addTool.mock.calls[0][0] as ToolDef;
+  return appiumSkillsTool as ToolDef;
 }
 
 async function runTool(args: any): Promise<string> {

--- a/src/tests/tools/documentation/plugin.test.ts
+++ b/src/tests/tools/documentation/plugin.test.ts
@@ -12,7 +12,7 @@ await jest.unstable_mockModule('../../../logger', () => ({
   default: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
 }));
 
-const { AppiumDocument } =
+const { AppiumDocumentation } =
   await import('../../../tools/documentation/plugin.js');
 
 type ToolDef = {
@@ -20,7 +20,7 @@ type ToolDef = {
   annotations?: unknown;
 };
 
-describe('AppiumDocument plugin', () => {
+describe('AppiumDocumentation plugin', () => {
   test('registers documentation query and skills tools', () => {
     const tools: ToolDef[] = [];
     const registry = {
@@ -29,7 +29,7 @@ describe('AppiumDocument plugin', () => {
       },
     };
 
-    new AppiumDocument().register(registry as never);
+    new AppiumDocumentation().register(registry as never);
 
     expect(tools.map((tool) => tool.name)).toEqual([
       'appium_documentation_query',

--- a/src/tests/tools/documentation/plugin.test.ts
+++ b/src/tests/tools/documentation/plugin.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../../../logger', () => ({
+  default: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+const { AppiumDocument } =
+  await import('../../../tools/documentation/plugin.js');
+
+type ToolDef = {
+  name: string;
+  annotations?: unknown;
+};
+
+describe('AppiumDocument plugin', () => {
+  test('registers documentation query and skills tools', () => {
+    const tools: ToolDef[] = [];
+    const registry = {
+      addTool(toolDef: ToolDef) {
+        tools.push(toolDef);
+      },
+    };
+
+    new AppiumDocument().register(registry as never);
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'appium_documentation_query',
+      'appium_skills',
+    ]);
+    expect(tools[1].annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: false,
+    });
+  });
+});

--- a/src/tests/tools/documentation/plugin.test.ts
+++ b/src/tests/tools/documentation/plugin.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, jest, test } from '@jest/globals';
 
+jest.unstable_mockModule('appium-uiautomator2-driver', () => ({
+  AndroidUiautomator2Driver: class {},
+}));
+jest.unstable_mockModule('appium-xcuitest-driver', () => ({
+  XCUITestDriver: class {},
+}));
+jest.unstable_mockModule('webdriver', () => ({ default: {} }));
+
 await jest.unstable_mockModule('../../../logger', () => ({
   default: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
 }));

--- a/src/tools/documentation/answer-appium.ts
+++ b/src/tools/documentation/answer-appium.ts
@@ -1,46 +1,51 @@
 /**
- * Tool to select mobile platform before creating a session
+ * Tool to query indexed Appium documentation.
  */
+import type { FastMCP } from 'fastmcp';
 import { z } from 'zod';
 import { answerAppiumQuery, initializeAppiumDocumentation } from './index.js';
 import log from '../../logger.js';
 import { errorResult, textResult } from '../tool-response.js';
 
-export default function answerAppium(server: any): void {
-  server.addTool({
-    name: 'appium_documentation_query',
-    description: `Query Appium documentation using RAG (Retrieval-Augmented Generation).
+type ToolDef = Parameters<FastMCP['addTool']>[0];
+
+export const appiumDocumentationQueryTool: ToolDef = {
+  name: 'appium_documentation_query',
+  description: `Query Appium documentation using RAG (Retrieval-Augmented Generation).
       This tool searches through indexed Appium documentation to answer questions about Appium features, setup, configuration, drivers, and usage.
       `,
-    parameters: z.object({
-      query: z
-        .string()
-        .describe('The question or query about Appium documentation'),
-    }),
-    execute: async (args: any, _context: any): Promise<any> => {
-      const query = args.query;
-      if (!query) {
-        return errorResult('Query parameter is required');
-      }
+  parameters: z.object({
+    query: z
+      .string()
+      .describe('The question or query about Appium documentation'),
+  }),
+  execute: async (args: any, _context: any): Promise<any> => {
+    const query = args.query;
+    if (!query) {
+      return errorResult('Query parameter is required');
+    }
 
+    try {
+      const result = await answerAppiumQuery({ query });
+      return textResult(result.answer);
+    } catch (_docError) {
+      // If documentation query fails, try to initialize and retry once
       try {
+        log.info('Documentation not initialized, initializing now...');
+        await initializeAppiumDocumentation();
         const result = await answerAppiumQuery({ query });
         return textResult(result.answer);
-      } catch (_docError) {
-        // If documentation query fails, try to initialize and retry once
-        try {
-          log.info('Documentation not initialized, initializing now...');
-          await initializeAppiumDocumentation();
-          const result = await answerAppiumQuery({ query });
-          return textResult(result.answer);
-        } catch (retryError) {
-          return errorResult(
-            `Error querying Appium documentation: ${
-              (retryError as Error).message
-            }. Please ensure the documentation is indexed first.`
-          );
-        }
+      } catch (retryError) {
+        return errorResult(
+          `Error querying Appium documentation: ${
+            (retryError as Error).message
+          }. Please ensure the documentation is indexed first.`
+        );
       }
-    },
-  });
+    }
+  },
+};
+
+export default function answerAppium(server: Pick<FastMCP, 'addTool'>): void {
+  server.addTool(appiumDocumentationQueryTool);
 }

--- a/src/tools/documentation/answer-appium.ts
+++ b/src/tools/documentation/answer-appium.ts
@@ -45,7 +45,3 @@ export const appiumDocumentationQueryTool: ToolDef = {
     }
   },
 };
-
-export default function answerAppium(server: Pick<FastMCP, 'addTool'>): void {
-  server.addTool(appiumDocumentationQueryTool);
-}

--- a/src/tools/documentation/appium-skills.ts
+++ b/src/tools/documentation/appium-skills.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import type { FastMCP } from 'fastmcp';
 import { z } from 'zod';
 import log from '../../logger.js';
 import { resolveAppiumResourcesPath } from '../../utils/paths.js';
@@ -9,6 +10,7 @@ type Platform = 'android' | 'ios';
 type Driver = 'uiautomator2' | 'espresso' | 'xcuitest';
 type Mode = 'setup' | 'troubleshoot';
 type OptionalSkill = 'ffmpeg' | 'bundletool';
+type ToolDef = Parameters<FastMCP['addTool']>[0];
 
 const ROOT = resolveAppiumResourcesPath('submodules', 'appium-skills');
 const AGENTS_PATH = path.join(ROOT, 'AGENTS.md');
@@ -42,114 +44,111 @@ const TEMPLATE_HEADINGS: Record<string, string> = {
   'troubleshoot:xcuitest': 'Troubleshooting',
 };
 
-export default function appiumSkills(server: any): void {
-  server.addTool({
-    name: 'appium_skills',
-    description: `Return ordered Appium setup or troubleshooting skills from the vendored appium/skills repository.
+export const appiumSkillsTool: ToolDef = {
+  name: 'appium_skills',
+  description: `Return ordered Appium setup or troubleshooting skills from the vendored appium/skills repository.
       Use this before preparing a LOCAL Appium environment or diagnosing local prerequisite issues.`,
-    parameters: z.object({
-      platform: z.enum(['android', 'ios']).describe('Target local platform.'),
-      driver: z
-        .enum(['uiautomator2', 'espresso', 'xcuitest'])
-        .describe('Target Appium automation driver.'),
-      mode: z
-        .enum(['setup', 'troubleshoot'])
-        .optional()
-        .default('setup')
-        .describe(
-          'Whether to prepare an environment or troubleshoot an existing failure.'
-        ),
-      realDevice: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe(
-          'For ios + xcuitest only: true for a physical device, false for simulator setup.'
-        ),
-      includeOptional: z
-        .array(z.enum(['ffmpeg', 'bundletool']))
-        .optional()
-        .default([])
-        .describe(
-          'Optional shared skills to include when explicitly requested.'
-        ),
-    }),
-    annotations: {
-      readOnlyHint: true,
-      openWorldHint: false,
-    },
-    execute: async (rawArgs: any): Promise<any> => {
-      const parsed = (rawArgs ?? {}) as Partial<{
-        platform: Platform;
-        driver: Driver;
-        mode: Mode;
-        realDevice: boolean;
-        includeOptional: OptionalSkill[];
-      }>;
-      const args = {
-        platform: parsed.platform as Platform,
-        driver: parsed.driver as Driver,
-        mode: parsed.mode ?? 'setup',
-        realDevice: parsed.realDevice ?? false,
-        includeOptional: Array.isArray(parsed.includeOptional)
-          ? parsed.includeOptional
-          : [],
-      };
-      const { skillNames, ignoredOptional } = getSkillNames(args);
+  parameters: z.object({
+    platform: z.enum(['android', 'ios']).describe('Target local platform.'),
+    driver: z
+      .enum(['uiautomator2', 'espresso', 'xcuitest'])
+      .describe('Target Appium automation driver.'),
+    mode: z
+      .enum(['setup', 'troubleshoot'])
+      .optional()
+      .default('setup')
+      .describe(
+        'Whether to prepare an environment or troubleshoot an existing failure.'
+      ),
+    realDevice: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'For ios + xcuitest only: true for a physical device, false for simulator setup.'
+      ),
+    includeOptional: z
+      .array(z.enum(['ffmpeg', 'bundletool']))
+      .optional()
+      .default([])
+      .describe('Optional shared skills to include when explicitly requested.'),
+  }),
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: false,
+  },
+  execute: async (rawArgs: any): Promise<any> => {
+    const parsed = (rawArgs ?? {}) as Partial<{
+      platform: Platform;
+      driver: Driver;
+      mode: Mode;
+      realDevice: boolean;
+      includeOptional: OptionalSkill[];
+    }>;
+    const args = {
+      platform: parsed.platform as Platform,
+      driver: parsed.driver as Driver,
+      mode: parsed.mode ?? 'setup',
+      realDevice: parsed.realDevice ?? false,
+      includeOptional: Array.isArray(parsed.includeOptional)
+        ? parsed.includeOptional
+        : [],
+    };
+    const { skillNames, ignoredOptional } = getSkillNames(args);
 
-      log.info(
-        `Loading Appium skills for ${args.platform}/${args.driver} (${args.mode}) from ${ROOT}`
-      );
+    log.info(
+      `Loading Appium skills for ${args.platform}/${args.driver} (${args.mode}) from ${ROOT}`
+    );
 
-      const agentsMarkdown = await readMarkdown(AGENTS_PATH);
-      const promptTemplate = getPromptTemplate(
-        agentsMarkdown,
-        getTemplateHeading(args.mode, args.driver, args.realDevice)
-      );
-      const skillContents = await Promise.all(
-        skillNames.map(async (skillName) => ({
-          name: skillName,
-          markdown: await readMarkdown(SKILL_PATH(skillName)),
-        }))
-      );
+    const agentsMarkdown = await readMarkdown(AGENTS_PATH);
+    const promptTemplate = getPromptTemplate(
+      agentsMarkdown,
+      getTemplateHeading(args.mode, args.driver, args.realDevice)
+    );
+    const skillContents = await Promise.all(
+      skillNames.map(async (skillName) => ({
+        name: skillName,
+        markdown: await readMarkdown(SKILL_PATH(skillName)),
+      }))
+    );
 
-      const lines = [
-        `Appium skills for ${args.platform}/${args.driver}`,
-        `Mode: ${args.mode}`,
-        `Real device: ${args.realDevice ? 'yes' : 'no'}`,
-        '',
-        'Recommended skill order:',
-        ...skillNames.map((skillName, index) => `${index + 1}. ${skillName}`),
-      ];
+    const lines = [
+      `Appium skills for ${args.platform}/${args.driver}`,
+      `Mode: ${args.mode}`,
+      `Real device: ${args.realDevice ? 'yes' : 'no'}`,
+      '',
+      'Recommended skill order:',
+      ...skillNames.map((skillName, index) => `${index + 1}. ${skillName}`),
+    ];
 
-      if (ignoredOptional.length) {
-        lines.push(
-          '',
-          `Ignored optional skills: ${ignoredOptional.join(', ')}`
-        );
-      }
+    if (ignoredOptional.length) {
+      lines.push('', `Ignored optional skills: ${ignoredOptional.join(', ')}`);
+    }
 
-      lines.push('', 'Source files:', '- AGENTS.md');
+    lines.push('', 'Source files:', '- AGENTS.md');
+    lines.push(
+      ...skillNames.map((skillName) => `- skills/${skillName}/SKILL.md`)
+    );
+
+    if (promptTemplate) {
+      lines.push('', 'Prompt template:', '```text', promptTemplate, '```');
+    }
+
+    lines.push('', '--- AGENTS.md ---', agentsMarkdown.trim());
+    for (const skill of skillContents) {
       lines.push(
-        ...skillNames.map((skillName) => `- skills/${skillName}/SKILL.md`)
+        '',
+        `--- skills/${skill.name}/SKILL.md ---`,
+        skill.markdown.trim()
       );
+    }
 
-      if (promptTemplate) {
-        lines.push('', 'Prompt template:', '```text', promptTemplate, '```');
-      }
+    return textResult(lines.join('\n'));
+  },
+};
 
-      lines.push('', '--- AGENTS.md ---', agentsMarkdown.trim());
-      for (const skill of skillContents) {
-        lines.push(
-          '',
-          `--- skills/${skill.name}/SKILL.md ---`,
-          skill.markdown.trim()
-        );
-      }
-
-      return textResult(lines.join('\n'));
-    },
-  });
+export default function appiumSkills(server: Pick<FastMCP, 'addTool'>): void {
+  server.addTool(appiumSkillsTool);
 }
 
 /**

--- a/src/tools/documentation/appium-skills.ts
+++ b/src/tools/documentation/appium-skills.ts
@@ -147,10 +147,6 @@ export const appiumSkillsTool: ToolDef = {
   },
 };
 
-export default function appiumSkills(server: Pick<FastMCP, 'addTool'>): void {
-  server.addTool(appiumSkillsTool);
-}
-
 /**
  * Get the list of skill names to return based on the input arguments,
  * and determine which optional skills were ignored.

--- a/src/tools/documentation/plugin.ts
+++ b/src/tools/documentation/plugin.ts
@@ -11,7 +11,7 @@ import pkg from '../../../package.json' with { type: 'json' };
  * - appium_skills
  */
 export class AppiumDocumentation implements AppiumMcpPlugin {
-  readonly name = 'appium-document';
+  readonly name = 'appium-documentation';
   readonly version = pkg.version;
 
   register(registry: McpRegistry): void {

--- a/src/tools/documentation/plugin.ts
+++ b/src/tools/documentation/plugin.ts
@@ -10,7 +10,7 @@ import pkg from '../../../package.json' with { type: 'json' };
  * - appium_documentation_query
  * - appium_skills
  */
-export class AppiumDocument implements AppiumMcpPlugin {
+export class AppiumDocumentation implements AppiumMcpPlugin {
   readonly name = 'appium-document';
   readonly version = pkg.version;
 
@@ -19,5 +19,3 @@ export class AppiumDocument implements AppiumMcpPlugin {
     registry.addTool(appiumSkillsTool);
   }
 }
-
-export default AppiumDocument;

--- a/src/tools/documentation/plugin.ts
+++ b/src/tools/documentation/plugin.ts
@@ -1,6 +1,7 @@
 import type { AppiumMcpPlugin, McpRegistry } from '../../plugin.js';
 import { appiumDocumentationQueryTool } from './answer-appium.js';
 import { appiumSkillsTool } from './appium-skills.js';
+import pkg from '../../../package.json' with { type: 'json' };
 
 /**
  * Appium documentation plugin.
@@ -11,7 +12,7 @@ import { appiumSkillsTool } from './appium-skills.js';
  */
 export class AppiumDocument implements AppiumMcpPlugin {
   readonly name = 'appium-document';
-  readonly version = '1.0.0';
+  readonly version = pkg.version;
 
   register(registry: McpRegistry): void {
     registry.addTool(appiumDocumentationQueryTool);

--- a/src/tools/documentation/plugin.ts
+++ b/src/tools/documentation/plugin.ts
@@ -1,0 +1,22 @@
+import type { AppiumMcpPlugin, McpRegistry } from '../../plugin.js';
+import { appiumDocumentationQueryTool } from './answer-appium.js';
+import { appiumSkillsTool } from './appium-skills.js';
+
+/**
+ * Appium documentation plugin.
+ *
+ * Registers the documentation-focused tools:
+ * - appium_documentation_query
+ * - appium_skills
+ */
+export class AppiumDocument implements AppiumMcpPlugin {
+  readonly name = 'appium-document';
+  readonly version = '1.0.0';
+
+  register(registry: McpRegistry): void {
+    registry.addTool(appiumDocumentationQueryTool);
+    registry.addTool(appiumSkillsTool);
+  }
+}
+
+export default AppiumDocument;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,8 +14,6 @@
  */
 import type { ContentResult, FastMCP } from 'fastmcp';
 import log from '../logger.js';
-import answerAppium from './documentation/answer-appium.js';
-import appiumSkills from './documentation/appium-skills.js';
 import session from './session/session.js';
 import generateLocators from './test-generation/locators.js';
 import selectDevice from './session/select-device.js';
@@ -186,10 +184,6 @@ export default function registerTools(server: FastMCP): void {
   // Test Generation
   generateLocators(server);
   generateTest(server);
-
-  // Documentation
-  answerAppium(server);
-  appiumSkills(server);
 
   // AI (vision-based fallback) — gated; only registered when explicitly enabled.
   assertAIConfig();


### PR DESCRIPTION
Part of https://github.com/appium/appium-mcp/issues/360

- Change the documentation implementation to plugin style
    - `src/tools/documentation/plugin.ts` is the primary method for this transition


After this, we can kind of safely split the `documentation` related implementation into another package. Then, the important part is `src/server.ts`. we can give the docs package as `plugins`  to load it.