### PR TITLE
chore: audit MCP tool discovery footprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - run: npm run build
         name: Build
 
+      - name: Audit MCP tool discovery footprint
+        run: npm run audit:tools
+
       - name: Run Unit Tests
         run: npm run test
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -559,9 +559,12 @@ The tools below are useful structural references — how a tool is wired up, sch
 ```bash
 npm run check   # eslint + prettier
 npm run build   # tsc
+npm run audit:tools  # measure the built tools/list payload and enforce its size budget
 ```
 
-Both must be green before opening a PR.
+All three must be green before opening a PR. The tool-footprint audit runs
+against the built stdio server with optional AI and documentation tools
+disabled, matching the default tool set used for the CI budget.
 
 ### 2. Unit test the response contract (recommended for non-trivial tools)
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "inspect": "npx fastmcp inspect src/index.js",
     "dev:built": "node dist/index.js",
     "inspect:built": "npx @modelcontextprotocol/inspector node dist/index.js",
+    "audit:tools": "node scripts/audit-tool-footprint.mjs",
     "verify:names": "node scripts/verify-names.mjs",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:locators": "NODE_OPTIONS=--experimental-vm-modules jest src/tests/generate-all-locators.test.ts",

--- a/scripts/audit-tool-footprint.mjs
+++ b/scripts/audit-tool-footprint.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const MAX_DISCOVERY_CHARS = 47_000;
+const ESTIMATED_CHARS_PER_TOKEN = 4;
+const LARGEST_TOOL_COUNT = 10;
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(scriptDir, '..');
+const serverEntry = join(projectRoot, 'dist', 'index.js');
+
+if (!existsSync(serverEntry)) {
+  console.error(
+    `Built server not found at ${serverEntry}. Run "npm run build" first.`
+  );
+  process.exit(1);
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [serverEntry],
+  cwd: projectRoot,
+  env: {
+    AI_VISION_ENABLED: 'false',
+    APPIUM_MCP_DOCS_ENABLED: 'false',
+    APPIUM_MCP_OTEL_ENABLED: 'false',
+    NO_UI: 'true',
+  },
+  stderr: 'ignore',
+});
+const client = new Client({
+  name: 'appium-mcp-tool-footprint-audit',
+  version: '1.0.0',
+});
+
+try {
+  await client.connect(transport);
+  const result = await client.listTools();
+  const payloadChars = JSON.stringify(result).length;
+  const withoutDescriptionsChars = JSON.stringify(
+    removeDescriptionFields(result)
+  ).length;
+  const withoutParameterDescriptionsChars = JSON.stringify(
+    removeParameterDescriptions(result)
+  ).length;
+  const estimatedTokens = Math.ceil(payloadChars / ESTIMATED_CHARS_PER_TOKEN);
+  const remainingChars = MAX_DISCOVERY_CHARS - payloadChars;
+  const largestTools = result.tools
+    .map((tool) => ({
+      name: tool.name,
+      chars: JSON.stringify(tool).length,
+    }))
+    .sort((a, b) => b.chars - a.chars || a.name.localeCompare(b.name))
+    .slice(0, LARGEST_TOOL_COUNT);
+
+  console.log('MCP tool discovery footprint');
+  console.log(`Tools: ${formatNumber(result.tools.length)}`);
+  console.log(
+    `Payload: ${formatNumber(payloadChars)} chars (~${formatNumber(estimatedTokens)} tokens)`
+  );
+  console.log(
+    `Description overhead: ${formatNumber(payloadChars - withoutDescriptionsChars)} chars`
+  );
+  console.log(
+    `Parameter-description overhead: ${formatNumber(payloadChars - withoutParameterDescriptionsChars)} chars`
+  );
+  console.log(
+    `Budget: ${formatNumber(MAX_DISCOVERY_CHARS)} chars (${formatSignedNumber(remainingChars)} remaining)`
+  );
+  console.log('Largest tools:');
+  for (const tool of largestTools) {
+    console.log(`  ${tool.name}: ${formatNumber(tool.chars)} chars`);
+  }
+
+  if (remainingChars < 0) {
+    console.error(
+      `Tool discovery payload exceeds the budget by ${formatNumber(-remainingChars)} chars.`
+    );
+    process.exitCode = 1;
+  } else {
+    console.log('Tool discovery payload is within budget.');
+  }
+} catch (error) {
+  console.error(
+    `Failed to audit MCP tool discovery footprint: ${
+      error instanceof Error ? error.message : String(error)
+    }`
+  );
+  process.exitCode = 1;
+} finally {
+  await client.close().catch(() => undefined);
+}
+
+function removeDescriptionFields(value) {
+  if (Array.isArray(value)) {
+    return value.map(removeDescriptionFields);
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'description')
+      .map(([key, child]) => [key, removeDescriptionFields(child)])
+  );
+}
+
+function removeParameterDescriptions(result) {
+  return {
+    ...result,
+    tools: result.tools.map((tool) => ({
+      ...tool,
+      inputSchema: removeDescriptionFields(tool.inputSchema),
+    })),
+  };
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatSignedNumber(value) {
+  return `${value >= 0 ? '+' : '-'}${formatNumber(Math.abs(value))}`;
+}


### PR DESCRIPTION
## What changed

- add `npm run audit:tools` to measure the real MCP `tools/list` response from the built stdio server
- report total discovery characters, estimated tokens, description overhead, parameter-description overhead, and the ten largest tool definitions
- enforce a 47,000-character CI ceiling against the current 46,111-character baseline
- disable optional AI, documentation, and telemetry features in the audit process so the measurement is deterministic
- run the audit after the build in the Node CI matrix
- document the audit in the contributor verification workflow

## Why

Tool definitions are repeatedly supplied to LLM clients and currently account for roughly 11.5k estimated tokens. Before compressing descriptions, the project needs a reproducible baseline and a regression gate that measures the actual framework-generated MCP payload rather than source-text approximations.

The 47,000-character ceiling provides 889 characters (about 1.9%) of initial headroom while preventing unnoticed discovery growth. It can be lowered as the description-compression work lands.

## Impact

- no tool names, schemas, descriptions, handlers, or runtime behavior change
- contributors get per-tool targets for future optimization
- CI fails when the default discovery payload exceeds the budget

Next implementation step for #470.

## Verification

- `node --check scripts/audit-tool-footprint.mjs`
- `npm run build`
- `npm run audit:tools` — 31 tools, 46,111 characters, ~11,528 estimated tokens
- `npm run check`
- CI workflow YAML parse check
- `npm test -- --runInBand` — 29 suites, 327 tests passed
