### PR TITLE
fix(session): reject local create when platform mismatches select_device

### DIFF
--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -111,6 +111,7 @@ const {
   buildIOSCapabilities,
   getPortFromUrl,
   validateRemoteServerUrl,
+  validateLocalCreatePlatformMatch,
 } = await import('../../../tools/session/create-session.js');
 
 // ── tool helper ───────────────────────────────────────────────────────────────
@@ -575,6 +576,52 @@ describe('getPortFromUrl', () => {
     ['https://example.com:8443/path', 8443],
   ])('%s → %i', (url, expected) => {
     expect(getPortFromUrl(new URL(url))).toBe(expected);
+  });
+});
+
+describe('validateLocalCreatePlatformMatch', () => {
+  test('returns error when local create platform mismatches select_device', () => {
+    mockSelectedDevicePlatform = 'ios';
+
+    const result = validateLocalCreatePlatformMatch('android');
+
+    expect(result).toBeDefined();
+    expect(result!.isError).toBe(true);
+    const message = (result!.content[0] as { text: string }).text;
+    expect(message).toContain('platform=android');
+    expect(message).toContain('platform=ios');
+  });
+
+  test('returns error for the reverse mismatch (android selected, ios create)', () => {
+    mockSelectedDevicePlatform = 'android';
+
+    const result = validateLocalCreatePlatformMatch('ios');
+
+    expect(result).toBeDefined();
+    expect(result!.isError).toBe(true);
+    const message = (result!.content[0] as { text: string }).text;
+    expect(message).toContain('platform=ios');
+    expect(message).toContain('platform=android');
+  });
+
+  test('allows remote create without matching select_device platform', () => {
+    mockSelectedDevicePlatform = 'ios';
+
+    expect(
+      validateLocalCreatePlatformMatch('android', 'http://localhost:4723')
+    ).toBeUndefined();
+  });
+
+  test('allows matching local platform', () => {
+    mockSelectedDevicePlatform = 'android';
+
+    expect(validateLocalCreatePlatformMatch('android')).toBeUndefined();
+  });
+
+  test('allows local create when select_device was not called', () => {
+    mockSelectedDevicePlatform = null;
+
+    expect(validateLocalCreatePlatformMatch('android')).toBeUndefined();
   });
 });
 

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -196,6 +196,27 @@ export async function buildIOSCapabilities(
 }
 
 /**
+ * For local sessions, ensure create platform matches a prior select_device choice.
+ */
+export function validateLocalCreatePlatformMatch(
+  platform: (typeof DRIVER_MODE_PLATFORMS)[number],
+  remoteServerUrl?: string
+): ContentResult | undefined {
+  if (remoteServerUrl || platform === 'general') {
+    return undefined;
+  }
+
+  const selectedPlatform = getSelectedDevicePlatform();
+  if (selectedPlatform && selectedPlatform !== platform) {
+    return errorResult(
+      `platform=${platform} does not match select_device (platform=${selectedPlatform}). Use action=create with platform=${selectedPlatform}, or call select_device again.`
+    );
+  }
+
+  return undefined;
+}
+
+/**
  * Validate the provided remote server URL.
  *
  * @param remoteServerUrl - The URL of the remote Appium server to validate.
@@ -248,6 +269,14 @@ export async function createSessionAction(args: {
       capabilities: customCapabilities,
       remoteServerUrl,
     } = args;
+
+    const platformMismatch = validateLocalCreatePlatformMatch(
+      platform,
+      remoteServerUrl
+    );
+    if (platformMismatch) {
+      return platformMismatch;
+    }
 
     const configCapabilities = await loadCapabilitiesConfig();
     if (platform === 'android') {

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -209,7 +209,7 @@ export function validateLocalCreatePlatformMatch(
   const selectedPlatform = getSelectedDevicePlatform();
   if (selectedPlatform && selectedPlatform !== platform) {
     return errorResult(
-      `platform=${platform} does not match select_device (platform=${selectedPlatform}). Use action=create with platform=${selectedPlatform}, or call select_device again.`
+      `platform=${platform} does not match select_device (platform=${selectedPlatform}).`
     );
   }
 


### PR DESCRIPTION
**Problem**
- For local sessions, the appium_session_management tool says platform must match what was chosen in select_device, but createSessionAction never enforced that, If a user selected an iOS device and the agent called action=create with platform=android, the iOS UDID was dropped silently. The session could start on a default or wrong Android device with no clear error, the capability builders only apply the selected device when platforms align:
buildAndroidCapabilities uses the UDID only when getSelectedDevicePlatform() === 'android'
buildIOSCapabilities does the same for 'ios'
-----------> so a platform mismatch was ignored instead of rejected.

**Expected behavior**
- For local create (no remoteServerUrl), if select_device was used, platform must match that selection. On mismatch, return an actionable errorResult so the agent can fix the call or run select_device again, remote sessions and creates without a prior select_device should behave as before.

**Fix**
- Add validateLocalCreatePlatformMatch() and call it at the start of createSessionAction, before capabilities are built, On mismatch return: platform=android does not match select_device (platform=ios). Use action=create with platform=ios, or call select_device again.