### PR TITLE
fix(session): local Android create when multiple devices unselected

### DIFF
--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -10,23 +10,41 @@ const mockAttachToSession = jest.fn<
 }));
 
 let mockSelectedDevicePlatform: 'android' | 'ios' | null = 'ios';
+let mockSelectedDevice: string | null = 'device-udid';
+
+const mockGetConnectedDevices = jest.fn<() => Promise<{ udid: string }[]>>(
+  async () => [{ udid: 'u1' }]
+);
 
 jest.unstable_mockModule('../../../tools/session/select-device', () => ({
-  getSelectedLocalDevice: () => ({
-    get udid() {
-      return 'device-udid';
-    },
-    get platform() {
-      return mockSelectedDevicePlatform;
-    },
-    get type() {
-      return mockSelectedDevicePlatform === 'ios' ? 'simulator' : null;
-    },
-    get info() {
-      return { name: 'iPhone 12', platform: '16.0' };
-    },
-  }),
+  getSelectedLocalDevice: () =>
+    mockSelectedDevice
+      ? {
+          get udid() {
+            return mockSelectedDevice;
+          },
+          get platform() {
+            return mockSelectedDevicePlatform;
+          },
+          get type() {
+            return mockSelectedDevicePlatform === 'ios' ? 'simulator' : null;
+          },
+          get info() {
+            return { name: 'iPhone 12', platform: '16.0' };
+          },
+        }
+      : null,
   clearSelectedDevice: () => {},
+}));
+
+jest.unstable_mockModule('../../../devicemanager/adb-manager', () => ({
+  ADBManager: {
+    getInstance: () => ({
+      initialize: async () => ({
+        getConnectedDevices: mockGetConnectedDevices,
+      }),
+    }),
+  },
 }));
 
 jest.unstable_mockModule('../../../devicemanager/ios-manager', () => ({
@@ -121,6 +139,7 @@ const {
   getPortFromUrl,
   validateRemoteServerUrl,
   validateLocalCreatePlatformMatch,
+  validateAndroidDeviceSelection,
 } = await import('../../../tools/session/create-session.js');
 
 // ── tool helper ───────────────────────────────────────────────────────────────
@@ -134,6 +153,8 @@ let mockFetch: jest.MockedFunction<typeof fetch>;
 beforeEach(() => {
   jest.clearAllMocks();
   mockSelectedDevicePlatform = 'ios';
+  mockSelectedDevice = 'device-udid';
+  mockGetConnectedDevices.mockResolvedValue([{ udid: 'u1' }]);
   mockGetSessionOwnership.mockReturnValue(null);
   mockAttachToSession.mockResolvedValue({
     sessionId: 'attached-session-id',
@@ -572,10 +593,10 @@ describe('appium_session_management tool', () => {
 // ── capability builder tests ──────────────────────────────────────────────────
 
 describe('buildAndroidCapabilities', () => {
-  test('includes udid for local server and removes empty values', () => {
+  test('includes udid for local server and removes empty values', async () => {
     mockSelectedDevicePlatform = 'android';
 
-    const caps = buildAndroidCapabilities(
+    const caps = await buildAndroidCapabilities(
       { 'appium:app': '/path/app.apk' },
       { 'appium:deviceName': '' },
       false
@@ -589,19 +610,94 @@ describe('buildAndroidCapabilities', () => {
     expect(caps['appium:settings[waitForSelectorTimeout]']).toBe(0);
   });
 
-  test('ignores selected iOS device for local server', () => {
+  test('ignores selected iOS device for local server', async () => {
     mockSelectedDevicePlatform = 'ios';
 
-    const caps = buildAndroidCapabilities({}, undefined, false);
+    const caps = await buildAndroidCapabilities({}, undefined, false);
 
     expect(caps.platformName).toBe('Android');
     expect(caps).not.toHaveProperty('appium:udid');
   });
 
-  test('does not include udid for remote server', () => {
-    const caps = buildAndroidCapabilities({}, undefined, true);
+  test('does not include udid for remote server', async () => {
+    const caps = await buildAndroidCapabilities({}, undefined, true);
     expect(caps.platformName).toBe('Android');
     expect(caps).not.toHaveProperty('appium:udid');
+  });
+});
+
+describe('validateAndroidDeviceSelection', () => {
+  test('skips validation for remote server', async () => {
+    mockGetConnectedDevices.mockResolvedValue([
+      { udid: 'a' },
+      { udid: 'b' },
+    ]);
+    mockSelectedDevice = null;
+
+    await expect(
+      validateAndroidDeviceSelection(true, undefined)
+    ).resolves.toBeUndefined();
+  });
+
+  test('allows single connected device without select_device', async () => {
+    mockGetConnectedDevices.mockResolvedValue([{ udid: 'only-one' }]);
+    mockSelectedDevice = null;
+
+    await expect(
+      validateAndroidDeviceSelection(false, undefined)
+    ).resolves.toBeUndefined();
+  });
+
+  test('allows multiple devices when select_device was used', async () => {
+    mockGetConnectedDevices.mockResolvedValue([
+      { udid: 'a' },
+      { udid: 'b' },
+    ]);
+    mockSelectedDevice = 'a';
+    mockSelectedDevicePlatform = 'android';
+
+    await expect(
+      validateAndroidDeviceSelection(false, undefined)
+    ).resolves.toBeUndefined();
+  });
+
+  test('allows multiple devices when appium:udid is in capabilities', async () => {
+    mockGetConnectedDevices.mockResolvedValue([
+      { udid: 'a' },
+      { udid: 'b' },
+    ]);
+    mockSelectedDevice = null;
+
+    await expect(
+      validateAndroidDeviceSelection(false, { 'appium:udid': 'b' })
+    ).resolves.toBeUndefined();
+  });
+
+  test('throws when multiple devices and no explicit target', async () => {
+    mockGetConnectedDevices.mockResolvedValue([
+      { udid: 'a' },
+      { udid: 'b' },
+    ]);
+    mockSelectedDevice = null;
+
+    await expect(
+      validateAndroidDeviceSelection(false, undefined)
+    ).rejects.toThrow(
+      'Multiple Android devices found (2). Use select_device with platform=android'
+    );
+  });
+
+  test('buildAndroidCapabilities throws when multiple devices and no selection', async () => {
+    mockGetConnectedDevices.mockResolvedValue([
+      { udid: 'a' },
+      { udid: 'b' },
+    ]);
+    mockSelectedDevice = null;
+    mockSelectedDevicePlatform = 'android';
+
+    await expect(buildAndroidCapabilities({}, undefined, false)).rejects.toThrow(
+      'Multiple Android devices found (2). Use select_device with platform=android'
+    );
   });
 });
 

--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -628,10 +628,7 @@ describe('buildAndroidCapabilities', () => {
 
 describe('validateAndroidDeviceSelection', () => {
   test('skips validation for remote server', async () => {
-    mockGetConnectedDevices.mockResolvedValue([
-      { udid: 'a' },
-      { udid: 'b' },
-    ]);
+    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
     mockSelectedDevice = null;
 
     await expect(
@@ -649,10 +646,7 @@ describe('validateAndroidDeviceSelection', () => {
   });
 
   test('allows multiple devices when select_device was used', async () => {
-    mockGetConnectedDevices.mockResolvedValue([
-      { udid: 'a' },
-      { udid: 'b' },
-    ]);
+    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
     mockSelectedDevice = 'a';
     mockSelectedDevicePlatform = 'android';
 
@@ -662,10 +656,7 @@ describe('validateAndroidDeviceSelection', () => {
   });
 
   test('allows multiple devices when appium:udid is in capabilities', async () => {
-    mockGetConnectedDevices.mockResolvedValue([
-      { udid: 'a' },
-      { udid: 'b' },
-    ]);
+    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
     mockSelectedDevice = null;
 
     await expect(
@@ -674,10 +665,7 @@ describe('validateAndroidDeviceSelection', () => {
   });
 
   test('throws when multiple devices and no explicit target', async () => {
-    mockGetConnectedDevices.mockResolvedValue([
-      { udid: 'a' },
-      { udid: 'b' },
-    ]);
+    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
     mockSelectedDevice = null;
 
     await expect(
@@ -688,14 +676,13 @@ describe('validateAndroidDeviceSelection', () => {
   });
 
   test('buildAndroidCapabilities throws when multiple devices and no selection', async () => {
-    mockGetConnectedDevices.mockResolvedValue([
-      { udid: 'a' },
-      { udid: 'b' },
-    ]);
+    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
     mockSelectedDevice = null;
     mockSelectedDevicePlatform = 'android';
 
-    await expect(buildAndroidCapabilities({}, undefined, false)).rejects.toThrow(
+    await expect(
+      buildAndroidCapabilities({}, undefined, false)
+    ).rejects.toThrow(
       'Multiple Android devices found (2). Use select_device with platform=android'
     );
   });

--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -12,10 +12,6 @@ const mockAttachToSession = jest.fn<
 let mockSelectedDevicePlatform: 'android' | 'ios' | null = 'ios';
 let mockSelectedDevice: string | null = 'device-udid';
 
-const mockGetConnectedDevices = jest.fn<() => Promise<{ udid: string }[]>>(
-  async () => [{ udid: 'u1' }]
-);
-
 jest.unstable_mockModule('../../../tools/session/select-device', () => ({
   getSelectedLocalDevice: () =>
     mockSelectedDevice
@@ -35,16 +31,6 @@ jest.unstable_mockModule('../../../tools/session/select-device', () => ({
         }
       : null,
   clearSelectedDevice: () => {},
-}));
-
-jest.unstable_mockModule('../../../devicemanager/adb-manager', () => ({
-  ADBManager: {
-    getInstance: () => ({
-      initialize: async () => ({
-        getConnectedDevices: mockGetConnectedDevices,
-      }),
-    }),
-  },
 }));
 
 jest.unstable_mockModule('../../../devicemanager/ios-manager', () => ({
@@ -139,7 +125,6 @@ const {
   getPortFromUrl,
   validateRemoteServerUrl,
   validateLocalCreatePlatformMatch,
-  validateAndroidDeviceSelection,
 } = await import('../../../tools/session/create-session.js');
 
 // ── tool helper ───────────────────────────────────────────────────────────────
@@ -154,7 +139,6 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockSelectedDevicePlatform = 'ios';
   mockSelectedDevice = 'device-udid';
-  mockGetConnectedDevices.mockResolvedValue([{ udid: 'u1' }]);
   mockGetSessionOwnership.mockReturnValue(null);
   mockAttachToSession.mockResolvedValue({
     sessionId: 'attached-session-id',
@@ -593,10 +577,10 @@ describe('appium_session_management tool', () => {
 // ── capability builder tests ──────────────────────────────────────────────────
 
 describe('buildAndroidCapabilities', () => {
-  test('includes udid for local server and removes empty values', async () => {
+  test('includes udid for local server and removes empty values', () => {
     mockSelectedDevicePlatform = 'android';
 
-    const caps = await buildAndroidCapabilities(
+    const caps = buildAndroidCapabilities(
       { 'appium:app': '/path/app.apk' },
       { 'appium:deviceName': '' },
       false
@@ -610,81 +594,43 @@ describe('buildAndroidCapabilities', () => {
     expect(caps['appium:settings[waitForSelectorTimeout]']).toBe(0);
   });
 
-  test('ignores selected iOS device for local server', async () => {
+  test('does not override explicit appium:udid from capabilities', () => {
+    mockSelectedDevicePlatform = 'android';
+
+    const caps = buildAndroidCapabilities(
+      {},
+      { 'appium:udid': 'explicit-udid' },
+      false
+    );
+
+    expect(caps['appium:udid']).toBe('explicit-udid');
+  });
+
+  test('does not override appium:udid from config capabilities', () => {
+    mockSelectedDevicePlatform = 'android';
+
+    const caps = buildAndroidCapabilities(
+      { 'appium:udid': 'config-udid' },
+      undefined,
+      false
+    );
+
+    expect(caps['appium:udid']).toBe('config-udid');
+  });
+
+  test('ignores selected iOS device for local server', () => {
     mockSelectedDevicePlatform = 'ios';
 
-    const caps = await buildAndroidCapabilities({}, undefined, false);
+    const caps = buildAndroidCapabilities({}, undefined, false);
 
     expect(caps.platformName).toBe('Android');
     expect(caps).not.toHaveProperty('appium:udid');
   });
 
-  test('does not include udid for remote server', async () => {
-    const caps = await buildAndroidCapabilities({}, undefined, true);
+  test('does not include udid for remote server', () => {
+    const caps = buildAndroidCapabilities({}, undefined, true);
     expect(caps.platformName).toBe('Android');
     expect(caps).not.toHaveProperty('appium:udid');
-  });
-});
-
-describe('validateAndroidDeviceSelection', () => {
-  test('skips validation for remote server', async () => {
-    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
-    mockSelectedDevice = null;
-
-    await expect(
-      validateAndroidDeviceSelection(true, undefined)
-    ).resolves.toBeUndefined();
-  });
-
-  test('allows single connected device without select_device', async () => {
-    mockGetConnectedDevices.mockResolvedValue([{ udid: 'only-one' }]);
-    mockSelectedDevice = null;
-
-    await expect(
-      validateAndroidDeviceSelection(false, undefined)
-    ).resolves.toBeUndefined();
-  });
-
-  test('allows multiple devices when select_device was used', async () => {
-    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
-    mockSelectedDevice = 'a';
-    mockSelectedDevicePlatform = 'android';
-
-    await expect(
-      validateAndroidDeviceSelection(false, undefined)
-    ).resolves.toBeUndefined();
-  });
-
-  test('allows multiple devices when appium:udid is in capabilities', async () => {
-    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
-    mockSelectedDevice = null;
-
-    await expect(
-      validateAndroidDeviceSelection(false, { 'appium:udid': 'b' })
-    ).resolves.toBeUndefined();
-  });
-
-  test('throws when multiple devices and no explicit target', async () => {
-    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
-    mockSelectedDevice = null;
-
-    await expect(
-      validateAndroidDeviceSelection(false, undefined)
-    ).rejects.toThrow(
-      'Multiple Android devices found (2). Use select_device with platform=android'
-    );
-  });
-
-  test('buildAndroidCapabilities throws when multiple devices and no selection', async () => {
-    mockGetConnectedDevices.mockResolvedValue([{ udid: 'a' }, { udid: 'b' }]);
-    mockSelectedDevice = null;
-    mockSelectedDevicePlatform = 'android';
-
-    await expect(
-      buildAndroidCapabilities({}, undefined, false)
-    ).rejects.toThrow(
-      'Multiple Android devices found (2). Use select_device with platform=android'
-    );
   });
 });
 
@@ -704,6 +650,18 @@ describe('buildIOSCapabilities', () => {
     expect(caps['appium:wdaStartupRetries']).toBe(4);
     expect(caps['custom:cap']).toBe('value');
     expect(caps['appium:bundleId']).toBe('com.example.app');
+  });
+
+  test('does not override explicit appium:udid from capabilities', async () => {
+    mockSelectedDevicePlatform = 'ios';
+
+    const caps = await buildIOSCapabilities(
+      {},
+      { 'appium:udid': 'explicit-udid' },
+      false
+    );
+
+    expect(caps['appium:udid']).toBe('explicit-udid');
   });
 
   test('ignores selected Android device for local server', async () => {

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -60,34 +60,6 @@ export function filterEmptyCapabilities(
 }
 
 /**
- * Validate Android device selection when multiple devices are available
- */
-export async function validateAndroidDeviceSelection(
-  isRemoteServer: boolean,
-  explicitDeviceCaps?: Record<string, any>
-): Promise<void> {
-  if (isRemoteServer) {
-    return;
-  }
-
-  if (explicitDeviceCaps?.['appium:udid']) {
-    return;
-  }
-
-  const adb = await ADBManager.getInstance().initialize();
-  const devices = await adb.getConnectedDevices();
-
-  if (devices.length > 1) {
-    const selectedDevice = getSelectedLocalDevice()?.udid;
-    if (!selectedDevice) {
-      throw new Error(
-        `Multiple Android devices found (${devices.length}). Use select_device with platform=android to choose one, then call appium_session_management with action=create.`
-      );
-    }
-  }
-}
-
-/**
  * Build Android capabilities by merging defaults, config, device selection, and custom capabilities
  */
 export function buildAndroidCapabilities(

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -9,6 +9,7 @@ import {
   clearSelectedDevice,
   getSelectedLocalDevice,
 } from './select-device.js';
+import { ADBManager } from '../../devicemanager/adb-manager.js';
 import { IOSManager } from '../../devicemanager/ios-manager.js';
 import log from '../../logger.js';
 import {
@@ -60,13 +61,46 @@ export function filterEmptyCapabilities(
 }
 
 /**
+ * Validate Android device selection when multiple devices are available
+ */
+export async function validateAndroidDeviceSelection(
+  isRemoteServer: boolean,
+  explicitDeviceCaps?: Record<string, any>
+): Promise<void> {
+  if (isRemoteServer) {
+    return;
+  }
+
+  if (explicitDeviceCaps?.['appium:udid']) {
+    return;
+  }
+
+  const adb = await ADBManager.getInstance().initialize();
+  const devices = await adb.getConnectedDevices();
+
+  if (devices.length > 1) {
+    const selectedDevice = getSelectedLocalDevice()?.udid;
+    if (!selectedDevice) {
+      throw new Error(
+        `Multiple Android devices found (${devices.length}). Use select_device with platform=android to choose one, then call appium_session_management with action=create.`
+      );
+    }
+  }
+}
+
+/**
  * Build Android capabilities by merging defaults, config, device selection, and custom capabilities
  */
-export function buildAndroidCapabilities(
+export async function buildAndroidCapabilities(
   configCaps: Record<string, any>,
   customCaps: Record<string, any> | undefined,
   isRemoteServer: boolean
-): Capabilities {
+): Promise<Capabilities> {
+  await validateAndroidDeviceSelection(isRemoteServer, {
+    ...configCaps,
+    ...customCaps,
+  });
+
   const defaultCaps: Capabilities = {
     platformName: 'Android',
     'appium:automationName': 'UiAutomator2',
@@ -287,7 +321,7 @@ export async function createSessionAction(args: {
 
     const configCapabilities = await loadCapabilitiesConfig();
     if (platform === 'android') {
-      finalCapabilities = buildAndroidCapabilities(
+      finalCapabilities = await buildAndroidCapabilities(
         configCapabilities.android,
         customCapabilities,
         !!remoteServerUrl

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -9,7 +9,6 @@ import {
   clearSelectedDevice,
   getSelectedLocalDevice,
 } from './select-device.js';
-import { ADBManager } from '../../devicemanager/adb-manager.js';
 import { IOSManager } from '../../devicemanager/ios-manager.js';
 import log from '../../logger.js';
 import {
@@ -91,27 +90,25 @@ export async function validateAndroidDeviceSelection(
 /**
  * Build Android capabilities by merging defaults, config, device selection, and custom capabilities
  */
-export async function buildAndroidCapabilities(
+export function buildAndroidCapabilities(
   configCaps: Record<string, any>,
   customCaps: Record<string, any> | undefined,
   isRemoteServer: boolean
-): Promise<Capabilities> {
-  await validateAndroidDeviceSelection(isRemoteServer, {
-    ...configCaps,
-    ...customCaps,
-  });
+): Capabilities {
+  const givenCaps = { ...configCaps, ...customCaps };
+  const selectedLocalDevice = getSelectedLocalDevice();
+  const selectedDeviceUdid =
+    !isRemoteServer &&
+    !givenCaps['appium:udid'] &&
+    selectedLocalDevice?.platform === 'android'
+      ? selectedLocalDevice.udid
+      : undefined;
 
   const defaultCaps: Capabilities = {
     platformName: 'Android',
     'appium:automationName': 'UiAutomator2',
     'appium:deviceName': 'Android Device',
   };
-
-  const selectedLocalDevice = getSelectedLocalDevice();
-  const selectedDeviceUdid =
-    !isRemoteServer && selectedLocalDevice?.platform === 'android'
-      ? selectedLocalDevice?.udid
-      : undefined;
 
   const additionalCaps = {
     'appium:settings[actionAcknowledgmentTimeout]': 0,
@@ -180,8 +177,13 @@ export async function buildIOSCapabilities(
   const deviceType = selectedIOSDevice?.type || null;
   await validateIOSDeviceSelection(deviceType);
 
-  // Get selected device info BEFORE constructing defaultCaps so we can use the actual device name
-  const selectedDeviceUdid = selectedIOSDevice?.udid;
+  const givenCaps = { ...configCaps, ...customCaps };
+  const selectedDeviceUdid =
+    !isRemoteServer &&
+    !givenCaps['appium:udid'] &&
+    selectedIOSDevice?.platform === 'ios'
+      ? selectedIOSDevice.udid
+      : undefined;
   const selectedDeviceInfo = selectedIOSDevice?.info;
 
   log.debug('Selected device info:', selectedDeviceInfo);
@@ -321,7 +323,7 @@ export async function createSessionAction(args: {
 
     const configCapabilities = await loadCapabilitiesConfig();
     if (platform === 'android') {
-      finalCapabilities = await buildAndroidCapabilities(
+      finalCapabilities = buildAndroidCapabilities(
         configCapabilities.android,
         customCapabilities,
         !!remoteServerUrl


### PR DESCRIPTION
Local Android session create could silently bind to the wrong device when multiple emulators or USB devices were connected and the agent skipped select_device. iOS already had a guard on the create path; Android did not so adding validateAndroidDeviceSelection() and runs it from buildAndroidCapabilities() before session creation.
 If more than one Android device is connected and there is no explicit target (select_device or appium:udid in capabilities), create fails with a clear error instead of picking an arbitrary device.
 
**Changes**
- add validateAndroidDeviceSelection() in create-session.ts
- make buildAndroidCapabilities() async and call validation on local create
- add unit tests for single device, multiple devices, remote server skip, and explicit appium:udid