### PR TITLE
fix(session): fail when multiple persisted sessions lack sessionId

### DIFF
--- a/src/tests/tools/tool-response.test.ts
+++ b/src/tests/tools/tool-response.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const mockAttachToRemoteSession = jest.fn<
+  (
+    options: Record<string, unknown>
+  ) => Promise<{ getTimeouts: () => Promise<void> }>
+>(async () => ({
+  getTimeouts: async () => {},
+}));
+
+const mockRemovePersistedSession = jest.fn(async () => {});
+
+jest.unstable_mockModule('../../persistence', () => ({
+  readAllPersistedSessions: jest.fn(async () => []),
+  removePersistedSession: mockRemovePersistedSession,
+}));
+
+jest.unstable_mockModule('../../session-store', () => ({
+  getDriver: jest.fn(),
+  setSession: jest.fn(async () => {}),
+}));
+
+jest.unstable_mockModule('../../utils/url.js', () => ({
+  attachToRemoteSession: mockAttachToRemoteSession,
+}));
+
+jest.unstable_mockModule('../../logger', () => ({
+  default: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+const { readAllPersistedSessions } = await import('../../persistence.js');
+const { getDriver, setSession } = await import('../../session-store.js');
+const { resolveDriver, ambiguousPersistedSessionsMessage } =
+  await import('../../tools/tool-response.js');
+
+const mockReadAllPersistedSessions =
+  readAllPersistedSessions as jest.MockedFunction<
+    typeof readAllPersistedSessions
+  >;
+const mockGetDriver = getDriver as jest.MockedFunction<typeof getDriver>;
+const mockSetSession = setSession as jest.MockedFunction<typeof setSession>;
+
+const persistedEntry = (sessionId: string) => ({
+  sessionId,
+  remoteServerUrl: 'http://localhost:4723',
+  capabilities: { platformName: 'Android' },
+  platform: 'Android',
+  automationName: 'UiAutomator2',
+  deviceName: 'Pixel',
+  ownership: 'attached' as const,
+});
+
+describe('resolveDriver rehydration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDriver.mockReturnValue(null as any);
+  });
+
+  test('returns ambiguous error when multiple persisted sessions and no sessionId', async () => {
+    mockReadAllPersistedSessions.mockResolvedValue([
+      persistedEntry('session-a'),
+      persistedEntry('session-b'),
+    ]);
+
+    const result = await resolveDriver();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.result.isError).toBe(true);
+    expect(result.result.content[0].text).toBe(
+      ambiguousPersistedSessionsMessage(['session-a', 'session-b'])
+    );
+    expect(mockAttachToRemoteSession).not.toHaveBeenCalled();
+    expect(mockSetSession).not.toHaveBeenCalled();
+  });
+
+  test('lists ambiguous sessions sorted and does not prune before erroring', async () => {
+    mockReadAllPersistedSessions.mockResolvedValue([
+      persistedEntry('session-c'),
+      persistedEntry('session-a'),
+      persistedEntry('session-b'),
+    ]);
+
+    const result = await resolveDriver();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.result.content[0].text).toBe(
+      ambiguousPersistedSessionsMessage(['session-a', 'session-b', 'session-c'])
+    );
+    // Guard fires before any liveness check, so nothing is pruned.
+    expect(mockRemovePersistedSession).not.toHaveBeenCalled();
+  });
+
+  test('rehydrates when exactly one persisted session and no sessionId', async () => {
+    const mockDriver = { sessionId: 'only-session' };
+    mockReadAllPersistedSessions.mockResolvedValue([
+      persistedEntry('only-session'),
+    ]);
+    mockAttachToRemoteSession.mockResolvedValue({
+      getTimeouts: async () => {},
+    });
+    mockGetDriver
+      .mockReturnValueOnce(null as any)
+      .mockReturnValue(mockDriver as any);
+
+    const result = await resolveDriver();
+
+    expect(result.ok).toBe(true);
+    expect(mockAttachToRemoteSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'only-session' })
+    );
+    expect(mockSetSession).toHaveBeenCalled();
+  });
+
+  test('rehydrates a specific sessionId when multiple persisted sessions exist', async () => {
+    const mockDriver = { sessionId: 'session-b' };
+    mockReadAllPersistedSessions.mockResolvedValue([
+      persistedEntry('session-a'),
+      persistedEntry('session-b'),
+    ]);
+    mockAttachToRemoteSession.mockResolvedValue({
+      getTimeouts: async () => {},
+    });
+    mockGetDriver
+      .mockReturnValueOnce(null as any)
+      .mockReturnValue(mockDriver as any);
+
+    const result = await resolveDriver('session-b');
+
+    expect(result.ok).toBe(true);
+    expect(mockAttachToRemoteSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-b' })
+    );
+    expect(mockAttachToRemoteSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/tools/tool-response.test.ts
+++ b/src/tests/tools/tool-response.test.ts
@@ -69,7 +69,7 @@ describe('resolveDriver rehydration', () => {
       return;
     }
     expect(result.result.isError).toBe(true);
-    expect(result.result.content[0].text).toBe(
+    expect((result.result.content[0] as { text: string }).text).toBe(
       ambiguousPersistedSessionsMessage(['session-a', 'session-b'])
     );
     expect(mockAttachToRemoteSession).not.toHaveBeenCalled();
@@ -89,7 +89,7 @@ describe('resolveDriver rehydration', () => {
     if (result.ok) {
       return;
     }
-    expect(result.result.content[0].text).toBe(
+    expect((result.result.content[0] as { text: string }).text).toBe(
       ambiguousPersistedSessionsMessage(['session-a', 'session-b', 'session-c'])
     );
     // Guard fires before any liveness check, so nothing is pruned.

--- a/src/tools/tool-response.ts
+++ b/src/tools/tool-response.ts
@@ -19,6 +19,11 @@ export type DriverOrError =
   | { ok: true; driver: DriverInstance }
   | { ok: false; result: ContentResult };
 
+type RehydrateAttachedSessionResult =
+  | { status: 'ok'; sessionId: string }
+  | { status: 'ambiguous'; sessionIds: string[] }
+  | { status: 'none' };
+
 /**
  * Normalizes unknown errors into a message string for tool responses.
  */
@@ -84,6 +89,13 @@ export function noActiveDriverSessionResult(sessionId?: string): ContentResult {
   return errorResult(noActiveDriverSessionMessage(sessionId));
 }
 
+/** Message when rehydration is ambiguous without an explicit sessionId. */
+export function ambiguousPersistedSessionsMessage(
+  sessionIds: string[]
+): string {
+  return `Multiple persisted sessions: ${sessionIds.join(', ')}. Pass sessionId.`;
+}
+
 /**
  * Resolves the driver for a tool call or returns a standardised error result.
  * On cache miss, transparently re-attaches to any persisted attached session
@@ -96,7 +108,15 @@ export async function resolveDriver(
   let driver = getDriver(sessionId);
   if (!driver) {
     const rehydrated = await rehydrateAttachedSession(sessionId);
-    if (rehydrated) {
+    if (rehydrated.status === 'ambiguous') {
+      return {
+        ok: false,
+        result: errorResult(
+          ambiguousPersistedSessionsMessage(rehydrated.sessionIds)
+        ),
+      };
+    }
+    if (rehydrated.status === 'ok') {
       driver = getDriver(sessionId ?? rehydrated.sessionId);
     }
   }
@@ -122,10 +142,17 @@ export function platformMismatch(
 
 async function rehydrateAttachedSession(
   sessionId?: string
-): Promise<{ sessionId: string } | null> {
+): Promise<RehydrateAttachedSessionResult> {
   const persisted = await readAllPersistedSessions();
   if (persisted.length === 0) {
-    return null;
+    return { status: 'none' };
+  }
+  if (!sessionId && persisted.length > 1) {
+    // Sort for a deterministic message; on-disk order follows readdir.
+    return {
+      status: 'ambiguous',
+      sessionIds: persisted.map((entry) => entry.sessionId).sort(),
+    };
   }
   const candidates = sessionId
     ? persisted.filter((p) => p.sessionId === sessionId)
@@ -170,7 +197,7 @@ async function rehydrateAttachedSession(
       log.info(
         `Rehydrated attached session ${entry.sessionId} from persisted store.`
       );
-      return { sessionId: entry.sessionId };
+      return { status: 'ok', sessionId: entry.sessionId };
     } catch (err) {
       log.warn(
         `Persisted session ${entry.sessionId} no longer attachable (${
@@ -180,7 +207,7 @@ async function rehydrateAttachedSession(
       await removePersistedSession(entry.sessionId);
     }
   }
-  return null;
+  return { status: 'none' };
 }
 
 function sanitizePrimaryElementIdLine(elementId: string): string {


### PR DESCRIPTION
**Summary**
- `resolveDriver()` no longer picks the first persisted session when several exist and no `sessionId` is passed
- returns `Multiple persisted sessions: id1, id2. Pass sessionId.` (sorted ids)
- single persisted session still auto-rehydrates; explicit `sessionId` unchanged