### PR TITLE
fix: find command element not-found misclassification

### DIFF
--- a/src/tests/tools/interactions/webdriver-ai-element-rejection.test.ts
+++ b/src/tests/tools/interactions/webdriver-ai-element-rejection.test.ts
@@ -10,6 +10,7 @@ jest.unstable_mockModule('../../../persistence.js', () => ({
 jest.unstable_mockModule('../../../session-store.js', () => ({
   getDriver: jest.fn(),
   setSession: jest.fn(),
+  getSessionInfo: jest.fn(() => null),
 }));
 
 jest.unstable_mockModule('../../../command.js', () => ({
@@ -131,5 +132,26 @@ describe('interaction tools and ai-element tokens', () => {
     expect(result.isError).toBe(true);
     expect(textFromResult(result)).toBe(AI_WEBDRIVER_REJECTION);
     expect(mockGetElementAttribute).not.toHaveBeenCalled();
+  });
+
+  test('find_element reports ELEMENT_NOT_FOUND for an id-less match', async () => {
+    process.env.APPIUM_MCP_EVIDENCE = '1';
+    try {
+      mockGetDriver.mockReturnValue({
+        findElement: jest.fn(async () => ({})), // resolves, but no element id
+      } as any);
+      const tool = await loadTool('../../../tools/interactions/find.js');
+      const result = await runTool(tool, {
+        strategy: 'id',
+        selector: 'org.x:id/nope',
+      });
+
+      expect(result.isError).toBe(true);
+      const block = result.content.find((c: any) => c.type === 'resource');
+      const record = JSON.parse(block.resource.text);
+      expect(record.error.code).toBe('ELEMENT_NOT_FOUND');
+    } finally {
+      delete process.env.APPIUM_MCP_EVIDENCE;
+    }
   });
 });

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -83,7 +83,10 @@ export default function findElement(server: FastMCP): void {
         const elementId = readWebElementId(element);
         if (!elementId) {
           return withEvidence(
-            errorResult('Element was returned without a valid element ID'),
+            errorResult(
+              `Element not found: the locator matched no resolvable element ` +
+                `(no element id returned) for strategy '${args.strategy}' selector '${args.selector}'.`
+            ),
             {
               name: 'appium_find_element',
               stage: 'locate',


### PR DESCRIPTION
### Why?
- `driver.findElement` for a missing element did not throw `NoSuchElement`, it resolved with a payload that had no usable W3C element `id`. 
- `find.ts` already had a branch for that (!elementId), but it returned a generic message with no error object, so the evidence layer classified it from prose and produced:
- `status: error   error.code: ACTION_FAILED   message: "Element was returned without a valid element ID"`
- `ELEMENT_NOT_FOUND` is the single most useful code for a find tool and collapsing it into `ACTION_FAILED` defeats the purpose.

### What?
- `find.ts` -> the `!elementId` branch now returns an honest not-found message, which classifies as `ELEMENT_NOT_FOUND`. 

Case | BEFORE | AFTER
-- | -- | --
find "Search Element" (real, acc id) | success | success
find absent (accessibility id) | error / ACTION_FAILED | error / ELEMENT_NOT_FOUND
find absent (resource-id) | error / ACTION_FAILED | error / ELEMENT_NOT_FOUND

