### PR TITLE
fix(find): surface remote "no such element" as a thrown not-found

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -279,6 +279,43 @@ export async function elementClick(
 }
 
 /**
+ * Find a single element by strategy + selector.
+ *
+ * @param driver - The driver instance to query.
+ * @param strategy
+ * @param selector
+ * @returns An element
+ */
+export async function findElement(
+  driver: DriverInstance,
+  strategy: string,
+  selector: string
+): Promise<unknown> {
+  if (isAndroidUiautomator2DriverSession(driver)) {
+    return await driver.findElement(strategy, selector);
+  } else if (isXCUITestDriverSession(driver)) {
+    return await driver.findElement(strategy, selector);
+  }
+  const result = await (driver as Client).findElement(strategy, selector);
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    'error' in result &&
+    (result as { error?: unknown }).error === 'no such element'
+  ) {
+    const message = (result as { message?: unknown }).message;
+    const err = new Error(
+      typeof message === 'string'
+        ? message
+        : 'no such element: An element could not be located on the page using the given search parameters'
+    );
+    err.name = 'no such element';
+    throw err;
+  }
+  return result;
+}
+
+/**
  * Get the bounding rectangle for an element.
  *
  * @param driver - The driver instance to query.

--- a/src/tests/command.test.ts
+++ b/src/tests/command.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect, jest } from '@jest/globals';
+
+jest.unstable_mockModule('../session-store', () => ({
+  getPlatformName: jest.fn(),
+  isAndroidUiautomator2DriverSession: jest.fn(() => false),
+  isRemoteDriverSession: jest.fn(() => true),
+  isXCUITestDriverSession: jest.fn(() => false),
+  PLATFORM: { ios: 'iOS', android: 'Android' },
+  getCurrentContext: jest.fn(),
+  getSessionInfo: jest.fn(),
+}));
+
+const { findElement } = await import('../command.js');
+
+describe('findElement: normalizes remote "no such element"', () => {
+  test('re-throws when the client returns a "no such element" value', async () => {
+    const driver = {
+      findElement: jest.fn(async () => ({
+        error: 'no such element',
+        message:
+          'An element could not be located on the page using the given search parameters',
+        stacktrace: 'io.appium...ElementNotFoundException',
+      })),
+    };
+
+    await expect(
+      findElement(driver as never, 'accessibility id', 'zzz-not-here')
+    ).rejects.toThrow(/could not be located/i);
+  });
+
+  test('returns the element unchanged when a real id is present', async () => {
+    const el = {
+      'element-6066-11e4-a52e-4f735466cecf': 'abc',
+      ELEMENT: 'abc',
+    };
+    const driver = { findElement: jest.fn(async () => el) };
+
+    await expect(findElement(driver as never, 'id', 'real')).resolves.toBe(el);
+  });
+});

--- a/src/tests/tools/llm-wording.test.ts
+++ b/src/tests/tools/llm-wording.test.ts
@@ -15,6 +15,10 @@ jest.unstable_mockModule('../../tools/tool-response', () => ({
   toolErrorMessage: jest.fn(mockToolErrorMessage),
 }));
 
+jest.unstable_mockModule('../../command', () => ({
+  findElement: jest.fn(),
+}));
+
 jest.unstable_mockModule('../../tools/session/attach-session', () => ({
   attachSessionAction: jest.fn(),
 }));

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -8,6 +8,7 @@ import {
   readWebElementId,
 } from '../tool-response.js';
 import { withEvidence, evidenceContext } from '../evidence.js';
+import { findElement as findSingleElement } from '../../command.js';
 
 export const findElementSchema = z.object({
   strategy: z
@@ -79,7 +80,11 @@ export default function findElement(server: FastMCP): void {
       const locator = { strategy: args.strategy, selector: args.selector };
       const context = await evidenceContext(args.sessionId);
       try {
-        const element = await driver.findElement(args.strategy, args.selector);
+        const element = await findSingleElement(
+          driver,
+          args.strategy,
+          args.selector
+        );
         const elementId = readWebElementId(element);
         if (!elementId) {
           return withEvidence(


### PR DESCRIPTION
### What?
For a missing element, `appium_find_element` reported `error.code: ACTION_FAILED` ("Element was returned without a valid element ID") instead of `ELEMENT_NOT_FOUND`.

### Why? 
- `find.ts` calls `driver.findElement(...)` directly. 
- In **remote** sessions the driver is the `webdriver` package's `Client`, whose `isSuccessfulResponse` treats a W3C `no such element` 404 as a **successful** response (so `$$`/`isExisting` work) and resolves with the error *value* `{error, message, stacktrace}` instead of throwing. That object has no element id, so `find` took the `!elementId` branch → `ACTION_FAILED`.

The Appium server itself is correct, raw log for the missing element:
```
--> POST /session/<id>/element {"using":"accessibility id","value":"zzz-not-here-zzz"}
Got response with status 404: {"value":{"error":"no such element",
  "message":"An element could not be located on the page using the given search parameters", ...}}
[W3C] Matched W3C error code 'no such element' to NoSuchElementError
<-- POST /session/<id>/element 404
```
So the driver already said "not found"; the signal was lost in the remote client layer.

### Fix
Add a `findElement` wrapper in `command.ts` (same driver-type dispatch as the other helpers) that, on the remote path, re-throws when the client returns a `no such element` value. `find`'s existing `catch` then classifies it -> `ELEMENT_NOT_FOUND`, surfacing the **real driver message**

#### Before / after
Same inputs, original build vs fixed build:

| Case | BEFORE | AFTER |
|------|--------|-------|
| find present (`"Search Element"`) | `success` | `success` |
| find absent | `error / ACTION_FAILED`<br>"Element was returned without a valid element ID" | `error / ELEMENT_NOT_FOUND`<br>"Failed to find element. Error: An element could not be located on the page…" |

- The Appium server returned the **same** `404 no such element` in both runs (fix is client-side)