### PR TITLE
fix: surface remote "no such element" on element commands

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -233,7 +233,9 @@ export async function setValue(
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.setValue(text, elementUUID);
   }
-  return await (driver as Client).elementSendKeys(elementUUID, text);
+  const result = await (driver as Client).elementSendKeys(elementUUID, text);
+  throwIfSwallowedRemoteError(result);
+  return result;
 }
 
 /**
@@ -297,21 +299,7 @@ export async function findElement(
     return await driver.findElement(strategy, selector);
   }
   const result = await (driver as Client).findElement(strategy, selector);
-  if (
-    typeof result === 'object' &&
-    result !== null &&
-    'error' in result &&
-    (result as { error?: unknown }).error === 'no such element'
-  ) {
-    const message = (result as { message?: unknown }).message;
-    const err = new Error(
-      typeof message === 'string'
-        ? message
-        : 'no such element: An element could not be located on the page using the given search parameters'
-    );
-    err.name = 'no such element';
-    throw err;
-  }
+  throwIfSwallowedRemoteError(result);
   return result;
 }
 
@@ -425,7 +413,9 @@ export async function getElementText(
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.getText(elementUUID);
   }
-  return await driver.getElementText(elementUUID);
+  const result = await driver.getElementText(elementUUID);
+  throwIfSwallowedRemoteError(result);
+  return result;
 }
 
 /**
@@ -446,7 +436,9 @@ export async function getElementAttribute(
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.getAttribute(attribute, elementUUID);
   }
-  return await driver.getElementAttribute(elementUUID, attribute);
+  const result = await driver.getElementAttribute(elementUUID, attribute);
+  throwIfSwallowedRemoteError(result);
+  return result;
 }
 
 export async function getActiveElement(
@@ -458,6 +450,7 @@ export async function getActiveElement(
     return await driver.active();
   }
   const result = await driver.getActiveElement();
+  throwIfSwallowedRemoteError(result);
   return result as unknown as AppiumElement;
 }
 
@@ -608,4 +601,25 @@ export async function back(driver: DriverInstance): Promise<void> {
     return await driver.back();
   }
   return await (driver as Client).back();
+}
+
+/**
+ * Remote WebDriver clients treat a W3C "no such element" 404 as success and
+ * resolve with the error value `{ error, message }` instead of throwing. Re-throw
+ * it so callers' catch handles it like the embedded drivers do.
+ */
+function throwIfSwallowedRemoteError(result: unknown): void {
+  if (
+    typeof result === 'object' &&
+    result !== null &&
+    'error' in result &&
+    typeof (result as { error?: unknown }).error === 'string'
+  ) {
+    const { error, message } = result as { error: string; message?: unknown };
+    const err = new Error(
+      typeof message === 'string' && message.length > 0 ? message : error
+    );
+    err.name = error;
+    throw err;
+  }
 }

--- a/src/tests/command.test.ts
+++ b/src/tests/command.test.ts
@@ -10,7 +10,21 @@ jest.unstable_mockModule('../session-store', () => ({
   getSessionInfo: jest.fn(),
 }));
 
-const { findElement } = await import('../command.js');
+const {
+  findElement,
+  setValue,
+  getElementText,
+  getElementAttribute,
+  getActiveElement,
+} = await import('../command.js');
+
+// What the remote client resolves with when it swallows a "no such element" 404.
+const NO_SUCH_ELEMENT_VALUE = {
+  error: 'no such element',
+  message:
+    'An element could not be located on the page using the given search parameters',
+  stacktrace: 'io.appium...ElementNotFoundException',
+};
 
 describe('findElement: normalizes remote "no such element"', () => {
   test('re-throws when the client returns a "no such element" value', async () => {
@@ -36,5 +50,85 @@ describe('findElement: normalizes remote "no such element"', () => {
     const driver = { findElement: jest.fn(async () => el) };
 
     await expect(findElement(driver as never, 'id', 'real')).resolves.toBe(el);
+  });
+});
+
+describe('element commands: re-throw swallowed remote "no such element"', () => {
+  test('setValue re-throws when elementSendKeys returns an error value', async () => {
+    const driver = {
+      elementSendKeys: jest.fn(async () => NO_SUCH_ELEMENT_VALUE),
+    };
+    await expect(setValue(driver as never, 'bad', 'hi')).rejects.toThrow(
+      /could not be located/i
+    );
+  });
+
+  test('setValue resolves normally when keys are sent', async () => {
+    const driver = { elementSendKeys: jest.fn(async () => undefined) };
+    await expect(
+      setValue(driver as never, 'el', 'hi')
+    ).resolves.toBeUndefined();
+  });
+
+  test('getElementText re-throws swallowed error, returns text otherwise', async () => {
+    await expect(
+      getElementText(
+        { getElementText: jest.fn(async () => NO_SUCH_ELEMENT_VALUE) } as never,
+        'bad'
+      )
+    ).rejects.toThrow(/could not be located/i);
+    await expect(
+      getElementText(
+        { getElementText: jest.fn(async () => 'hello') } as never,
+        'el'
+      )
+    ).resolves.toBe('hello');
+  });
+
+  test('getElementAttribute re-throws swallowed error; passes null/value through', async () => {
+    await expect(
+      getElementAttribute(
+        {
+          getElementAttribute: jest.fn(async () => NO_SUCH_ELEMENT_VALUE),
+        } as never,
+        'bad',
+        'enabled'
+      )
+    ).rejects.toThrow(/could not be located/i);
+    await expect(
+      getElementAttribute(
+        { getElementAttribute: jest.fn(async () => null) } as never,
+        'el',
+        'value'
+      )
+    ).resolves.toBeNull();
+    await expect(
+      getElementAttribute(
+        { getElementAttribute: jest.fn(async () => 'true') } as never,
+        'el',
+        'enabled'
+      )
+    ).resolves.toBe('true');
+  });
+
+  test('getActiveElement re-throws swallowed error, returns element otherwise', async () => {
+    await expect(
+      getActiveElement({
+        getActiveElement: jest.fn(async () => NO_SUCH_ELEMENT_VALUE),
+      } as never)
+    ).rejects.toThrow(/could not be located/i);
+    const el = { 'element-6066-11e4-a52e-4f735466cecf': 'abc' };
+    await expect(
+      getActiveElement({ getActiveElement: jest.fn(async () => el) } as never)
+    ).resolves.toBe(el);
+  });
+
+  test('preserves the W3C error code as the error name (for classifyError)', async () => {
+    await expect(
+      getElementText(
+        { getElementText: jest.fn(async () => NO_SUCH_ELEMENT_VALUE) } as never,
+        'bad'
+      )
+    ).rejects.toMatchObject({ name: 'no such element' });
   });
 });


### PR DESCRIPTION
## What?
- Follow-up to #392, which fixed this for `findElement`. The same client-side swallow affects the other element commands.
- In **remote** (W3C) sessions, `appium_get_text`, `appium_get_element_attribute`, `appium_set_value`, and `appium_get_active_element` returned a **fake success** when the element didn't exist instead of an error.
- `set_value` is the worst case: it reported success for a write into a non-existent element.

**MCP tool response — before vs after:**

| call (bogus id) | BEFORE | AFTER |
|---|---|---|
| `get_text` | `isError:false` · `"Successfully got text [object Object]…"` | `isError:true` · `"Failed to get text … not present in the cache…"` |
| `get_element_attribute` | `isError:false` · `'…: [object Object]'` | `isError:true` · `"Failed to get attribute \"enabled\" …"` |
| `set_value` | `isError:false` · `"Successfully set value x into element…"` | `isError:true` · `"Failed to set value x …"` |