### PR TITLE
fix(command): re-throw swallowed remote errors for element click, rect, and screenshot

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -277,7 +277,8 @@ export async function elementClick(
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.click(elementUUID);
   }
-  return await driver.elementClick(elementUUID);
+  const result = await driver.elementClick(elementUUID);
+  throwIfSwallowedRemoteError(result);
 }
 
 /**
@@ -319,7 +320,9 @@ export async function getElementRect(
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.getElementRect(elementUUID);
   }
-  return await driver.getElementRect(elementUUID);
+  const result = await driver.getElementRect(elementUUID);
+  throwIfSwallowedRemoteError(result);
+  return result;
 }
 
 /**
@@ -386,7 +389,9 @@ export async function getScreenshot(
     } else if (isXCUITestDriverSession(driver)) {
       return await driver.getElementScreenshot(elementId);
     }
-    return await driver.takeElementScreenshot(elementId);
+    const result = await driver.takeElementScreenshot(elementId);
+    throwIfSwallowedRemoteError(result);
+    return result;
   }
 
   if (isAndroidUiautomator2DriverSession(driver)) {

--- a/src/tests/command.test.ts
+++ b/src/tests/command.test.ts
@@ -16,6 +16,9 @@ const {
   getElementText,
   getElementAttribute,
   getActiveElement,
+  elementClick,
+  getElementRect,
+  getScreenshot,
 } = await import('../command.js');
 
 // What the remote client resolves with when it swallows a "no such element" 404.
@@ -121,6 +124,54 @@ describe('element commands: re-throw swallowed remote "no such element"', () => 
     await expect(
       getActiveElement({ getActiveElement: jest.fn(async () => el) } as never)
     ).resolves.toBe(el);
+  });
+
+  test('elementClick re-throws swallowed error, resolves otherwise', async () => {
+    await expect(
+      elementClick(
+        { elementClick: jest.fn(async () => NO_SUCH_ELEMENT_VALUE) } as never,
+        'bad'
+      )
+    ).rejects.toThrow(/could not be located/i);
+    await expect(
+      elementClick(
+        { elementClick: jest.fn(async () => undefined) } as never,
+        'el'
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  test('getElementRect re-throws swallowed error, returns rect otherwise', async () => {
+    await expect(
+      getElementRect(
+        { getElementRect: jest.fn(async () => NO_SUCH_ELEMENT_VALUE) } as never,
+        'bad'
+      )
+    ).rejects.toThrow(/could not be located/i);
+    const rect = { x: 0, y: 0, width: 100, height: 40 };
+    await expect(
+      getElementRect(
+        { getElementRect: jest.fn(async () => rect) } as never,
+        'el'
+      )
+    ).resolves.toBe(rect);
+  });
+
+  test('getScreenshot(elementId) re-throws swallowed error, returns base64 otherwise', async () => {
+    await expect(
+      getScreenshot(
+        {
+          takeElementScreenshot: jest.fn(async () => NO_SUCH_ELEMENT_VALUE),
+        } as never,
+        'bad'
+      )
+    ).rejects.toThrow(/could not be located/i);
+    await expect(
+      getScreenshot(
+        { takeElementScreenshot: jest.fn(async () => 'base64png') } as never,
+        'el'
+      )
+    ).resolves.toBe('base64png');
   });
 
   test('preserves the W3C error code as the error name (for classifyError)', async () => {


### PR DESCRIPTION
### Problem

`command.ts` normalizes swallowed remote "no such element" responses (a raw WebDriver `Client` resolves the 404 as a `{ error, message }` value instead of throwing) via `throwIfSwallowedRemoteError` for `findElement`, `setValue`, `getElementText`, `getElementAttribute`, and `getActiveElement`. Three element-targeted wrappers were missed:

- `getElementRect` — the error object flows into `tap.ts` `resolveCoordsFromElement`, producing `Math.floor(NaN)` coordinates and a tap at a garbage location instead of surfacing the error.
- `elementClick` — reports success without clicking (silent no-op).
- `getScreenshot(elementId)` — returns the error object as the screenshot payload.

### Fix

Run the remote results of `elementClick`, `getElementRect`, and the element-screenshot path through `throwIfSwallowedRemoteError`, matching the sibling element wrappers. This mirrors the same normalization already applied to `scroll_to_element` (#446) and the Android alert button lookup.

### Test

Extended `src/tests/command.test.ts` with cases asserting each of the three wrappers re-throws the swallowed error and passes valid results through unchanged.