### PR TITLE
fix(context): pass sessionId to setCurrentContext

### DIFF
--- a/src/tests/tools/context/context.test.ts
+++ b/src/tests/tools/context/context.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, test, expect, jest } from '@jest/globals';
+
+const mockDriver = {};
+const mockSetCurrentContext = jest.fn(() => true);
+
+jest.unstable_mockModule('../../../session-store', () => ({
+  setCurrentContext: mockSetCurrentContext,
+}));
+
+jest.unstable_mockModule('../../../command', () => ({
+  getContexts: jest.fn(async () => ['NATIVE_APP', 'WEBVIEW_com.example']),
+  getCurrentContext: jest.fn(async () => 'NATIVE_APP'),
+  setContext: jest.fn(async () => undefined),
+}));
+
+jest.unstable_mockModule('../../../tools/tool-response', () => ({
+  resolveDriver: jest.fn(async () => ({ ok: true, driver: mockDriver })),
+  textResult: (text: string) => ({ content: [{ type: 'text', text }] }),
+  errorResult: (text: string) => ({
+    content: [{ type: 'text', text }],
+    isError: true,
+  }),
+  toolErrorMessage: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}));
+
+jest.unstable_mockModule('../../../ui/mcp-ui-utils', () => ({
+  createUIResource: jest.fn(() => ({})),
+  createContextSwitcherUI: jest.fn(() => ''),
+  addUIResourceToResponse: jest.fn((_result: unknown) => _result),
+}));
+
+const { getCurrentContext } = await import('../../../command.js');
+
+const mockGetCurrentContext = getCurrentContext as jest.MockedFunction<
+  typeof getCurrentContext
+>;
+
+describe('appium_context tool', () => {
+  const mockServer = { addTool: jest.fn() } as any;
+
+  async function getToolExecute() {
+    const { default: contextTool } =
+      await import('../../../tools/context/context.js');
+    contextTool(mockServer);
+    return (mockServer.addTool as jest.MockedFunction<any>).mock.calls.at(
+      -1
+    )?.[0];
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentContext.mockResolvedValue('NATIVE_APP');
+  });
+
+  test('setCurrentContext uses sessionId on list', async () => {
+    const tool = await getToolExecute();
+
+    await tool.execute({ action: 'list', sessionId: 'session-b' }, undefined);
+
+    expect(mockSetCurrentContext).toHaveBeenCalledWith(
+      'NATIVE_APP',
+      'session-b'
+    );
+  });
+
+  test('setCurrentContext uses sessionId on switch', async () => {
+    const tool = await getToolExecute();
+    mockGetCurrentContext
+      .mockResolvedValueOnce('NATIVE_APP')
+      .mockResolvedValueOnce('WEBVIEW_com.example');
+
+    await tool.execute(
+      {
+        action: 'switch',
+        context: 'WEBVIEW_com.example',
+        sessionId: 'session-b',
+      },
+      undefined
+    );
+
+    expect(mockSetCurrentContext).toHaveBeenLastCalledWith(
+      'WEBVIEW_com.example',
+      'session-b'
+    );
+  });
+});

--- a/src/tests/tools/context/context.test.ts
+++ b/src/tests/tools/context/context.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, test, expect, jest } from '@jest/globals';
 
 const mockDriver = {};
-const mockSetCurrentContext = jest.fn(() => true);
+const mockSetCurrentContext = jest.fn<
+  (context: string, sessionId?: string) => boolean
+>(() => true);
 
 jest.unstable_mockModule('../../../session-store', () => ({
   setCurrentContext: mockSetCurrentContext,

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -57,7 +57,7 @@ export default function context(server: FastMCP): void {
         ]);
 
         if (currentContext) {
-          setCurrentContext(currentContext);
+          setCurrentContext(currentContext, args.sessionId);
         }
 
         if (args.action === 'list') {
@@ -97,7 +97,7 @@ export default function context(server: FastMCP): void {
 
         await setContext(driver, args.context);
         const newContext = await getCurrentContext(driver);
-        setCurrentContext(newContext);
+        setCurrentContext(newContext, args.sessionId);
 
         return textResult(
           `Successfully switched context from "${currentContext}" to "${newContext}".`


### PR DESCRIPTION
## Summary
- `appium_context` switched the driver for the requested `sessionId`, but `setCurrentContext` always updated the active session metadata
- Pass `args.sessionId` through on list/switch so stored context matches the targeted session (needed for iOS webview click routing)