### PR TITLE
fix(session): return error on invalid capabilities JSON

### DIFF
--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -488,6 +488,74 @@ describe('appium_session_management tool', () => {
         'platform is required for create action'
       );
     });
+
+    test('returns error when capabilities JSON is invalid', async () => {
+      const tool = await getToolExecute();
+
+      const result = await tool.execute(
+        {
+          action: 'create',
+          platform: 'android',
+          capabilities: '{not valid json}',
+        },
+        undefined
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid capabilities JSON');
+      expect(mockSetSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('capabilities parsing', () => {
+    test('parses valid capabilities JSON string for attach', async () => {
+      const tool = await getToolExecute();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ value: { platformName: 'Android' } }),
+      } as Response);
+
+      const result = await tool.execute(
+        {
+          action: 'attach',
+          remoteServerUrl: 'http://localhost:4723',
+          sessionId: 'borrowed',
+          capabilities: '{"platformName":"Android","appium:app":"demo.apk"}',
+        },
+        undefined
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(mockSetSession).toHaveBeenCalledWith(
+        expect.anything(),
+        'borrowed',
+        expect.objectContaining({
+          platformName: 'Android',
+          'appium:app': 'demo.apk',
+        }),
+        'attached',
+        expect.any(String)
+      );
+    });
+
+    test('returns error on invalid JSON for attach before contacting server', async () => {
+      const tool = await getToolExecute();
+
+      const result = await tool.execute(
+        {
+          action: 'attach',
+          remoteServerUrl: 'http://localhost:4723',
+          sessionId: 'borrowed',
+          capabilities: '{"platformName":',
+        },
+        undefined
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid capabilities JSON');
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockAttachToSession).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -93,16 +93,21 @@ export default function session(server: FastMCP): void {
     execute: async (args: z.infer<typeof schema>): Promise<any> => {
       try {
         // Parse capabilities: some LLMs (e.g. Gemini) pass a JSON string instead of an object.
-        const parsedCapabilities: Record<string, any> | undefined = (() => {
-          if (typeof args.capabilities === 'string') {
-            try {
-              return JSON.parse(args.capabilities) as Record<string, any>;
-            } catch {
-              return undefined;
-            }
+        let parsedCapabilities: Record<string, any> | undefined;
+        if (typeof args.capabilities === 'string') {
+          try {
+            parsedCapabilities = JSON.parse(args.capabilities) as Record<
+              string,
+              any
+            >;
+          } catch (err: unknown) {
+            return errorResult(
+              `Invalid capabilities JSON: ${toolErrorMessage(err)}`
+            );
           }
-          return args.capabilities;
-        })();
+        } else {
+          parsedCapabilities = args.capabilities;
+        }
 
         if (args.action === 'create') {
           if (!args.platform) {


### PR DESCRIPTION
When appium_session_management receives capabilities as a JSON string and parsing fails, the tool now returns an errorResult immediately instead of silently treating capabilities as undefined that prevents create/attach from proceeding without intended caps (appium:app, bundleId ,e.g.) and surfacing confusing failures later
**Enhancements:**
-- Fail fast with Invalid capabilities JSON: <parse error>
-- Applies to both create and attach
-- Object passthrough unchanged for callers that already pass a parsed object