### PR TITLE
fix(session): keep device selection when create fails

### DIFF
--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -10,6 +10,7 @@ const mockAttachToSession = jest.fn<
 }));
 
 let mockSelectedDevicePlatform: 'android' | 'ios' | null = 'ios';
+const mockClearSelectedDevice = jest.fn();
 
 jest.unstable_mockModule('../../../tools/session/select-device', () => ({
   getSelectedDevice: () => 'device-udid',
@@ -17,7 +18,7 @@ jest.unstable_mockModule('../../../tools/session/select-device', () => ({
   getSelectedDeviceType: () =>
     mockSelectedDevicePlatform === 'ios' ? 'simulator' : null,
   getSelectedDeviceInfo: () => ({ name: 'iPhone 12', platform: '16.0' }),
-  clearSelectedDevice: () => {},
+  clearSelectedDevice: mockClearSelectedDevice,
 }));
 
 jest.unstable_mockModule('../../../devicemanager/ios-manager', () => ({
@@ -525,6 +526,14 @@ describe('buildAndroidCapabilities', () => {
     expect(caps.platformName).toBe('Android');
     expect(caps).not.toHaveProperty('appium:udid');
   });
+
+  test('does not clear the selected device while building capabilities', () => {
+    mockSelectedDevicePlatform = 'android';
+
+    buildAndroidCapabilities({}, undefined, false);
+
+    expect(mockClearSelectedDevice).not.toHaveBeenCalled();
+  });
 });
 
 describe('buildIOSCapabilities', () => {
@@ -562,6 +571,14 @@ describe('buildIOSCapabilities', () => {
     expect(caps.platformName).toBe('iOS');
     expect(caps['appium:deviceName']).toBe('iPhone Simulator');
     expect(caps).not.toHaveProperty('appium:udid');
+  });
+
+  test('does not clear the selected device while building capabilities', async () => {
+    mockSelectedDevicePlatform = 'ios';
+
+    await buildIOSCapabilities({}, undefined, false);
+
+    expect(mockClearSelectedDevice).not.toHaveBeenCalled();
   });
 });
 

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -97,10 +97,6 @@ export function buildAndroidCapabilities(
     ...customCaps,
   };
 
-  if (selectedDeviceUdid) {
-    clearSelectedDevice();
-  }
-
   return filterEmptyCapabilities(capabilities);
 }
 
@@ -187,10 +183,6 @@ export async function buildIOSCapabilities(
     // customCaps should override additionalCaps.
     ...customCaps,
   };
-
-  if (selectedDeviceUdid) {
-    clearSelectedDevice();
-  }
 
   return filterEmptyCapabilities(capabilities);
 }
@@ -324,6 +316,8 @@ export async function createSessionAction(args: {
       await setSession(driver, sessionId, finalCapabilities, 'owned');
     }
 
+    clearSelectedDeviceAfterSuccessfulCreate(platform, remoteServerUrl);
+
     const sessionIdStr =
       typeof sessionId === 'string'
         ? sessionId
@@ -361,6 +355,25 @@ export async function createSessionAction(args: {
         finalCapabilities,
       })
     );
+  }
+}
+
+/**
+ * Clear the selected device only after a session has been created
+ * successfully, so a failed create attempt does not force the user to run
+ * select_device again. No-op for remote and general sessions, which do not
+ * consume the local device selection.
+ */
+function clearSelectedDeviceAfterSuccessfulCreate(
+  platform: (typeof DRIVER_MODE_PLATFORMS)[number],
+  remoteServerUrl?: string
+): void {
+  if (remoteServerUrl || platform === 'general') {
+    return;
+  }
+
+  if (getSelectedDevicePlatform() === platform) {
+    clearSelectedDevice();
   }
 }
 


### PR DESCRIPTION
- When a user runs select_device and then appium_session_management with action=create, a failed session creation still clears the selected device.

- clearSelectedDevice() ran inside buildAndroidCapabilities() and buildIOSCapabilities() while capabilities were being built --> before the session was actually created. If create failed (missing app, WDA error, port conflict, invalid caps, etc.), the selected UDID and platform were already gone, the user had to run select_device again even when the failure had nothing to do with device choice.

**Expected behavior**
- Device selection should stay until session creation succeeds, so the user can retry action=create without re-selecting the device.

**Fix**
- Move clearSelectedDevice() to after a successful setSession(), and only for local Android/iOS sessions where the selected platform matches.