### PR TITLE
fix: limit the node version to not use 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,5 +124,8 @@
     "src/**/*.{js,json}": [
       "prettier --write"
     ]
+  },
+  "engines": {
+    "node": ">=22 <26"
   }
 }


### PR DESCRIPTION
A short term workaround of https://github.com/appium/appium-mcp/issues/454 until a new webdriver version will be released