### PR TITLE
fix(build): cast Android Uiautomator2 sessions to AndroidDriverBase

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,5 +1,6 @@
 import type { Client } from 'webdriver';
 import {
+  asAndroidDriver,
   getPlatformName,
   isAndroidUiautomator2DriverSession,
   isRemoteDriverSession,
@@ -40,7 +41,7 @@ export async function execute(
   params: any
 ): Promise<any> {
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.execute(cmd, params);
+    return await asAndroidDriver(driver).execute(cmd, params);
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.execute(cmd, params);
   } else {
@@ -64,7 +65,7 @@ export async function queryAppState(
   appId: string
 ): Promise<number> {
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.queryAppState(appId);
+    return await asAndroidDriver(driver).queryAppState(appId);
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.queryAppState(appId);
   }
@@ -121,7 +122,7 @@ export async function activateApp(
   appId: string
 ): Promise<void> {
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.activateApp(appId);
+    return await asAndroidDriver(driver).activateApp(appId);
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.activateApp(appId);
   }
@@ -138,7 +139,7 @@ export async function getCurrentContext(
   driver: DriverInstance
 ): Promise<string> {
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.getCurrentContext();
+    return await asAndroidDriver(driver).getCurrentContext();
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.getCurrentContext();
   } else if (isRemoteDriverSession(driver)) {
@@ -155,7 +156,7 @@ export async function getCurrentContext(
  */
 export async function getContexts(driver: DriverInstance): Promise<string[]> {
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.getContexts();
+    return await asAndroidDriver(driver).getContexts();
   } else if (isXCUITestDriverSession(driver)) {
     return (await driver.getContexts()) as string[];
   } else if (isRemoteDriverSession(driver)) {
@@ -176,7 +177,7 @@ export async function setContext(
   name?: string
 ): Promise<void> {
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.setContext(name);
+    return await asAndroidDriver(driver).setContext(name);
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.setContext(name || null);
   } else if (isRemoteDriverSession(driver)) {
@@ -229,7 +230,7 @@ export async function setValue(
     return await performActions(driver, [buildW3cKeyActions(text)]);
   }
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.setValue(text, elementUUID);
+    return await asAndroidDriver(driver).setValue(text, elementUUID);
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.setValue(text, elementUUID);
   }
@@ -473,7 +474,7 @@ export async function startRecordingScreen(
   options: IOSRecordingOptions | AndroidRecordingOptions = {}
 ): Promise<string> {
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.startRecordingScreen(
+    return await asAndroidDriver(driver).startRecordingScreen(
       options as AndroidRecordingOptions
     );
   } else if (isXCUITestDriverSession(driver)) {
@@ -492,7 +493,7 @@ export async function stopRecordingScreen(
   driver: DriverInstance
 ): Promise<string> {
   if (isAndroidUiautomator2DriverSession(driver)) {
-    return await driver.stopRecordingScreen({});
+    return await asAndroidDriver(driver).stopRecordingScreen({});
   } else if (isXCUITestDriverSession(driver)) {
     return (await driver.stopRecordingScreen({})) ?? '';
   }

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -35,18 +35,6 @@ export type AndroidDriverBase = ThisParameterType<
   AndroidUiautomator2Driver['activateApp']
 >;
 
-/**
- * Cast a narrowed uiautomator2 session to its {@link AndroidDriverBase} so that
- * commands inherited from `AndroidDriver` remain callable. See the
- * {@link AndroidDriverBase} docs for the upstream type regression this works
- * around.
- */
-export function asAndroidDriver(
-  driver: AndroidUiautomator2Driver
-): AndroidDriverBase {
-  return driver as unknown as AndroidDriverBase;
-}
-
 export type SessionCapabilities = Record<string, any>;
 export type SessionOwnership = 'owned' | 'attached';
 
@@ -80,6 +68,18 @@ export const PLATFORM = {
   android: 'Android',
   ios: 'iOS',
 };
+
+/**
+ * Cast a narrowed uiautomator2 session to its {@link AndroidDriverBase} so that
+ * commands inherited from `AndroidDriver` remain callable. See the
+ * {@link AndroidDriverBase} docs for the upstream type regression this works
+ * around.
+ */
+export function asAndroidDriver(
+  driver: AndroidUiautomator2Driver
+): AndroidDriverBase {
+  return driver as unknown as AndroidDriverBase;
+}
 
 /**
  * Determine whether the provided driver represents a remote Appium session

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -13,6 +13,40 @@ export type DriverInstance =
   | AndroidUiautomator2Driver
   | XCUITestDriver;
 export type NullableDriverInstance = DriverInstance | null;
+
+/**
+ * The `AndroidDriver` base type, recovered from an inherited command's `this`
+ * annotation. It is derived rather than imported because `appium-android-driver`
+ * is only a transitive dependency and is not re-exported by
+ * `appium-uiautomator2-driver`.
+ *
+ * Why this exists: as of `appium-android-driver@13` (pulled in by
+ * `appium-uiautomator2-driver@7`), the base `getAttribute()` returns
+ * `Promise<string | null>` while `AndroidUiautomator2Driver` overrides it to
+ * return the non-null `Promise<string>`. That makes `AndroidUiautomator2Driver`
+ * no longer structurally assignable to its own `AndroidDriver` base, so every
+ * command *inherited* from `AndroidDriver` (declared with `this: AndroidDriver`,
+ * e.g. `execute`, `activateApp`, `setValue`) becomes impossible to call on a
+ * narrowed uiautomator2 session (TS2684). Casting such a session with
+ * {@link asAndroidDriver} restores access to those inherited commands with
+ * their real signatures.
+ */
+export type AndroidDriverBase = ThisParameterType<
+  AndroidUiautomator2Driver['activateApp']
+>;
+
+/**
+ * Cast a narrowed uiautomator2 session to its {@link AndroidDriverBase} so that
+ * commands inherited from `AndroidDriver` remain callable. See the
+ * {@link AndroidDriverBase} docs for the upstream type regression this works
+ * around.
+ */
+export function asAndroidDriver(
+  driver: AndroidUiautomator2Driver
+): AndroidDriverBase {
+  return driver as unknown as AndroidDriverBase;
+}
+
 export type SessionCapabilities = Record<string, any>;
 export type SessionOwnership = 'owned' | 'attached';
 

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -3,6 +3,7 @@ import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { DriverInstance } from '../../session-store.js';
 import {
+  asAndroidDriver,
   getPlatformName,
   isRemoteDriverSession,
   isAndroidUiautomator2DriverSession,
@@ -14,7 +15,6 @@ import {
   createAppListUI,
   addUIResourceToResponse,
 } from '../../ui/mcp-ui-utils.js';
-import type { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import type { XCUITestDriver } from 'appium-xcuitest-driver';
 import { execute } from '../../command.js';
 import {
@@ -74,7 +74,7 @@ export async function listAppsFromDevice(
     platform === PLATFORM.android &&
     isAndroidUiautomator2DriverSession(driver)
   ) {
-    const result = await (driver as AndroidUiautomator2Driver).mobileListApps();
+    const result = await asAndroidDriver(driver).mobileListApps();
     const ids = Object.keys(result || {});
     return ids.map((packageName) => ({ packageName, appName: packageName }));
   }


### PR DESCRIPTION
Currently, when we run `npm run build` we are getting errors related to Android Uiautomator2, this casts and fixes the issue. The cause is mentioned as comment for `AndroidDriverBase` type declaration.

Let me know if we can have a better fix for this.

We could also add `"strictFunctionTypes": false` in `tsconfig.json` to suppress errors but I don't think that's good. 