### PR TITLE
fix: Skip UI construction when NO_UI is enabled

### DIFF
--- a/src/tests/mcp-ui-utils.test.ts
+++ b/src/tests/mcp-ui-utils.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, test } from '@jest/globals';
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
 
 import {
+  addUIResourceToResponse,
   createContextSwitcherUI,
   createLocatorGeneratorUI,
   createPageSourceInspectorUI,
   createTestCodeViewerUI,
+  createUIResource,
 } from '../ui/mcp-ui-utils.js';
 
 describe('createLocatorGeneratorUI', () => {
@@ -40,6 +42,56 @@ describe('createLocatorGeneratorUI', () => {
     expect(html).toContain(
       'data-selector="com.attacker.app/`&lt;img src=x onerror=alert(1)&gt;"'
     );
+  });
+});
+
+describe('addUIResourceToResponse', () => {
+  const originalNoUI = process.env.NO_UI;
+
+  afterEach(() => {
+    if (originalNoUI === undefined) {
+      delete process.env.NO_UI;
+    } else {
+      process.env.NO_UI = originalNoUI;
+    }
+  });
+
+  test.each(['true', '1'])(
+    'does not construct UI resources when NO_UI=%s',
+    (value) => {
+      process.env.NO_UI = value;
+      const response = { content: [{ type: 'text', text: 'result' }] };
+      const createResource = jest.fn(() =>
+        createUIResource('ui://test/resource', '<html></html>')
+      );
+
+      const result = addUIResourceToResponse(response, createResource);
+
+      expect(result).toBe(response);
+      expect(createResource).not.toHaveBeenCalled();
+    }
+  );
+
+  test('constructs and appends lazy UI resources when UI is enabled', () => {
+    delete process.env.NO_UI;
+    const response = { content: [{ type: 'text', text: 'result' }] };
+    const uiResource = createUIResource('ui://test/resource', '<html></html>');
+    const createResource = jest.fn(() => uiResource);
+
+    const result = addUIResourceToResponse(response, createResource);
+
+    expect(createResource).toHaveBeenCalledTimes(1);
+    expect(result.content).toEqual([...response.content, uiResource]);
+  });
+
+  test('continues to accept prebuilt UI resources', () => {
+    delete process.env.NO_UI;
+    const response = { content: [{ type: 'text', text: 'result' }] };
+    const uiResource = createUIResource('ui://test/resource', '<html></html>');
+
+    const result = addUIResourceToResponse(response, uiResource);
+
+    expect(result.content).toEqual([...response.content, uiResource]);
   });
 });
 

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -104,11 +104,12 @@ export async function list(
     const textResponse = textResult(
       `Installed apps: ${JSON.stringify(apps, null, 2)}`
     );
-    const uiResource = createUIResource(
-      `ui://appium-mcp/app-list/${Date.now()}`,
-      createAppListUI(apps)
+    return addUIResourceToResponse(textResponse, () =>
+      createUIResource(
+        `ui://appium-mcp/app-list/${Date.now()}`,
+        createAppListUI(apps)
+      )
     );
-    return addUIResourceToResponse(textResponse, uiResource);
   } catch (err: unknown) {
     return errorResult(`Failed to list apps. err: ${toolErrorMessage(err)}`);
   }

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -69,12 +69,12 @@ export default function context(server: FastMCP): void {
             `Available contexts: ${JSON.stringify(availableContexts, null, 2)}\nCurrent context: ${currentContext}`
           );
 
-          const uiResource = createUIResource(
-            `ui://appium-mcp/context-switcher/${Date.now()}`,
-            createContextSwitcherUI(availableContexts, currentContext)
+          return addUIResourceToResponse(textResponse, () =>
+            createUIResource(
+              `ui://appium-mcp/context-switcher/${Date.now()}`,
+              createContextSwitcherUI(availableContexts, currentContext)
+            )
           );
-
-          return addUIResourceToResponse(textResponse, uiResource);
         }
 
         if (!args.context) {

--- a/src/tools/interactions/get-page-source.ts
+++ b/src/tools/interactions/get-page-source.ts
@@ -52,12 +52,12 @@ export default function getPageSource(server: FastMCP): void {
         );
 
         // Add interactive page source inspector UI
-        const uiResource = createUIResource(
-          `ui://appium-mcp/page-source-inspector/${Date.now()}`,
-          createPageSourceInspectorUI(pageSource)
+        return addUIResourceToResponse(textResponse, () =>
+          createUIResource(
+            `ui://appium-mcp/page-source-inspector/${Date.now()}`,
+            createPageSourceInspectorUI(pageSource)
+          )
         );
-
-        return addUIResourceToResponse(textResponse, uiResource);
       } catch (err: unknown) {
         return errorResult(
           `Failed to get page source. Error: ${toolErrorMessage(err)}`

--- a/src/tools/interactions/screenshot.ts
+++ b/src/tools/interactions/screenshot.ts
@@ -111,12 +111,12 @@ export async function executeScreenshot(opts: {
     );
 
     // Add interactive screenshot viewer UI
-    const uiResource = createUIResource(
-      `ui://appium-mcp/screenshot-viewer/${Date.now()}`,
-      createScreenshotViewerUI(displayBase64, filepath)
+    return addUIResourceToResponse(textResponse, () =>
+      createUIResource(
+        `ui://appium-mcp/screenshot-viewer/${Date.now()}`,
+        createScreenshotViewerUI(displayBase64, filepath)
+      )
     );
-
-    return addUIResourceToResponse(textResponse, uiResource);
   } catch (err: unknown) {
     return errorResult(
       `Failed to take screenshot. err: ${toolErrorMessage(err)}`

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -455,20 +455,21 @@ export async function createSessionAction(args: {
     const textResponse = textResult(
       `${platform.toUpperCase()} session created successfully with ID: ${sessionIdStr}\nPlatform: ${finalCapabilities.platformName}\nAutomation: ${finalCapabilities['appium:automationName']}\nDevice: ${finalCapabilities['appium:deviceName']}\nActive sessions: ${totalSessions}`
     );
+    const sessionCapabilities = finalCapabilities;
 
-    const uiResource = createUIResource(
-      `ui://appium-mcp/session-dashboard/${sessionIdStr}`,
-      createSessionDashboardUI({
-        sessionId: sessionIdStr,
-        platform: finalCapabilities.platformName,
-        automationName: finalCapabilities['appium:automationName'],
-        deviceName: finalCapabilities['appium:deviceName'],
-        platformVersion: finalCapabilities['appium:platformVersion'],
-        udid: finalCapabilities['appium:udid'],
-      })
+    return addUIResourceToResponse(textResponse, () =>
+      createUIResource(
+        `ui://appium-mcp/session-dashboard/${sessionIdStr}`,
+        createSessionDashboardUI({
+          sessionId: sessionIdStr,
+          platform: sessionCapabilities.platformName,
+          automationName: sessionCapabilities['appium:automationName'],
+          deviceName: sessionCapabilities['appium:deviceName'],
+          platformVersion: sessionCapabilities['appium:platformVersion'],
+          udid: sessionCapabilities['appium:udid'],
+        })
+      )
     );
-
-    return addUIResourceToResponse(textResponse, uiResource);
   } catch (error: unknown) {
     log.error('Error creating session:', error);
     return errorResult(

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -225,12 +225,12 @@ function formatAndroidListResponse(devices: any[]): ContentResult {
   );
 
   // Add interactive UI picker
-  const uiResource = createUIResource(
-    `ui://appium-mcp/device-picker/android-${Date.now()}`,
-    createDevicePickerUI(devices, 'android')
+  return addUIResourceToResponse(textResponse, () =>
+    createUIResource(
+      `ui://appium-mcp/device-picker/android-${Date.now()}`,
+      createDevicePickerUI(devices, 'android')
+    )
   );
-
-  return addUIResourceToResponse(textResponse, uiResource);
 }
 
 /**
@@ -344,12 +344,12 @@ function formatIOSListResponse(
   );
 
   // Add interactive UI picker
-  const uiResource = createUIResource(
-    `ui://appium-mcp/device-picker/ios-${iosDeviceType}-${Date.now()}`,
-    createDevicePickerUI(devices, 'ios', iosDeviceType)
+  return addUIResourceToResponse(textResponse, () =>
+    createUIResource(
+      `ui://appium-mcp/device-picker/ios-${iosDeviceType}-${Date.now()}`,
+      createDevicePickerUI(devices, 'ios', iosDeviceType)
+    )
   );
-
-  return addUIResourceToResponse(textResponse, uiResource);
 }
 
 /**

--- a/src/tools/test-generation/locators.ts
+++ b/src/tools/test-generation/locators.ts
@@ -85,12 +85,12 @@ export default function generateLocators(server: any): void {
           })
         );
 
-        const uiResource = createUIResource(
-          `ui://appium-mcp/locator-generator/${Date.now()}`,
-          createLocatorGeneratorUI(interactableElements)
+        return addUIResourceToResponse(textResponse, () =>
+          createUIResource(
+            `ui://appium-mcp/locator-generator/${Date.now()}`,
+            createLocatorGeneratorUI(interactableElements)
+          )
         );
-
-        return addUIResourceToResponse(textResponse, uiResource);
       } catch (err: unknown) {
         log.error('Error getting page source:', err);
         return errorResult(

--- a/src/ui/mcp-ui-utils.ts
+++ b/src/ui/mcp-ui-utils.ts
@@ -1678,18 +1678,24 @@ export function createTestCodeViewerUI(
 
 /**
  * Helper function to add UI resource to response content
- * Returns both text and UI resource for backward compatibility
+ * Accepts a lazy factory so NO_UI can skip expensive UI construction.
+ * Returns both text and UI resource for backward compatibility.
  */
 export function addUIResourceToResponse(
   response: { content: Array<{ type: string; text?: string }> },
-  uiResource: ReturnType<typeof createUIResource>
+  uiResource:
+    | ReturnType<typeof createUIResource>
+    | (() => ReturnType<typeof createUIResource>)
 ): { content: Array<any> } {
   if (process.env.NO_UI === 'true' || process.env.NO_UI === '1') {
     return response;
   }
 
+  const resolvedUIResource =
+    typeof uiResource === 'function' ? uiResource() : uiResource;
+
   return {
-    content: [...response.content, uiResource],
+    content: [...response.content, resolvedUIResource],
   };
 }
 


### PR DESCRIPTION
## What changed

- allow `addUIResourceToResponse` to accept a lazy UI-resource factory
- defer UI resource, HTML, and embedded screenshot construction until after the `NO_UI` check
- update all current UI-producing paths: screenshots, page source, locators, device selection, session dashboard, contexts, and installed apps
- retain support for callers that pass a prebuilt UI resource
- add regression coverage for `NO_UI=true`, `NO_UI=1`, UI-enabled lazy construction, and the existing prebuilt-resource API

## Why

`NO_UI` previously removed UI blocks from the returned MCP result only after each tool had already generated the HTML resource. For large page sources, locator sets, and screenshots, this still incurred the CPU and memory cost of constructing duplicated HTML/base64 content even though none of it was returned.

The lazy factory makes the documented `NO_UI` behavior skip UI generation at the source while preserving UI-enabled responses and Appium/WebDriver execution behavior.

## Impact

- `NO_UI=true` or `NO_UI=1`: expensive UI payload construction is skipped
- default UI-enabled mode: response content remains unchanged
- tool names, schemas, parameters, and Appium operations are unchanged

First implementation step for #470.

## Verification

- `npm run build`
- `npm run check`
- `npm test -- --runInBand` — 29 suites, 327 tests passed
