### PR TITLE
feat(attach-session): fetch capabilities automatically from server when attaching sessions

### DIFF
--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -383,7 +383,7 @@ describe('appium_session_management tool', () => {
       );
     });
 
-    test('falls back to caller-provided capabilities when server fetch fails', async () => {
+    test('returns error when both capability endpoints are unreachable', async () => {
       const tool = await getToolExecute();
       // mockFetch already returns ok: false for both endpoints by default
 
@@ -392,34 +392,24 @@ describe('appium_session_management tool', () => {
           action: 'attach',
           remoteServerUrl: 'http://localhost:4723',
           sessionId: 'borrowed',
-          capabilities: {
-            platformName: 'Android',
-            'appium:automationName': 'UiAutomator2',
-            deviceName: 'Pixel 9 Pro XL',
-            'appium:app': 'demo.apk',
-          },
+          capabilities: { platformName: 'Android' },
         },
         undefined
       );
 
-      expect(result.isError).toBeFalsy();
-      expect(mockSetSession).toHaveBeenCalledWith(
-        expect.anything(),
-        'borrowed',
-        {
-          platformName: 'Android',
-          'appium:automationName': 'UiAutomator2',
-          'appium:deviceName': 'Pixel 9 Pro XL',
-          'appium:app': 'demo.apk',
-        },
-        'attached',
-        expect.any(String)
-      );
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Failed to fetch capabilities');
+      expect(result.content[0].text).toContain('borrowed');
+      expect(mockAttachToSession).not.toHaveBeenCalled();
     });
 
     test('detaches an existing attached session before re-attaching the same id', async () => {
       const tool = await getToolExecute();
       mockGetSessionOwnership.mockReturnValue('attached');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: { platformName: 'Android' } }),
+      } as Response);
 
       const result = await tool.execute(
         {

--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -113,6 +113,10 @@ const {
 
 const mockServer = { addTool: jest.fn() } as any;
 
+// Default fetch mock: both capability endpoints return nothing (404-like).
+// Individual tests override this for the specific responses they need.
+let mockFetch: jest.MockedFunction<typeof fetch>;
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockGetSessionOwnership.mockReturnValue(null);
@@ -120,6 +124,10 @@ beforeEach(() => {
     sessionId: 'attached-session-id',
     capabilities: { platformName: 'Android' },
   });
+  mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+    ok: false,
+  } as Response);
+  global.fetch = mockFetch;
 });
 
 async function getToolExecute() {
@@ -270,82 +278,82 @@ describe('appium_session_management tool', () => {
       );
     });
 
-    test('attaches an existing remote session and prefers getAppiumSessionCapabilities per field', async () => {
+    test('fetches capabilities from server before creating client and prefers W3C extension endpoint', async () => {
       const tool = await getToolExecute();
       mockListSessions.mockReturnValue([
         { sessionId: 'borrowed', isActive: true, ownership: 'attached' },
       ] as any);
-      mockAttachToSession.mockResolvedValue({
-        sessionId: 'attached-session-id',
-        getAppiumSessionCapabilities: async () => ({
-          capabilities: {
-            platformName: 'Android',
-            automationName: 'UiAutomator2',
-          },
-        }),
-        getSession: async () => ({
-          platformName: 'iOS',
-          automationName: 'XCUITest',
-          deviceName: 'Ignored Device',
-        }),
-      } as any);
+      mockFetch.mockImplementation(async (input) => {
+        const url = input.toString();
+        if (url.includes('appium/session_capabilities')) {
+          return {
+            ok: true,
+            json: async () => ({
+              value: {
+                platformName: 'Android',
+                automationName: 'UiAutomator2',
+              },
+            }),
+          } as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            value: {
+              platformName: 'iOS',
+              automationName: 'XCUITest',
+              deviceName: 'Ignored Device',
+            },
+          }),
+        } as Response;
+      });
 
       const result = await tool.execute(
         {
           action: 'attach',
           remoteServerUrl: 'http://localhost:4723',
           sessionId: 'borrowed',
-          capabilities: {
-            platformName: 'Provided',
-            automationName: 'UiAutomator2',
-            deviceName: 'Pixel 9 Pro XL',
-            'appium:app': 'demo.apk',
-          },
+          capabilities: { 'appium:app': 'demo.apk' },
         },
         undefined
       );
 
       expect(result.isError).toBeFalsy();
       expect(result.content[0].text).toContain('Attached to existing session');
-      expect(mockAttachToSession).toHaveBeenCalledWith({
-        sessionId: 'borrowed',
-        protocol: 'http',
-        hostname: 'localhost',
-        port: 4723,
-        path: '/',
-        capabilities: {
-          platformName: 'Provided',
-          automationName: 'UiAutomator2',
-          deviceName: 'Pixel 9 Pro XL',
-          'appium:app': 'demo.apk',
-        },
-      });
+      // Client created with merged caps — W3C extension wins over deprecated and caller
+      expect(mockAttachToSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          capabilities: expect.objectContaining({ platformName: 'Android' }),
+        })
+      );
       expect(mockSetSession).toHaveBeenCalledWith(
         expect.anything(),
         'borrowed',
         {
-          'appium:app': 'demo.apk',
           platformName: 'Android',
           'appium:automationName': 'UiAutomator2',
           'appium:deviceName': 'Ignored Device',
+          'appium:app': 'demo.apk',
         },
         'attached',
         expect.any(String)
       );
     });
 
-    test('falls back to getSession when getAppiumSessionCapabilities is unavailable', async () => {
+    test('falls back to deprecated session endpoint when W3C extension is unavailable', async () => {
       const tool = await getToolExecute();
-      mockAttachToSession.mockResolvedValue({
-        sessionId: 'attached-session-id',
-        getAppiumSessionCapabilities: async () => {
-          throw new Error('unsupported');
-        },
-        getSession: async () => ({
-          platformName: 'Android',
-          automationName: 'UiAutomator2',
-        }),
-      } as any);
+      mockFetch.mockImplementation(async (input) => {
+        const url = input.toString();
+        if (url.includes('appium/session_capabilities')) {
+          return { ok: false } as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            value: { platformName: 'Android', automationName: 'UiAutomator2' },
+          }),
+        } as Response;
+      });
 
       const result = await tool.execute(
         {
@@ -365,21 +373,19 @@ describe('appium_session_management tool', () => {
         expect.anything(),
         'borrowed',
         {
-          'appium:app': 'demo.apk',
           platformName: 'Android',
           'appium:automationName': 'UiAutomator2',
           'appium:deviceName': 'Pixel 9 Pro XL',
+          'appium:app': 'demo.apk',
         },
         'attached',
         expect.any(String)
       );
     });
 
-    test('falls back to provided capabilities when runtime capability methods are unavailable', async () => {
+    test('falls back to caller-provided capabilities when server fetch fails', async () => {
       const tool = await getToolExecute();
-      mockAttachToSession.mockResolvedValue({
-        sessionId: 'attached-session-id',
-      } as any);
+      // mockFetch already returns ok: false for both endpoints by default
 
       const result = await tool.execute(
         {
@@ -401,10 +407,10 @@ describe('appium_session_management tool', () => {
         expect.anything(),
         'borrowed',
         {
-          'appium:app': 'demo.apk',
           platformName: 'Android',
           'appium:automationName': 'UiAutomator2',
           'appium:deviceName': 'Pixel 9 Pro XL',
+          'appium:app': 'demo.apk',
         },
         'attached',
         expect.any(String)

--- a/src/tools/session/attach-session.ts
+++ b/src/tools/session/attach-session.ts
@@ -10,7 +10,7 @@ import {
 import { readAllPersistedSessions } from '../../persistence.js';
 import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 import { validateRemoteServerUrl } from './create-session.js';
-import { attachToRemoteSession } from '../../utils/url.js';
+import { attachToRemoteSession, getPortFromUrl } from '../../utils/url.js';
 
 /**
  * Normalize capability payloads returned by Appium/WebdriverIO into a flat
@@ -44,9 +44,14 @@ const METADATA_FIELDS = [
  * Attach MCP Appium to an existing remote Appium session without taking
  * ownership of the underlying session lifecycle.
  *
+ * Session capabilities are fetched from the server before creating the
+ * WebDriver client so that WebDriver.attachToSession receives the full
+ * capability set (including platformName) and sessionEnvironmentDetector can
+ * correctly configure isMobile / isAndroid / isIOS on the client instance.
+ *
  * @param args - Remote server location, target session id, and optional
- *   capability overrides to seed local metadata.
- * @returns A tool response describing whether the attach succeeded.
+ *   capability overrides.
+ * @returns A tool response describing whether the attachment succeeded.
  */
 export async function attachSessionAction(args: {
   remoteServerUrl: string;
@@ -69,29 +74,41 @@ export async function attachSessionAction(args: {
       process.env.REMOTE_SERVER_URL_ALLOW_REGEX
     );
 
-    const client: Client = await attachToRemoteSession({
-      remoteServerUrl: args.remoteServerUrl,
-      sessionId: args.sessionId,
-      capabilities: args.capabilities,
-    });
-
-    const [appiumCapabilities, sessionCapabilities] = await Promise.all([
-      readClientCapabilities(client, 'getAppiumSessionCapabilities'),
-      readClientCapabilities(client, 'getSession'),
-    ]);
+    // Fetch capabilities from the server BEFORE creating the WebDriver client.
+    // This ensures WebDriver.attachToSession receives platformName so that
+    // sessionEnvironmentDetector configures isMobile / isAndroid / isIOS
+    // correctly. Caller-provided capabilities take the lowest priority; the W3C
+    // Appium extension endpoint wins.
+    const [sessionCapabilities, deprecatedSessionCapabilities] =
+      await Promise.all([
+        fetchCapabilitiesFromServer(
+          args.remoteServerUrl,
+          args.sessionId,
+          'appium/session_capabilities'
+        ),
+        fetchCapabilitiesFromServer(args.remoteServerUrl, args.sessionId),
+      ]);
 
     const sources = [
-      appiumCapabilities,
       sessionCapabilities,
+      deprecatedSessionCapabilities,
       args.capabilities,
     ];
     const capabilities: SessionCapabilities = Object.assign(
       {},
       args.capabilities ?? {},
-      sessionCapabilities ?? {},
-      appiumCapabilities ?? {}
+      deprecatedSessionCapabilities ?? {},
+      sessionCapabilities ?? {}
     );
 
+    const client: Client = await attachToRemoteSession({
+      remoteServerUrl: args.remoteServerUrl,
+      sessionId: args.sessionId,
+      capabilities,
+    });
+
+    // Normalize metadata fields into their canonical prefixed forms for
+    // local session tracking.
     for (const [plainKey, prefixedKey, targetKey] of METADATA_FIELDS) {
       const source = sources.find(
         (candidate) =>
@@ -99,10 +116,8 @@ export async function attachSessionAction(args: {
           candidate?.[prefixedKey] !== undefined
       );
       const value = source?.[plainKey] ?? source?.[prefixedKey];
-
       delete capabilities[plainKey];
       delete capabilities[prefixedKey];
-
       if (value !== undefined) {
         capabilities[targetKey] = value;
       }
@@ -141,23 +156,49 @@ export async function attachSessionAction(args: {
 }
 
 /**
- * Read capabilities from a WebdriverIO client method when available.
+ * Fetch session capabilities from the Appium server via a plain HTTP request.
  *
- * @param client - Attached WebdriverIO client for the target Appium session.
- * @param methodName - Capability reader to invoke on the client.
- * @returns Parsed capabilities, or `undefined` when the method is missing or fails.
+ * Making this request before WebDriver.attachToSession avoids the ordering
+ * problem where the client is created before platformName is known.
+ *
+ * @param remoteServerUrl - Base URL of the Appium server.
+ * @param sessionId - ID of the existing session to query.
+ * @param endpoint - Optional sub-path after `/session/{id}/`.
+ * @returns Parsed capabilities, or `undefined` when the request fails or the
+ *   endpoint is not supported by the server.
  */
-async function readClientCapabilities(
-  client: Client,
-  methodName: 'getAppiumSessionCapabilities' | 'getSession'
+async function fetchCapabilitiesFromServer(
+  remoteServerUrl: string,
+  sessionId: string,
+  endpoint?: string
 ): Promise<SessionCapabilities | undefined> {
-  const method = client[methodName];
-  if (typeof method !== 'function') {
-    return undefined;
-  }
-
   try {
-    return readCapabilities(await method.call(client));
+    const url = new URL(remoteServerUrl);
+    const port = getPortFromUrl(url);
+    const basePath = url.pathname.replace(/\/$/, '');
+    const path = `${basePath}/session/${sessionId}${endpoint ? '/' + endpoint : ''}`;
+    const requestUrl = `${url.protocol}//${url.hostname}:${port}${path}`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (url.username && url.password) {
+      const credentials = Buffer.from(
+        `${decodeURIComponent(url.username)}:${decodeURIComponent(url.password)}`
+      ).toString('base64');
+      headers.Authorization = `Basic ${credentials}`;
+    }
+
+    const response = await fetch(requestUrl, {
+      headers,
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const json = (await response.json()) as { value?: unknown };
+    return readCapabilities(json.value);
   } catch {
     return undefined;
   }

--- a/src/tools/session/attach-session.ts
+++ b/src/tools/session/attach-session.ts
@@ -89,6 +89,16 @@ export async function attachSessionAction(args: {
         fetchCapabilitiesFromServer(args.remoteServerUrl, args.sessionId),
       ]);
 
+    if (
+      sessionCapabilities === undefined &&
+      deprecatedSessionCapabilities === undefined
+    ) {
+      return errorResult(
+        `Failed to fetch capabilities for session ${args.sessionId} from ${args.remoteServerUrl}. ` +
+          `The server may be unreachable or the session may no longer exist.`
+      );
+    }
+
     const sources = [
       sessionCapabilities,
       deprecatedSessionCapabilities,

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -39,7 +39,7 @@ const schema = z.object({
     .describe(
       'Action to perform. ' +
         `create: ${CREATE_SESSION_DESCRIPTION}` +
-        'attach: Attach MCP Appium to an existing remote Appium session without taking ownership of its lifecycle. Requires remoteServerUrl and sessionId.' +
+        'attach: Attach MCP Appium to an existing remote Appium session without taking ownership of its lifecycle. Requires remoteServerUrl and sessionId. Always pass capabilities with at least platformName (e.g. \'{"platformName":"iOS"}\' or \'{"platformName":"Android"}\') so the client is configured with the correct protocol commands.' +
         'detach: Remove an attached Appium session from MCP Appium without deleting the real remote session. Defaults to the active session.' +
         'delete: Delete a mobile session and clean up resources. If sessionId is omitted, deletes the active session.' +
         'list: List all active Appium sessions managed by this MCP server, including active flag, ownership, and current context.' +
@@ -59,9 +59,8 @@ const schema = z.object({
     .optional()
     .describe(
       'Optional W3C capabilities for create. Provide as a JSON string (e.g. \'{"appium:app":"/path/to/app","appium:platformVersion":"17.0"}\'). ' +
-        'Applied on top of defaults for ios/android, or used as-is for general. ' +
-        'Common: appium:app, appium:deviceName, appium:platformVersion, appium:bundleId. ' +
-        'When passing from a capabilitiesHint result, serialize the full object to JSON — do NOT drop boolean or numeric values.'
+        'For create: applied on top of defaults for ios/android, or used as-is for general. Common: appium:app, appium:deviceName, appium:platformVersion, appium:bundleId. When passing from a capabilitiesHint result, serialize the full object to JSON — do NOT drop boolean or numeric values. ' +
+        'For attach: always include platformName ("iOS" or "Android") so the WebDriver client loads the correct Appium protocol commands (e.g. \'{"platformName":"iOS"}\').'
     ),
   remoteServerUrl: z
     .string()

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -37,7 +37,7 @@ export async function attachToRemoteSession(
     hostname: url.hostname,
     port,
     path: url.pathname,
-    capabilities: options.capabilities,
+    capabilities: options.capabilities ?? {},
     ...(user && key ? { user, key } : {}),
   });
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -3,7 +3,7 @@ import WebDriver, { type Client } from 'webdriver';
 export interface RemoteAttachOptions {
   remoteServerUrl: string;
   sessionId: string;
-  capabilities?: Record<string, unknown>;
+  capabilities: Record<string, unknown>;
 }
 
 /**
@@ -37,7 +37,7 @@ export async function attachToRemoteSession(
     hostname: url.hostname,
     port,
     path: url.pathname,
-    capabilities: options.capabilities ?? {},
+    capabilities: options.capabilities,
     ...(user && key ? { user, key } : {}),
   });
 }


### PR DESCRIPTION
 Give proper capabilities/flags to webdriver client to generate a proper client instance

Fixes https://github.com/appium/appium-mcp/issues/299