### PR TITLE
fix(session): reject delete for attached sessions unless force=true

### DIFF
--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -256,7 +256,23 @@ describe('appium_session_management tool', () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('action=detach');
+      expect(result.content[0].text).toContain('force=true');
       expect(mockSafeDeleteSession).not.toHaveBeenCalled();
+    });
+
+    test('deletes attached session when force is true', async () => {
+      const tool = await getToolExecute();
+      mockGetSessionOwnership.mockReturnValue('attached');
+      mockSafeDeleteSession.mockResolvedValue(true as any);
+
+      const result = await tool.execute(
+        { action: 'delete', sessionId: 'borrowed', force: true },
+        undefined
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('deleted successfully');
+      expect(mockSafeDeleteSession).toHaveBeenCalledWith('borrowed');
     });
 
     test('reports not found when session does not exist', async () => {

--- a/src/tests/tools/session/session.test.ts
+++ b/src/tests/tools/session/session.test.ts
@@ -245,31 +245,32 @@ describe('appium_session_management tool', () => {
       expect(result.content[0].text).toContain('deleted successfully');
     });
 
-    test('allows deleting an attached session when explicitly requested', async () => {
+    test('rejects deleting an attached session', async () => {
       const tool = await getToolExecute();
-      mockSafeDeleteSession.mockResolvedValue(true as any);
+      mockGetSessionOwnership.mockReturnValue('attached');
 
       const result = await tool.execute(
         { action: 'delete', sessionId: 'borrowed' },
         undefined
       );
 
-      expect(result.isError).toBeFalsy();
-      expect(result.content[0].text).toContain('deleted successfully');
-      expect(mockSafeDeleteSession).toHaveBeenCalledWith('borrowed');
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('action=detach');
+      expect(mockSafeDeleteSession).not.toHaveBeenCalled();
     });
 
     test('reports not found when session does not exist', async () => {
       const tool = await getToolExecute();
-      mockGetSessionOwnership.mockReturnValue('owned');
-      mockSafeDeleteSession.mockResolvedValue(false as any);
+      mockGetSessionOwnership.mockReturnValue(null);
 
       const result = await tool.execute(
         { action: 'delete', sessionId: 'ghost' },
         undefined
       );
+      expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('ghost');
       expect(result.content[0].text).toContain('not found');
+      expect(mockSafeDeleteSession).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tools/session/delete-session.ts
+++ b/src/tools/session/delete-session.ts
@@ -1,18 +1,21 @@
 import { getSessionOwnership, safeDeleteSession } from '../../session-store.js';
 import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 
-export async function deleteSessionAction(sessionId?: string): Promise<any> {
+export async function deleteSessionAction(
+  sessionId?: string,
+  force?: boolean
+): Promise<any> {
   const ownership = getSessionOwnership(sessionId);
   if (!ownership) {
     return errorResult(
       sessionId ? `Session ${sessionId} not found.` : 'No active session found.'
     );
   }
-  if (ownership === 'attached') {
+  if (ownership === 'attached' && !force) {
     return errorResult(
       sessionId
-        ? `Session ${sessionId} is attached from a remote server. Use action=detach to remove it from MCP without deleting the remote session.`
-        : 'Active session is attached from a remote server. Use action=detach to remove it from MCP without deleting the remote session.'
+        ? `Session ${sessionId} is attached from a remote server. Use action=detach to remove it from MCP without deleting the remote session, or pass force=true to delete the remote session.`
+        : 'Active session is attached from a remote server. Use action=detach to remove it from MCP without deleting the remote session, or pass force=true to delete the remote session.'
     );
   }
 

--- a/src/tools/session/delete-session.ts
+++ b/src/tools/session/delete-session.ts
@@ -1,7 +1,21 @@
-import { safeDeleteSession } from '../../session-store.js';
+import { getSessionOwnership, safeDeleteSession } from '../../session-store.js';
 import { errorResult, textResult, toolErrorMessage } from '../tool-response.js';
 
 export async function deleteSessionAction(sessionId?: string): Promise<any> {
+  const ownership = getSessionOwnership(sessionId);
+  if (!ownership) {
+    return errorResult(
+      sessionId ? `Session ${sessionId} not found.` : 'No active session found.'
+    );
+  }
+  if (ownership === 'attached') {
+    return errorResult(
+      sessionId
+        ? `Session ${sessionId} is attached from a remote server. Use action=detach to remove it from MCP without deleting the remote session.`
+        : 'Active session is attached from a remote server. Use action=detach to remove it from MCP without deleting the remote session.'
+    );
+  }
+
   try {
     const deleted = await safeDeleteSession(sessionId);
     if (deleted) {

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -44,7 +44,7 @@ const schema = z.object({
         `create: ${CREATE_SESSION_DESCRIPTION}` +
         'attach: Attach MCP Appium to an existing remote Appium session without taking ownership of its lifecycle. Requires remoteServerUrl and sessionId. Always pass capabilities with at least platformName (e.g. \'{"platformName":"iOS"}\' or \'{"platformName":"Android"}\') so the client is configured with the correct protocol commands.' +
         'detach: Remove an attached Appium session from MCP Appium without deleting the real remote session. Defaults to the active session.' +
-        'delete: Delete a mobile session and clean up resources. If sessionId is omitted, deletes the active session.' +
+        'delete: Delete an MCP-owned mobile session and clean up resources. Does not delete attached remote sessions; use detach for those. If sessionId is omitted, deletes the active session.' +
         'list: List all active Appium sessions managed by this MCP server, including active flag, ownership, and current context.' +
         'select: Set an existing Appium session as the active session for subsequent tool calls (requires sessionId).'
     ),

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -44,7 +44,7 @@ const schema = z.object({
         `create: ${CREATE_SESSION_DESCRIPTION}` +
         'attach: Attach MCP Appium to an existing remote Appium session without taking ownership of its lifecycle. Requires remoteServerUrl and sessionId. Always pass capabilities with at least platformName (e.g. \'{"platformName":"iOS"}\' or \'{"platformName":"Android"}\') so the client is configured with the correct protocol commands.' +
         'detach: Remove an attached Appium session from MCP Appium without deleting the real remote session. Defaults to the active session.' +
-        'delete: Delete an MCP-owned mobile session and clean up resources. Does not delete attached remote sessions; use detach for those. If sessionId is omitted, deletes the active session.' +
+        'delete: Delete an MCP-owned mobile session and clean up resources. Attached remote sessions are rejected unless force=true; use detach to drop attached sessions from MCP without terminating the remote session. If sessionId is omitted, deletes the active session.' +
         'list: List all active Appium sessions managed by this MCP server, including active flag, ownership, and current context.' +
         'select: Set an existing Appium session as the active session for subsequent tool calls (requires sessionId).'
     ),
@@ -76,6 +76,12 @@ const schema = z.object({
     .optional()
     .describe(
       'For attach: existing session to connect to. For delete: session to remove (defaults to active). For detach: attached session to remove from MCP (defaults to active). For select: session to activate. Required for attach and select.'
+    ),
+  force: z
+    .boolean()
+    .optional()
+    .describe(
+      'For delete only: when true, also terminate an attached remote Appium session. Defaults to false.'
     ),
 });
 
@@ -139,7 +145,7 @@ export default function session(server: FastMCP): void {
         }
 
         if (args.action === 'delete') {
-          return deleteSessionAction(args.sessionId);
+          return deleteSessionAction(args.sessionId, args.force);
         }
 
         if (args.action === 'list') {


### PR DESCRIPTION
## Summary
- `action=delete` could terminate attached (borrowed) remote Appium sessions and kill shared CI/farm sessions
- Reject delete when `ownership=attached` by default and point agents to `action=detach`
- Add optional `force=true` to intentionally delete the remote session when needed