### PR TITLE
fix(session): return errorResult from select_device and session create failures

### DIFF
--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -18,7 +18,8 @@ import {
   createSessionDashboardUI,
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
-import { textResult, toolErrorMessage } from '../tool-response.js';
+import type { ContentResult } from 'fastmcp';
+import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 import WebDriver from 'webdriver';
 
 // Define capabilities type
@@ -107,7 +108,7 @@ export async function validateIOSDeviceSelection(
     const selectedDevice = getSelectedDevice();
     if (!selectedDevice) {
       throw new Error(
-        `Multiple iOS ${deviceType === 'simulator' ? 'simulators' : 'devices'} found (${devices.length}). Please use the select_device tool to choose which device to use before creating a session.`
+        `Multiple iOS ${deviceType === 'simulator' ? 'simulators' : 'devices'} found (${devices.length}). Use select_device with platform=ios and iosDeviceType=${deviceType} to choose one, then call appium_session_management with action=create.`
       );
     }
   }
@@ -215,13 +216,13 @@ export function validateRemoteServerUrl(
  * - text: Success message with session ID and device details
  * - ui: Interactive session dashboard UI component
  *
- * @throws {Error} If session creation fails or platform capabilities cannot be loaded
+ * Returns a tool-execution error result (isError: true) on failure.
  */
 export async function createSessionAction(args: {
   platform: 'ios' | 'android' | 'general';
   capabilities?: Record<string, any>;
   remoteServerUrl?: string;
-}): Promise<any> {
+}): Promise<ContentResult> {
   try {
     const {
       platform,
@@ -256,10 +257,16 @@ export async function createSessionAction(args: {
     );
     let sessionId;
     if (remoteServerUrl) {
-      validateRemoteServerUrl(
-        remoteServerUrl,
-        process.env.REMOTE_SERVER_URL_ALLOW_REGEX
-      );
+      try {
+        validateRemoteServerUrl(
+          remoteServerUrl,
+          process.env.REMOTE_SERVER_URL_ALLOW_REGEX
+        );
+      } catch (err: unknown) {
+        return errorResult(
+          `Invalid remoteServerUrl. ${toolErrorMessage(err)} Pass a valid http(s) URL, or omit remoteServerUrl to use the local embedded driver.`
+        );
+      }
 
       const remoteUrl = new URL(remoteServerUrl);
       const protocol = remoteUrl.protocol.replace(':', '');
@@ -291,8 +298,8 @@ export async function createSessionAction(args: {
       );
     } else {
       if (platform === 'general') {
-        throw new Error(
-          'platform="general" requires a remoteServerUrl — local drivers are not supported for general sessions.'
+        return errorResult(
+          'platform=general requires remoteServerUrl. Local embedded mode supports platform=android or platform=ios only.'
         );
       }
       const driver = createDriverForPlatform(platform);
@@ -329,11 +336,11 @@ export async function createSessionAction(args: {
     );
 
     return addUIResourceToResponse(textResponse, uiResource);
-  } catch (error: any) {
+  } catch (error: unknown) {
     log.error('Error creating session:', error);
-    throw new Error(`Failed to create session: ${error.message}`, {
-      cause: error,
-    });
+    return errorResult(
+      `Failed to create session. ${toolErrorMessage(error)} For local sessions, call select_device first (matching platform), then appium_session_management with action=create.`
+    );
   }
 }
 

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -264,7 +264,7 @@ export async function createSessionAction(args: {
         );
       } catch (err: unknown) {
         return errorResult(
-          `Invalid remoteServerUrl. ${toolErrorMessage(err)} Pass a valid http(s) URL, or omit remoteServerUrl to use the local embedded driver.`
+          `Invalid remoteServerUrl "${remoteServerUrl}". ${toolErrorMessage(err)} Pass a valid http(s) URL, or omit remoteServerUrl to use the local embedded driver.`
         );
       }
 
@@ -339,9 +339,47 @@ export async function createSessionAction(args: {
   } catch (error: unknown) {
     log.error('Error creating session:', error);
     return errorResult(
-      `Failed to create session. ${toolErrorMessage(error)} For local sessions, call select_device first (matching platform), then appium_session_management with action=create.`
+      buildCreateSessionFailureMessage(error, {
+        platform: args.platform,
+        remoteServerUrl: args.remoteServerUrl,
+        customCapabilities: args.capabilities,
+      })
     );
   }
+}
+
+function buildCreateSessionFailureMessage(
+  error: unknown,
+  ctx: {
+    platform: 'ios' | 'android' | 'general';
+    remoteServerUrl?: string;
+    customCapabilities?: Record<string, any>;
+  }
+): string {
+  const detail = toolErrorMessage(error);
+  const base = `Failed to create session. ${detail}`;
+
+  if (ctx.remoteServerUrl) {
+    return `${base} remoteServerUrl="${ctx.remoteServerUrl}". Check the URL and your capabilities.`;
+  }
+
+  if (/select_device/i.test(detail)) {
+    return base;
+  }
+
+  const caps = ctx.customCapabilities ?? {};
+  const hasDeviceTarget =
+    Boolean(caps['appium:udid'] || caps['appium:deviceName']) ||
+    Boolean(getSelectedDevice());
+
+  if (
+    !hasDeviceTarget &&
+    (ctx.platform === 'ios' || ctx.platform === 'android')
+  ) {
+    return `${base} For local sessions without appium:udid (or a prior select_device), use select_device with a matching platform or pass target device capabilities, then action=create.`;
+  }
+
+  return base;
 }
 
 /**

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -223,6 +223,8 @@ export async function createSessionAction(args: {
   capabilities?: Record<string, any>;
   remoteServerUrl?: string;
 }): Promise<ContentResult> {
+  let finalCapabilities: Capabilities | undefined;
+
   try {
     const {
       platform,
@@ -231,7 +233,6 @@ export async function createSessionAction(args: {
     } = args;
 
     const configCapabilities = await loadCapabilitiesConfig();
-    let finalCapabilities: Capabilities;
     if (platform === 'android') {
       finalCapabilities = buildAndroidCapabilities(
         configCapabilities.android,
@@ -298,9 +299,7 @@ export async function createSessionAction(args: {
       );
     } else {
       if (platform === 'general') {
-        return errorResult(
-          'platform=general requires remoteServerUrl. Local embedded mode supports platform=android or platform=ios only.'
-        );
+        return errorResult('platform=general requires remoteServerUrl.');
       }
       const driver = createDriverForPlatform(platform);
       log.info(`Sending session with ${driver.constructor.name}`);
@@ -342,7 +341,7 @@ export async function createSessionAction(args: {
       buildCreateSessionFailureMessage(error, {
         platform: args.platform,
         remoteServerUrl: args.remoteServerUrl,
-        customCapabilities: args.capabilities,
+        finalCapabilities,
       })
     );
   }
@@ -353,21 +352,21 @@ function buildCreateSessionFailureMessage(
   ctx: {
     platform: 'ios' | 'android' | 'general';
     remoteServerUrl?: string;
-    customCapabilities?: Record<string, any>;
+    finalCapabilities?: Capabilities;
   }
 ): string {
   const detail = toolErrorMessage(error);
   const base = `Failed to create session. ${detail}`;
 
   if (ctx.remoteServerUrl) {
-    return `${base} remoteServerUrl="${ctx.remoteServerUrl}". Check the URL and your capabilities.`;
+    return `${base} remoteServerUrl="${ctx.remoteServerUrl}".`;
   }
 
   if (/select_device/i.test(detail)) {
     return base;
   }
 
-  const caps = ctx.customCapabilities ?? {};
+  const caps: Record<string, any> = ctx.finalCapabilities ?? {};
   const hasDeviceTarget =
     Boolean(caps['appium:udid'] || caps['appium:deviceName']) ||
     Boolean(getSelectedDevice());

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -10,7 +10,8 @@ import {
   createDevicePickerUI,
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
-import { textResult } from '../tool-response.js';
+import type { ContentResult } from 'fastmcp';
+import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 
 // Store selected device globally
 let selectedDeviceUdid: string | null = null;
@@ -83,62 +84,74 @@ export default function selectDevice(server: any): void {
       readOnlyHint: false,
       openWorldHint: false,
     },
-    execute: async (args: any, _context: any): Promise<any> => {
+    execute: async (args: any, _context: any): Promise<ContentResult> => {
       try {
         const { platform, iosDeviceType, deviceUdid } = args;
 
         if (platform === 'android') {
           return await handleAndroidDeviceSelection(deviceUdid);
-        } else if (platform === 'ios') {
-          return await handleIOSDeviceSelection(iosDeviceType, deviceUdid);
-        } else {
-          throw new Error(
-            `Invalid platform: ${platform}. Please choose 'android' or 'ios'.`
-          );
         }
-      } catch (error: any) {
+        if (platform === 'ios') {
+          return await handleIOSDeviceSelection(iosDeviceType, deviceUdid);
+        }
+        return errorResult(
+          `Invalid platform '${String(platform)}'. Use platform='android' or platform='ios'.`
+        );
+      } catch (error: unknown) {
         log.error('Error selecting device:', error);
-        throw new Error(`Failed to select device: ${error.message}`, {
-          cause: error,
-        });
+        return errorResult(
+          `Failed to select device. ${toolErrorMessage(error)}`
+        );
       }
     },
   });
 }
 
+type DevicesOk = { ok: true; devices: any[] };
+type DevicesFail = { ok: false; result: ContentResult };
+
 /**
  * Get and validate Android devices
  */
-async function getAndroidDevices(): Promise<any[]> {
+async function getAndroidDevices(): Promise<DevicesOk | DevicesFail> {
   const adb = await ADBManager.getInstance().initialize();
   const devices = await adb.getConnectedDevices();
 
   if (devices.length === 0) {
-    throw new Error('No Android devices/emulators found');
+    return {
+      ok: false,
+      result: errorResult(
+        'No Android devices or emulators found. Connect a USB device with USB debugging enabled, or start an Android emulator, then call select_device again with platform=android.'
+      ),
+    };
   }
 
-  return devices;
+  return { ok: true, devices };
 }
 
 /**
  * Validate and select Android device by UDID
  */
-function selectAndroidDevice(deviceUdid: string, devices: any[]): void {
+function selectAndroidDevice(
+  deviceUdid: string,
+  devices: any[]
+): ContentResult | undefined {
   const selectedDevice = devices.find((d) => d.udid === deviceUdid);
   if (!selectedDevice) {
-    throw new Error(
-      `Device with UDID "${deviceUdid}" not found. Available devices: ${devices.map((d) => d.udid).join(', ')}`
+    return errorResult(
+      `Device with UDID "${deviceUdid}" not found. Available devices: ${devices.map((d) => d.udid).join(', ')}. Call select_device again with deviceUdid set to one of these values.`
     );
   }
 
   selectedDeviceUdid = deviceUdid;
   log.info(`Device selected: ${deviceUdid}`);
+  return undefined;
 }
 
 /**
  * Format device selection response for Android
  */
-function formatAndroidSelectionResponse(deviceUdid: string): any {
+function formatAndroidSelectionResponse(deviceUdid: string): ContentResult {
   return textResult(
     JSON.stringify(
       {
@@ -159,7 +172,7 @@ function formatAndroidSelectionResponse(deviceUdid: string): any {
 /**
  * Format device list response for Android
  */
-function formatAndroidListResponse(devices: any[]): any {
+function formatAndroidListResponse(devices: any[]): ContentResult {
   const deviceList = devices
     .map((device, index) => `  ${index + 1}. ${device.udid}`)
     .join('\n');
@@ -182,12 +195,13 @@ function formatAndroidListResponse(devices: any[]): any {
  */
 function validateIOSDeviceType(
   iosDeviceType: 'simulator' | 'real' | undefined
-): void {
+): ContentResult | undefined {
   if (!iosDeviceType) {
-    throw new Error(
-      "For iOS platform, iosDeviceType ('simulator' or 'real') is required"
+    return errorResult(
+      "iosDeviceType is required when platform=ios. Pass iosDeviceType='simulator' or iosDeviceType='real'."
     );
   }
+  return undefined;
 }
 
 /**
@@ -195,33 +209,42 @@ function validateIOSDeviceType(
  */
 async function getIOSDevices(
   iosDeviceType: 'simulator' | 'real'
-): Promise<any[]> {
+): Promise<DevicesOk | DevicesFail> {
   const iosManager = IOSManager.getInstance();
   const devices = await iosManager.getDevicesByType(iosDeviceType);
 
   if (devices.length === 0) {
-    throw new Error(
-      `No iOS ${iosDeviceType === 'simulator' ? 'simulators' : 'devices'} found`
-    );
+    return {
+      ok: false,
+      result: errorResult(
+        `No iOS ${iosDeviceType === 'simulator' ? 'simulators' : 'devices'} found. Start a simulator in Xcode, or connect a real device with Developer Mode enabled, then call select_device again with platform=ios and iosDeviceType=${iosDeviceType}.`
+      ),
+    };
   }
 
-  return devices;
+  return { ok: true, devices };
 }
 
 /**
  * Validate and select iOS device by UDID
  */
+type SelectIOSOk = { ok: true; device: any };
+type SelectIOSFail = { ok: false; result: ContentResult };
+
 function selectIOSDevice(
   deviceUdid: string,
   devices: any[],
   iosDeviceType: 'simulator' | 'real'
-): any {
+): SelectIOSOk | SelectIOSFail {
   const selectedDevice = devices.find((d) => d.udid === deviceUdid);
   if (!selectedDevice) {
     const deviceList = devices.map((d) => `${d.name} (${d.udid})`).join(', ');
-    throw new Error(
-      `Device with UDID "${deviceUdid}" not found. Available devices: ${deviceList}`
-    );
+    return {
+      ok: false,
+      result: errorResult(
+        `Device with UDID "${deviceUdid}" not found. Available devices: ${deviceList}. Call select_device again with deviceUdid set to one of these values.`
+      ),
+    };
   }
 
   selectedDeviceUdid = deviceUdid;
@@ -231,7 +254,7 @@ function selectIOSDevice(
     `iOS ${iosDeviceType} selected: ${selectedDevice.name} (${deviceUdid})`
   );
 
-  return selectedDevice;
+  return { ok: true, device: selectedDevice };
 }
 
 /**
@@ -240,7 +263,7 @@ function selectIOSDevice(
 function formatIOSSelectionResponse(
   deviceName: string,
   deviceUdid: string
-): any {
+): ContentResult {
   return textResult(
     JSON.stringify(
       {
@@ -264,7 +287,7 @@ function formatIOSSelectionResponse(
 function formatIOSListResponse(
   devices: any[],
   iosDeviceType: 'simulator' | 'real'
-): any {
+): ContentResult {
   const deviceList = devices
     .map(
       (device, index) =>
@@ -288,17 +311,29 @@ function formatIOSListResponse(
 /**
  * Handle Android device selection
  */
-async function handleAndroidDeviceSelection(deviceUdid?: string): Promise<any> {
-  const devices = await getAndroidDevices();
+async function handleAndroidDeviceSelection(
+  deviceUdid?: string
+): Promise<ContentResult> {
+  const listed = await getAndroidDevices();
+  if (!listed.ok) {
+    return listed.result;
+  }
+  const { devices } = listed;
 
   if (deviceUdid) {
-    selectAndroidDevice(deviceUdid, devices);
+    const selectionError = selectAndroidDevice(deviceUdid, devices);
+    if (selectionError) {
+      return selectionError;
+    }
     return formatAndroidSelectionResponse(deviceUdid);
   }
 
   // Auto-select when only one device is available
   if (devices.length === 1) {
-    selectAndroidDevice(devices[0].udid, devices);
+    const selectionError = selectAndroidDevice(devices[0].udid, devices);
+    if (selectionError) {
+      return selectionError;
+    }
     return formatAndroidSelectionResponse(devices[0].udid);
   }
 
@@ -311,29 +346,40 @@ async function handleAndroidDeviceSelection(deviceUdid?: string): Promise<any> {
 async function handleIOSDeviceSelection(
   iosDeviceType: 'simulator' | 'real' | undefined,
   deviceUdid?: string
-): Promise<any> {
+): Promise<ContentResult> {
   const iosManager = IOSManager.getInstance();
   if (!iosManager.isMac()) {
-    throw new Error('iOS testing is only available on macOS');
+    return errorResult(
+      'iOS device selection requires macOS with Xcode installed. Use platform=android on this host, or connect to a remote macOS Appium server with remoteServerUrl on appium_session_management (action=create).'
+    );
   }
 
-  validateIOSDeviceType(iosDeviceType);
+  const typeError = validateIOSDeviceType(iosDeviceType);
+  if (typeError) {
+    return typeError;
+  }
 
-  const devices = await getIOSDevices(iosDeviceType!);
+  const listed = await getIOSDevices(iosDeviceType!);
+  if (!listed.ok) {
+    return listed.result;
+  }
+  const { devices } = listed;
 
   if (deviceUdid) {
-    const selectedDevice = selectIOSDevice(deviceUdid, devices, iosDeviceType!);
-    return formatIOSSelectionResponse(selectedDevice.name, deviceUdid);
+    const selected = selectIOSDevice(deviceUdid, devices, iosDeviceType!);
+    if (!selected.ok) {
+      return selected.result;
+    }
+    return formatIOSSelectionResponse(selected.device.name, deviceUdid);
   }
 
   // Auto-select when only one device is available
   if (devices.length === 1) {
-    const selectedDevice = selectIOSDevice(
-      devices[0].udid,
-      devices,
-      iosDeviceType!
-    );
-    return formatIOSSelectionResponse(selectedDevice.name, devices[0].udid);
+    const selected = selectIOSDevice(devices[0].udid, devices, iosDeviceType!);
+    if (!selected.ok) {
+      return selected.result;
+    }
+    return formatIOSSelectionResponse(selected.device.name, devices[0].udid);
   }
 
   return formatIOSListResponse(devices, iosDeviceType!);

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -350,7 +350,7 @@ async function handleIOSDeviceSelection(
   const iosManager = IOSManager.getInstance();
   if (!iosManager.isMac()) {
     return errorResult(
-      'iOS device selection requires macOS with Xcode installed. To automate iOS from this host, use appium_session_management (action=create) with a remoteServerUrl that points at a macOS Appium server.'
+      'iOS device selection requires macOS with Xcode installed.'
     );
   }
 

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -350,7 +350,7 @@ async function handleIOSDeviceSelection(
   const iosManager = IOSManager.getInstance();
   if (!iosManager.isMac()) {
     return errorResult(
-      'iOS device selection requires macOS with Xcode installed. Use platform=android on this host, or connect to a remote macOS Appium server with remoteServerUrl on appium_session_management (action=create).'
+      'iOS device selection requires macOS with Xcode installed. To automate iOS from this host, use appium_session_management (action=create) with a remoteServerUrl that points at a macOS Appium server.'
     );
   }
 


### PR DESCRIPTION
when select_device or session create failed, the server often threw instead of returning a normal tool error. Many MCP hosts then show something like “Tool execution failed: …” and the model loses the real message
**The PR fixes :**
- select_device --> failures (no devices, bad UDID, iOS on non‑Mac, missing iosDeviceType, etc.) return isError: true with short, actionable text and what to try next.
- appium_session_management (action=create) --> bad remote URL, platform=general without a remote server, and other create failures return errorResult instead of throwing. iOS “multiple devices, pick one first” still throws inside the helper but is caught and turned into the same error shape