### PR TITLE
fix: keep FastMCP logs off stdio stdout

### DIFF
--- a/src/create-server.ts
+++ b/src/create-server.ts
@@ -36,6 +36,14 @@ const SERVER_INSTRUCTIONS = [
   '- For local Appium install, doctor, or smoke tests, run appium_skills before guessing commands.',
 ].join('\n');
 
+const FAST_MCP_LOGGER = {
+  debug: (...args: unknown[]) => log.debug(...args),
+  error: (...args: unknown[]) => log.error(...args),
+  info: (...args: unknown[]) => log.info(...args),
+  log: (...args: unknown[]) => log.info(...args),
+  warn: (...args: unknown[]) => log.warn(...args),
+};
+
 export interface CreateAppiumMcpServerOptions {
   /**
    * List of plugins to register with the server.
@@ -105,6 +113,7 @@ export async function createAppiumMcpServer(
     name: serverName,
     version: serverVersion,
     instructions,
+    logger: FAST_MCP_LOGGER,
     // Appium MCP will not allow client to ask the local workspace/project folders.
     roots: {
       enabled: false,

--- a/src/tests/create-server.test.ts
+++ b/src/tests/create-server.test.ts
@@ -171,6 +171,9 @@ afterEach(() => {
   registeredServers.length = 0;
   sessions = [];
   safeDeleteAllSessions.mockReset();
+  jest.mocked(log.debug).mockReset();
+  jest.mocked(log.error).mockReset();
+  jest.mocked(log.info).mockReset();
   jest.mocked(log.warn).mockReset();
   delete process.env.APPIUM_MCP_ON_CLIENT_DISCONNECT;
 });
@@ -184,6 +187,20 @@ describe('createAppiumMcpServer plugin lifecycle', () => {
         enabled: false,
       },
     });
+  });
+
+  test('passes the appium logger to FastMCP', () => {
+    createAppiumMcpServer();
+
+    const options = registeredServers[0]?.options as {
+      logger: Record<string, (...args: unknown[]) => void>;
+    };
+
+    options.logger.debug('fastmcp debug');
+    options.logger.log('fastmcp log');
+
+    expect(log.debug).toHaveBeenCalledWith('fastmcp debug');
+    expect(log.info).toHaveBeenCalledWith('fastmcp log');
   });
 
   test('registers plugin capabilities during construction but initializes lazily', async () => {


### PR DESCRIPTION
## Summary

- pass the Appium logger into `FastMCP` instead of using FastMCP's default console logger
- keep FastMCP debug/info logs off stdio stdout so MCP clients can parse JSON-RPC cleanly
- add coverage that `createAppiumMcpServer` wires FastMCP logging through the Appium logger

## Problem

When the server starts with stdio transport, FastMCP can write debug output such as:

```text
[FastMCP debug] roots capability explicitly disabled via config
```

to stdout before the JSON-RPC `initialize` response. Strict MCP clients then fail parsing the first stdout line as JSON, for example:

```text
Unexpected token 'F', "[FastMCP de"... is not valid JSON
```

## Verification

- `npm run build`
- `npm test`
- `npm run check` (passes with the existing `src/utils/ports.ts` sort warning)
- manual stdio smoke: start `node dist/index.js`, send `initialize`, verify stdout contains only the JSON-RPC response while FastMCP debug logs appear on stderr
