### PR TITLE
fix(gestures): use findElement in scroll_to_element visibility check

### DIFF
--- a/src/tests/tools/gestures/scroll-to-element.test.ts
+++ b/src/tests/tools/gestures/scroll-to-element.test.ts
@@ -33,6 +33,10 @@ jest.unstable_mockModule(
 const { handleScrollToElement } =
   await import('../../../tools/gestures/handlers/scroll-to-element.js');
 
+function resultText(result: { content: Array<{ type: string }> }): string {
+  return (result.content[0] as unknown as { text: string }).text;
+}
+
 const NO_SUCH_ELEMENT = {
   error: 'no such element',
   message:
@@ -51,14 +55,15 @@ describe('handleScrollToElement', () => {
     mockPerformVerticalScroll.mockClear();
 
     const result = await handleScrollToElement(remoteDriver as never, {
+      action: 'scroll_to_element',
       strategy: 'accessibility id',
       selector: 'missing',
       maxScrollAttempts: 1,
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('not found after 1 scroll');
-    expect(result.content[0].text).not.toContain('already visible');
+    expect(resultText(result)).toContain('not found after 1 scroll');
+    expect(resultText(result)).not.toContain('already visible');
     expect(mockPerformVerticalScroll).toHaveBeenCalledTimes(1);
   });
 
@@ -72,13 +77,14 @@ describe('handleScrollToElement', () => {
     mockPerformVerticalScroll.mockClear();
 
     const result = await handleScrollToElement(remoteDriver as never, {
+      action: 'scroll_to_element',
       strategy: 'accessibility id',
       selector: 'submit',
       maxScrollAttempts: 1,
     });
 
     expect(result.isError).toBeFalsy();
-    expect(result.content[0].text).toContain('already visible');
+    expect(resultText(result)).toContain('already visible');
     expect(mockPerformVerticalScroll).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/tools/gestures/scroll-to-element.test.ts
+++ b/src/tests/tools/gestures/scroll-to-element.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../../persistence', () => ({
+  readAllPersistedSessions: jest.fn(async () => []),
+  removePersistedSession: jest.fn(async () => {}),
+}));
+
+jest.unstable_mockModule('../../../session-store', () => ({
+  getDriver: jest.fn(),
+  setSession: jest.fn(),
+  getPlatformName: jest.fn(),
+  isAndroidUiautomator2DriverSession: jest.fn(() => false),
+  isRemoteDriverSession: jest.fn(() => true),
+  isXCUITestDriverSession: jest.fn(() => false),
+  PLATFORM: { ios: 'iOS', android: 'Android' },
+  getCurrentContext: jest.fn(),
+  getSessionInfo: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../../logger', () => ({
+  default: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+}));
+
+const mockPerformVerticalScroll = jest.fn(async () => undefined);
+
+jest.unstable_mockModule(
+  '../../../tools/gestures/handlers/swipe-scroll.js',
+  () => ({
+    performVerticalScroll: mockPerformVerticalScroll,
+  })
+);
+
+const { handleScrollToElement } =
+  await import('../../../tools/gestures/handlers/scroll-to-element.js');
+
+const NO_SUCH_ELEMENT = {
+  error: 'no such element',
+  message:
+    'An element could not be located on the page using the given search parameters',
+};
+
+describe('handleScrollToElement', () => {
+  test('does not treat remote swallowed no-such-element as already visible', async () => {
+    const remoteDriver = {
+      findElement: jest.fn(async () => NO_SUCH_ELEMENT),
+      getPageSource: jest
+        .fn<() => Promise<string>>()
+        .mockResolvedValueOnce('<before/>')
+        .mockResolvedValueOnce('<after/>'),
+    };
+    mockPerformVerticalScroll.mockClear();
+
+    const result = await handleScrollToElement(remoteDriver as never, {
+      strategy: 'accessibility id',
+      selector: 'missing',
+      maxScrollAttempts: 1,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not found after 1 scroll');
+    expect(result.content[0].text).not.toContain('already visible');
+    expect(mockPerformVerticalScroll).toHaveBeenCalledTimes(1);
+  });
+
+  test('reports already visible when findElement succeeds', async () => {
+    const remoteDriver = {
+      findElement: jest.fn(async () => ({
+        'element-6066-11e4-a52e-4f735466cecf': 'el-1',
+      })),
+      getPageSource: jest.fn(async () => '<xml/>'),
+    };
+    mockPerformVerticalScroll.mockClear();
+
+    const result = await handleScrollToElement(remoteDriver as never, {
+      strategy: 'accessibility id',
+      selector: 'submit',
+      maxScrollAttempts: 1,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('already visible');
+    expect(mockPerformVerticalScroll).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/gestures/handlers/scroll-to-element.ts
+++ b/src/tools/gestures/handlers/scroll-to-element.ts
@@ -1,6 +1,6 @@
 import type { ContentResult } from 'fastmcp';
 import type { DriverInstance } from '../../../session-store.js';
-import { getPageSource } from '../../../command.js';
+import { findElement, getPageSource } from '../../../command.js';
 import log from '../../../logger.js';
 import {
   errorResult,
@@ -98,7 +98,7 @@ async function tryFindElement(
   selector: string
 ): Promise<boolean> {
   try {
-    await driver.findElement(strategy, selector);
+    await findElement(driver, strategy, selector);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- `scroll_to_element` called `driver.findElement` directly; remote WebDriver clients resolve 404 no-such-element as `{ error, message }` without throwing
- That made missing elements look "already visible" on remote/CI sessions
- Route through `findElement()` from `command.ts` so `throwIfSwallowedRemoteError` applies (same pattern as `command.test.ts`)
