### PR TITLE
perf: reduce MCP tool discovery tokens

### DIFF
--- a/scripts/audit-tool-footprint.mjs
+++ b/scripts/audit-tool-footprint.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
-const MAX_DISCOVERY_CHARS = 40_000;
+const MAX_DISCOVERY_CHARS = 42_000;
 const ESTIMATED_CHARS_PER_TOKEN = 4;
 const LARGEST_TOOL_COUNT = 10;
 

--- a/scripts/audit-tool-footprint.mjs
+++ b/scripts/audit-tool-footprint.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
-const MAX_DISCOVERY_CHARS = 47_000;
+const MAX_DISCOVERY_CHARS = 30_000;
 const ESTIMATED_CHARS_PER_TOKEN = 4;
 const LARGEST_TOOL_COUNT = 10;
 

--- a/scripts/audit-tool-footprint.mjs
+++ b/scripts/audit-tool-footprint.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
-const MAX_DISCOVERY_CHARS = 30_000;
+const MAX_DISCOVERY_CHARS = 40_000;
 const ESTIMATED_CHARS_PER_TOKEN = 4;
 const LARGEST_TOOL_COUNT = 10;
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,4 +2,4 @@ import { z } from 'zod';
 
 export const elementUUIDScheme = z
   .string()
-  .describe('The uuid of the element returned by appium_find_element to click');
+  .describe('Element ID from appium_find_element.');

--- a/src/tests/tools/llm-wording.test.ts
+++ b/src/tests/tools/llm-wording.test.ts
@@ -145,15 +145,26 @@ describe('LLM-facing MCP tool wording', () => {
       /create.*attach.*detach.*delete.*list.*select/i
     );
 
-    expect(actionDescription).toMatch(/DEFAULT MODE/i);
+    expect(actionDescription).toMatch(/DEFAULT\/LOCAL MODE/i);
     expect(actionDescription).toMatch(/no separate Appium process is needed/i);
-    expect(actionDescription).toMatch(/select_device tool FIRST/i);
+    expect(actionDescription).toMatch(
+      /select_device first.*explicit target capabilities.*appium:udid/i
+    );
     expect(actionDescription).toMatch(/do NOT pass remoteServerUrl/i);
     expect(actionDescription).toMatch(/NEVER invent a localhost URL/i);
-    expect(actionDescription).toMatch(/prepare_ios_simulator.*before create/i);
+    expect(actionDescription).toMatch(
+      /prepare_ios_simulator.*appium_prepare_ios_real_device/i
+    );
+    expect(actionDescription).toMatch(
+      /full returned capabilitiesHint as capabilities/i
+    );
     expect(actionDescription).toMatch(/REMOTE SERVER MODE/i);
     expect(actionDescription).toMatch(
       /only when the user explicitly provides/i
+    );
+    expect(actionDescription).toMatch(/skip select_device/i);
+    expect(actionDescription).toMatch(
+      /platform=general.*requires remoteServerUrl/i
     );
     expect(actionDescription).toMatch(/without taking ownership/i);
     expect(actionDescription).toMatch(
@@ -181,7 +192,10 @@ describe('LLM-facing MCP tool wording', () => {
     );
     expect(description).toMatch(/NEVER use.*REMOTE.*remoteServerUrl/i);
     expect(description).toMatch(
-      /prepare_ios_simulator.*appium_session_management.*create/i
+      /prepare_ios_simulator.*appium_prepare_ios_real_device/i
+    );
+    expect(description).toMatch(
+      /full capabilitiesHint.*appium_session_management.*create/i
     );
     expect(description).toMatch(/Remote devices.*session capabilities/i);
 

--- a/src/tests/tools/llm-wording.test.ts
+++ b/src/tests/tools/llm-wording.test.ts
@@ -22,6 +22,30 @@ jest.unstable_mockModule('../../command', () => ({
   findElement: jest.fn(),
 }));
 
+jest.unstable_mockModule('../../devicemanager/adb-manager', () => ({
+  ADBManager: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../devicemanager/ios-manager', () => ({
+  IOSManager: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../logger', () => ({
+  default: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule('../../ui/mcp-ui-utils', () => ({
+  addUIResourceToResponse: jest.fn(),
+  createAppListUI: jest.fn(),
+  createDevicePickerUI: jest.fn(),
+  createUIResource: jest.fn(),
+}));
+
 jest.unstable_mockModule('../../tools/session/attach-session', () => ({
   attachSessionAction: jest.fn(),
 }));
@@ -97,7 +121,9 @@ describe('LLM-facing MCP tool wording', () => {
       /Android.*prefer.*android uiautomator/i
     );
     expect(strategyDescription).toMatch(/xpath last/i);
-    expect(selectorDescription).toMatch(/not natural language/i);
+    expect(selectorDescription).toMatch(
+      /do not pass natural-language descriptions/i
+    );
   });
 
   test('appium_session_management explains local vs remote session creation', async () => {
@@ -139,6 +165,35 @@ describe('LLM-facing MCP tool wording', () => {
     expect(remoteServerUrlDescription).toMatch(/omit for embedded create/i);
     expect(sessionIdDescription).toMatch(/required for attach\/select/i);
     expect(tool.annotations?.destructiveHint).toBe(true);
+  });
+
+  test('select_device preserves the local and remote workflow', async () => {
+    const tool = await registerTool('../../tools/session/select-device.js');
+    const description = normalizeText(tool.description);
+
+    expect(tool.name).toBe('select_device');
+    expect(description).toMatch(/LOCAL servers ONLY/i);
+    expect(description).toMatch(/ASK THE USER.*Android.*iOS.*do not assume/i);
+    expect(description).toMatch(/without deviceUdid.*list/i);
+    expect(description).toMatch(/one result.*auto-select/i);
+    expect(description).toMatch(
+      /multiple results.*ask the user.*chosen deviceUdid/i
+    );
+    expect(description).toMatch(/NEVER use.*REMOTE.*remoteServerUrl/i);
+    expect(description).toMatch(
+      /prepare_ios_simulator.*appium_session_management.*create/i
+    );
+    expect(description).toMatch(/Remote devices.*session capabilities/i);
+
+    expect(normalizeText(paramDescription(tool, 'platform'))).toMatch(
+      /user-selected.*never assume/i
+    );
+    expect(normalizeText(paramDescription(tool, 'iosDeviceType'))).toMatch(
+      /Required.*iOS.*simulator.*real/i
+    );
+    expect(normalizeText(paramDescription(tool, 'deviceUdid'))).toMatch(
+      /omit.*list.*ask.*multiple/i
+    );
   });
 
   test('appium_mobile_permissions retains action-specific requirements', async () => {

--- a/src/tests/tools/llm-wording.test.ts
+++ b/src/tests/tools/llm-wording.test.ts
@@ -89,12 +89,12 @@ describe('LLM-facing MCP tool wording', () => {
     expect(description).toMatch(/appium_ai.*find_element/i);
 
     expect(strategyDescription).toMatch(/cross-platform.*fastest.*stable/i);
-    expect(strategyDescription).toMatch(/iOS prefer/i);
-    expect(strategyDescription).toMatch(/Android prefer/i);
-    expect(strategyDescription).toMatch(/xpath last/i);
-    expect(selectorDescription).toMatch(
-      /Do not pass natural-language descriptions/i
+    expect(strategyDescription).toMatch(/iOS.*prefer.*predicate.*class chain/i);
+    expect(strategyDescription).toMatch(
+      /Android.*prefer.*android uiautomator/i
     );
+    expect(strategyDescription).toMatch(/xpath last/i);
+    expect(selectorDescription).toMatch(/not natural language/i);
   });
 
   test('appium_session_management explains local vs remote session creation', async () => {
@@ -122,16 +122,18 @@ describe('LLM-facing MCP tool wording', () => {
     expect(actionDescription).toMatch(/do NOT pass remoteServerUrl/i);
     expect(actionDescription).toMatch(/NEVER invent a localhost URL/i);
     expect(actionDescription).toMatch(/REMOTE SERVER MODE/i);
-    expect(actionDescription).toMatch(/only when user explicitly provides/i);
+    expect(actionDescription).toMatch(
+      /only when the user explicitly provides/i
+    );
     expect(actionDescription).toMatch(/without taking ownership/i);
     expect(actionDescription).toMatch(
       /without deleting the real remote session/i
     );
 
-    expect(platformDescription).toMatch(/Required for create/i);
-    expect(platformDescription).toMatch(/general.*non-Android\/iOS/i);
-    expect(remoteServerUrlDescription).toMatch(/Omit to use local server/i);
-    expect(sessionIdDescription).toMatch(/Required for attach and select/i);
+    expect(platformDescription).toMatch(/create platform/i);
+    expect(platformDescription).toMatch(/general.*other remote drivers/i);
+    expect(remoteServerUrlDescription).toMatch(/omit for embedded create/i);
+    expect(sessionIdDescription).toMatch(/required for attach\/select/i);
     expect(tool.annotations?.destructiveHint).toBe(true);
   });
 });

--- a/src/tests/tools/llm-wording.test.ts
+++ b/src/tests/tools/llm-wording.test.ts
@@ -164,7 +164,7 @@ describe('LLM-facing MCP tool wording', () => {
     const tool = await registerTool('../../tools/session/file-transfer.js');
     const pathDescription = normalizeText(paramDescription(tool, 'remotePath'));
 
-    expect(pathDescription).toMatch(/absolute Android path/i);
+    expect(pathDescription).toMatch(/Android.*absolute path/i);
     expect(pathDescription).toMatch(/\/sdcard\/Download/i);
     expect(pathDescription).toMatch(/@com\.example\.app:documents/i);
     expect(normalizeText(paramDescription(tool, 'payloadBase64'))).toMatch(

--- a/src/tests/tools/llm-wording.test.ts
+++ b/src/tests/tools/llm-wording.test.ts
@@ -9,13 +9,16 @@ jest.unstable_mockModule('../../tools/tool-response', () => ({
     content: [{ type: 'text', text }],
     isError: true,
   })),
+  noActiveDriverSessionMessage: jest.fn(),
   readWebElementId: jest.fn(),
   resolveDriver: jest.fn(),
+  textResult: jest.fn(),
   textResultWithPrimaryElementId: jest.fn(),
   toolErrorMessage: jest.fn(mockToolErrorMessage),
 }));
 
 jest.unstable_mockModule('../../command', () => ({
+  execute: jest.fn(),
   findElement: jest.fn(),
 }));
 
@@ -121,6 +124,7 @@ describe('LLM-facing MCP tool wording', () => {
     expect(actionDescription).toMatch(/select_device tool FIRST/i);
     expect(actionDescription).toMatch(/do NOT pass remoteServerUrl/i);
     expect(actionDescription).toMatch(/NEVER invent a localhost URL/i);
+    expect(actionDescription).toMatch(/prepare_ios_simulator.*before create/i);
     expect(actionDescription).toMatch(/REMOTE SERVER MODE/i);
     expect(actionDescription).toMatch(
       /only when the user explicitly provides/i
@@ -130,10 +134,60 @@ describe('LLM-facing MCP tool wording', () => {
       /without deleting the real remote session/i
     );
 
-    expect(platformDescription).toMatch(/create platform/i);
+    expect(platformDescription).toMatch(/Required for create/i);
     expect(platformDescription).toMatch(/general.*other remote drivers/i);
     expect(remoteServerUrlDescription).toMatch(/omit for embedded create/i);
     expect(sessionIdDescription).toMatch(/required for attach\/select/i);
     expect(tool.annotations?.destructiveHint).toBe(true);
+  });
+
+  test('appium_mobile_permissions retains action-specific requirements', async () => {
+    const tool = await registerTool(
+      '../../tools/app-management/permissions.js'
+    );
+
+    expect(normalizeText(paramDescription(tool, 'action'))).toMatch(
+      /get.*Android.*iOS.*update.*Android.*iOS.*reset.*iOS/i
+    );
+    expect(normalizeText(paramDescription(tool, 'service'))).toMatch(
+      /Required.*iOS get\/reset.*service name.*numeric/i
+    );
+    expect(normalizeText(paramDescription(tool, 'permissions'))).toMatch(
+      /Required.*Android update/i
+    );
+    expect(normalizeText(paramDescription(tool, 'access'))).toMatch(
+      /Required.*iOS update.*yes.*no.*unset.*limited/i
+    );
+  });
+
+  test('appium_mobile_file retains platform-specific path syntax', async () => {
+    const tool = await registerTool('../../tools/session/file-transfer.js');
+    const pathDescription = normalizeText(paramDescription(tool, 'remotePath'));
+
+    expect(pathDescription).toMatch(/absolute Android path/i);
+    expect(pathDescription).toMatch(/\/sdcard\/Download/i);
+    expect(pathDescription).toMatch(/@com\.example\.app:documents/i);
+    expect(normalizeText(paramDescription(tool, 'payloadBase64'))).toMatch(
+      /required.*push/i
+    );
+  });
+
+  test('appium_mobile_press_key maps logical keys by platform', async () => {
+    const tool = await registerTool('../../tools/interactions/press-key.js');
+    const keyDescription = normalizeText(paramDescription(tool, 'key'));
+
+    expect(keyDescription).toMatch(/Android.*BACK.*HOME.*APP_SWITCH/i);
+    expect(keyDescription).toMatch(/iOS\/tvOS.*VOLUME_UP.*PLAY_PAUSE.*SELECT/i);
+  });
+
+  test('appium_gesture retains scroll direction defaults', async () => {
+    const { gestureSchema } = await import('../../tools/gestures/schema.js');
+    const directionDescription = normalizeText(
+      gestureSchema.shape.direction.description ?? ''
+    );
+
+    expect(directionDescription).toMatch(
+      /scroll_to_element.*up\/down.*default down/i
+    );
   });
 });

--- a/src/tools/app-management/app.ts
+++ b/src/tools/app-management/app.ts
@@ -32,76 +32,49 @@ const schema = z.object({
   action: z
     .enum(APP_ACTIONS)
     .describe(
-      'Action to perform. ' +
-        'activate: bring app to foreground (requires id or name). ' +
-        'terminate: stop a running app (requires id or name). ' +
-        'install: install from file path (requires path). ' +
-        'uninstall: remove from device (requires id or name; optional keepData for Android). ' +
-        'list: list installed apps (optional applicationType for iOS). ' +
-        'is_installed: check if app is installed (requires id or name). ' +
-        'query_state: get state 0=not installed,1=not running,2=background suspended,3=background,4=foreground (requires id or name). ' +
-        'background: send foreground app to background (optional seconds, default 5). ' +
-        'clear: clear app data without uninstalling (requires id or name). ' +
-        'deep_link: open a URL with an app (requires url; optional id or name).'
+      'App action. install requires path; deep_link requires url; list/background need no id. ' +
+        'Other actions require id or name. query_state returns WebDriver states 0–4.'
     ),
   id: z
     .string()
     .optional()
-    .describe(
-      'App identifier (package name for Android, bundle ID for iOS). Takes precedence over name. Required for: activate, terminate, uninstall, is_installed, query_state, clear.'
-    ),
+    .describe('Android package or iOS bundle ID; preferred over name.'),
   name: z
     .string()
     .optional()
-    .describe(
-      'Human-readable app name (e.g. "Spotify"). Used to resolve the app id. Required (as alternative to id) for: activate, terminate, uninstall, is_installed, query_state, clear.'
-    ),
-  path: z
-    .string()
-    .optional()
-    .describe('Path to the app file to install. Required for: install.'),
+    .describe('App name resolved to an ID; alternative to id.'),
+  path: z.string().optional().describe('App file path; required for install.'),
   keepData: z
     .boolean()
     .optional()
-    .describe(
-      'Keep app data and cache after uninstall. Android only. Used with: uninstall.'
-    ),
+    .describe('Android uninstall: retain data/cache.'),
   applicationType: z
     .enum(['User', 'System'])
     .optional()
-    .describe(
-      'iOS only: filter by "User" (default) or "System" apps. Used with: list.'
-    ),
+    .describe('iOS list filter; default User.'),
   seconds: z
     .number()
     .min(-1)
     .max(86400)
     .optional()
     .describe(
-      `Seconds to keep the app in the background. Defaults to ${DEFAULT_BACKGROUND_SECONDS}. Use -1 to stay in background without auto-resuming. Used with: background.`
+      `background seconds; default ${DEFAULT_BACKGROUND_SECONDS}; -1 stays backgrounded.`
     ),
-  url: z
-    .string()
-    .optional()
-    .describe(
-      'Deep link URL to open (e.g. https://example.com, myapp://path). Required for: deep_link.'
-    ),
+  url: z.string().optional().describe('URL; required for deep_link.'),
   waitForLaunch: z
     .boolean()
     .optional()
-    .describe(
-      'Android only. If false, ADB does not wait for the activity to return. Defaults to true. Used with: deep_link.'
-    ),
+    .describe('Android deep_link: wait for launch; default true.'),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 export default function app(server: FastMCP): void {
   server.addTool({
     name: 'appium_app_lifecycle',
-    description: `Manage apps on the device. Use the action parameter to choose what to do: ${APP_ACTIONS.join(', ')}.`,
+    description: `Manage app lifecycle: ${APP_ACTIONS.join(', ')}.`,
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/app-management/app.ts
+++ b/src/tools/app-management/app.ts
@@ -32,39 +32,66 @@ const schema = z.object({
   action: z
     .enum(APP_ACTIONS)
     .describe(
-      'App action. install requires path; deep_link requires url; list/background need no id. ' +
-        'Other actions require id or name. query_state returns WebDriver states 0–4.'
+      'Action to perform. ' +
+        'activate: bring app to foreground (requires id or name). ' +
+        'terminate: stop a running app (requires id or name). ' +
+        'install: install from file path (requires path). ' +
+        'uninstall: remove from device (requires id or name; optional keepData for Android). ' +
+        'list: list installed apps (optional applicationType for iOS). ' +
+        'is_installed: check if app is installed (requires id or name). ' +
+        'query_state: get state 0=not installed,1=not running,2=background suspended,3=background,4=foreground (requires id or name). ' +
+        'background: send foreground app to background (optional seconds, default 5). ' +
+        'clear: clear app data without uninstalling (requires id or name). ' +
+        'deep_link: open a URL with an app (requires url; optional id or name).'
     ),
   id: z
     .string()
     .optional()
-    .describe('Android package or iOS bundle ID; preferred over name.'),
+    .describe(
+      'App identifier (package name for Android, bundle ID for iOS). Takes precedence over name. Required for: activate, terminate, uninstall, is_installed, query_state, clear.'
+    ),
   name: z
     .string()
     .optional()
-    .describe('App name resolved to an ID; alternative to id.'),
-  path: z.string().optional().describe('App file path; required for install.'),
+    .describe(
+      'Human-readable app name (e.g. "Spotify"). Used to resolve the app id. Required (as alternative to id) for: activate, terminate, uninstall, is_installed, query_state, clear.'
+    ),
+  path: z
+    .string()
+    .optional()
+    .describe('Path to the app file to install. Required for: install.'),
   keepData: z
     .boolean()
     .optional()
-    .describe('Android uninstall: retain data/cache.'),
+    .describe(
+      'Keep app data and cache after uninstall. Android only. Used with: uninstall.'
+    ),
   applicationType: z
     .enum(['User', 'System'])
     .optional()
-    .describe('iOS list filter; default User.'),
+    .describe(
+      'iOS only: filter by "User" (default) or "System" apps. Used with: list.'
+    ),
   seconds: z
     .number()
     .min(-1)
     .max(86400)
     .optional()
     .describe(
-      `background seconds; default ${DEFAULT_BACKGROUND_SECONDS}; -1 stays backgrounded.`
+      `Seconds to keep the app in the background. Defaults to ${DEFAULT_BACKGROUND_SECONDS}. Use -1 to stay in background without auto-resuming. Used with: background.`
     ),
-  url: z.string().optional().describe('URL; required for deep_link.'),
+  url: z
+    .string()
+    .optional()
+    .describe(
+      'Deep link URL to open (e.g. https://example.com, myapp://path). Required for: deep_link.'
+    ),
   waitForLaunch: z
     .boolean()
     .optional()
-    .describe('Android deep_link: wait for launch; default true.'),
+    .describe(
+      'Android only. If false, ADB does not wait for the activity to return. Defaults to true. Used with: deep_link.'
+    ),
   sessionId: z
     .string()
     .optional()
@@ -74,7 +101,7 @@ const schema = z.object({
 export default function app(server: FastMCP): void {
   server.addTool({
     name: 'appium_app_lifecycle',
-    description: `Manage app lifecycle: ${APP_ACTIONS.join(', ')}.`,
+    description: `Manage apps on the device. Use the action parameter to choose what to do: ${APP_ACTIONS.join(', ')}.`,
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/app-management/permissions.ts
+++ b/src/tools/app-management/permissions.ts
@@ -17,53 +17,38 @@ export default function mobilePermissions(server: FastMCP): void {
     action: z
       .enum(['get', 'update', 'reset'])
       .describe(
-        'get: list (Android) or read one privacy state (iOS Simulator). ' +
-          'update: grant/revoke (Android) or set privacy map (iOS Simulator). ' +
-          'reset: restore a privacy prompt for the app under test (iOS only).'
+        'get reads; update changes; reset restores an iOS privacy prompt.'
       ),
     id: z
       .string()
       .optional()
       .describe(
-        'App identifier (package name for Android, bundle ID for iOS). Takes precedence over name. ' +
-          'Optional for Android (defaults to the app under test). Required for iOS get and update.'
+        'Package/bundle ID; preferred over name. iOS get/update requires id or name.'
       ),
     name: z
       .string()
       .optional()
-      .describe(
-        'Human-readable app name (e.g. "Spotify"). Used to resolve the app id. ' +
-          'Optional for Android (defaults to the app under test). Required (as alternative to id) for iOS get and update.'
-      ),
+      .describe('App name resolved to ID; alternative to id.'),
     sessionId: z
       .string()
       .optional()
-      .describe('Session ID to target. If omitted, uses the active session.'),
+      .describe('Target session; defaults to active.'),
     permissionFilter: z
       .enum(['denied', 'granted', 'requested'])
       .optional()
-      .describe(
-        'Android get only: which bucket to return. Defaults to requested per UiAutomator2.'
-      ),
+      .describe('Android get bucket; default requested.'),
     service: z
       .union([z.string(), z.number()])
       .optional()
-      .describe(
-        'iOS get: privacy service name (e.g. camera, microphone, photos). ' +
-          'iOS reset: service name or numeric XCUIProtectedResource id.'
-      ),
+      .describe('iOS privacy service; reset also accepts numeric resource ID.'),
     permissions: z
       .union([z.string(), z.array(z.string())])
       .optional()
-      .describe(
-        'Android update only: permission name(s), `all` (with pm target), or appops names. Required for Android update.'
-      ),
+      .describe('Android update permission(s), all, or appops names.'),
     permissionChangeAction: z
       .string()
       .optional()
-      .describe(
-        'Android update: for pm target grant (default) or revoke; for appops allow, deny, ignore, default.'
-      ),
+      .describe('Android update mode: pm grant/revoke or appops mode.'),
     target: z
       .enum(['pm', 'appops'])
       .optional()
@@ -71,15 +56,13 @@ export default function mobilePermissions(server: FastMCP): void {
     access: z
       .record(z.string(), iosPermissionStateSchema)
       .optional()
-      .describe(
-        'iOS update only: map of access rule → yes|no|unset|limited (Simulator + AppleSimulatorUtils). Required for iOS update.'
-      ),
+      .describe('iOS update access map; required on Simulator.'),
   });
 
   server.addTool({
     name: 'appium_mobile_permissions',
     description:
-      'Manage mobile app permissions in one place. action=get: Android lists runtime permissions for a package; iOS Simulator reads one service state for an app (needs id or name + service). action=update: Android changes permissions (grant/revoke or AppOps); iOS Simulator sets privacy via access map (needs id or name + access). action=reset: iOS only — resets one privacy service for the AUT (needs service).',
+      'Get/update Android permissions or iOS Simulator privacy; reset is iOS-only. See action fields for required platform inputs.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/app-management/permissions.ts
+++ b/src/tools/app-management/permissions.ts
@@ -17,7 +17,7 @@ export default function mobilePermissions(server: FastMCP): void {
     action: z
       .enum(['get', 'update', 'reset'])
       .describe(
-        'get reads; update changes; reset restores an iOS privacy prompt.'
+        'get: Android list or iOS service state; update: Android permissions or iOS access map; reset: restore an iOS service prompt.'
       ),
     id: z
       .string()
@@ -40,11 +40,15 @@ export default function mobilePermissions(server: FastMCP): void {
     service: z
       .union([z.string(), z.number()])
       .optional()
-      .describe('iOS privacy service; reset also accepts numeric resource ID.'),
+      .describe(
+        'Required for iOS get/reset; get needs a service name, reset also accepts a numeric resource ID.'
+      ),
     permissions: z
       .union([z.string(), z.array(z.string())])
       .optional()
-      .describe('Android update permission(s), all, or appops names.'),
+      .describe(
+        'Required for Android update: permission name(s), all, or appops names.'
+      ),
     permissionChangeAction: z
       .string()
       .optional()
@@ -56,7 +60,9 @@ export default function mobilePermissions(server: FastMCP): void {
     access: z
       .record(z.string(), iosPermissionStateSchema)
       .optional()
-      .describe('iOS update access map; required on Simulator.'),
+      .describe(
+        'Required for iOS update: service → yes|no|unset|limited map (Simulator).'
+      ),
   });
 
   server.addTool({

--- a/src/tools/app-management/permissions.ts
+++ b/src/tools/app-management/permissions.ts
@@ -17,18 +17,24 @@ export default function mobilePermissions(server: FastMCP): void {
     action: z
       .enum(['get', 'update', 'reset'])
       .describe(
-        'get: Android list or iOS service state; update: Android permissions or iOS access map; reset: restore an iOS service prompt.'
+        'get: list (Android) or read one privacy state (iOS Simulator). ' +
+          'update: grant/revoke (Android) or set privacy map (iOS Simulator). ' +
+          'reset: restore a privacy prompt for the app under test (iOS only).'
       ),
     id: z
       .string()
       .optional()
       .describe(
-        'Package/bundle ID; preferred over name. iOS get/update requires id or name.'
+        'App identifier (package name for Android, bundle ID for iOS). Takes precedence over name. ' +
+          'Optional for Android (defaults to the app under test). Required for iOS get and update.'
       ),
     name: z
       .string()
       .optional()
-      .describe('App name resolved to ID; alternative to id.'),
+      .describe(
+        'Human-readable app name (e.g. "Spotify"). Used to resolve the app id. ' +
+          'Optional for Android (defaults to the app under test). Required (as alternative to id) for iOS get and update.'
+      ),
     sessionId: z
       .string()
       .optional()
@@ -36,7 +42,9 @@ export default function mobilePermissions(server: FastMCP): void {
     permissionFilter: z
       .enum(['denied', 'granted', 'requested'])
       .optional()
-      .describe('Android get bucket; default requested.'),
+      .describe(
+        'Android get only: which bucket to return. Defaults to requested per UiAutomator2.'
+      ),
     service: z
       .union([z.string(), z.number()])
       .optional()
@@ -52,7 +60,9 @@ export default function mobilePermissions(server: FastMCP): void {
     permissionChangeAction: z
       .string()
       .optional()
-      .describe('Android update mode: pm grant/revoke or appops mode.'),
+      .describe(
+        'Android update: for pm target grant (default) or revoke; for appops allow, deny, ignore, default.'
+      ),
     target: z
       .enum(['pm', 'appops'])
       .optional()
@@ -68,7 +78,7 @@ export default function mobilePermissions(server: FastMCP): void {
   server.addTool({
     name: 'appium_mobile_permissions',
     description:
-      'Get/update Android permissions or iOS Simulator privacy; reset is iOS-only. See action fields for required platform inputs.',
+      'Manage mobile app permissions in one place. action=get: Android lists runtime permissions for a package; iOS Simulator reads one service state for an app (needs id or name + service). action=update: Android changes permissions (grant/revoke or AppOps); iOS Simulator sets privacy via access map (needs id or name + access). action=reset: iOS only — resets one privacy service for the AUT (needs service).',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -19,7 +19,9 @@ const contextSchema = z.object({
   context: z
     .string()
     .optional()
-    .describe('switch target, e.g. NATIVE_APP or WEBVIEW_<id>.'),
+    .describe(
+      'Required for switch, e.g. NATIVE_APP or WEBVIEW_<id>/<package>.'
+    ),
   sessionId: z
     .string()
     .optional()

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -15,26 +15,21 @@ import {
 } from '../tool-response.js';
 
 const contextSchema = z.object({
-  action: z
-    .enum(['list', 'switch'])
-    .describe('Use list to fetch contexts or switch to change context.'),
+  action: z.enum(['list', 'switch']).describe('list or switch.'),
   context: z
     .string()
     .optional()
-    .describe(
-      'Required when action is switch. Common values: NATIVE_APP or WEBVIEW_<id>/WEBVIEW_<package>.'
-    ),
+    .describe('switch target, e.g. NATIVE_APP or WEBVIEW_<id>.'),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 export default function context(server: FastMCP): void {
   server.addTool({
     name: 'appium_context',
-    description:
-      'Manage Appium contexts with one tool. action=list returns all contexts and current context. action=switch changes to a target context.',
+    description: 'List or switch Appium contexts.',
     parameters: contextSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -15,12 +15,14 @@ import {
 } from '../tool-response.js';
 
 const contextSchema = z.object({
-  action: z.enum(['list', 'switch']).describe('list or switch.'),
+  action: z
+    .enum(['list', 'switch'])
+    .describe('Use list to fetch contexts or switch to change context.'),
   context: z
     .string()
     .optional()
     .describe(
-      'Required for switch, e.g. NATIVE_APP or WEBVIEW_<id>/<package>.'
+      'Required when action is switch. Common values: NATIVE_APP or WEBVIEW_<id>/WEBVIEW_<package>.'
     ),
   sessionId: z
     .string()
@@ -31,7 +33,8 @@ const contextSchema = z.object({
 export default function context(server: FastMCP): void {
   server.addTool({
     name: 'appium_context',
-    description: 'List or switch Appium contexts.',
+    description:
+      'Manage Appium contexts with one tool. action=list returns all contexts and current context. action=switch changes to a target context.',
     parameters: contextSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/gestures/drag-and-drop.ts
+++ b/src/tools/gestures/drag-and-drop.ts
@@ -26,51 +26,63 @@ const dragAndDropSchema = z.object({
   sourceElementUUID: elementUUIDScheme
     .optional()
     .describe(
-      AI_UUID_HINT + 'Source element; otherwise provide sourceX + sourceY.'
+      AI_UUID_HINT +
+        'UUID of source element to drag from. Either sourceElementUUID or sourceX+sourceY must be provided.'
     ),
   sourceX: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe('Source X when no source element.'),
+    .describe(
+      'Source X coordinate. Required if sourceElementUUID is not provided.'
+    ),
   sourceY: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe('Source Y when no source element.'),
+    .describe(
+      'Source Y coordinate. Required if sourceElementUUID is not provided.'
+    ),
   targetElementUUID: elementUUIDScheme
     .optional()
     .describe(
-      AI_UUID_HINT + 'Target element; otherwise provide targetX + targetY.'
+      AI_UUID_HINT +
+        'UUID of target element to drop on. Either targetElementUUID or targetX+targetY must be provided.'
     ),
   targetX: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe('Target X when no target element.'),
+    .describe(
+      'Target X coordinate. Required if targetElementUUID is not provided.'
+    ),
   targetY: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe('Target Y when no target element.'),
+    .describe(
+      'Target Y coordinate. Required if targetElementUUID is not provided.'
+    ),
   duration: z
     .number()
     .int()
     .min(100)
     .max(5000)
     .optional()
-    .describe('Drag milliseconds; default 1200.'),
+    .describe('Duration of the drag movement in milliseconds. Default 1200.'),
   longPressDuration: z
     .number()
     .int()
     .min(400)
     .max(2000)
     .optional()
-    .describe('Pre-drag hold milliseconds; default 600.'),
+    .describe(
+      'Duration of the long press before dragging in milliseconds. Default 600.'
+    ),
   sessionId: z
     .string()
     .optional()
@@ -83,7 +95,10 @@ export default function dragAndDrop(server: FastMCP): void {
   server.addTool({
     name: 'appium_drag_and_drop',
     description:
-      'Drag between element IDs or coordinates; default hold 600ms and movement 1200ms.',
+      'Perform a drag-and-drop gesture from a source location to a target location. ' +
+      'The gesture: long press the source (default 600ms), drag to the target (default 1200ms), then release. ' +
+      'Source and target can each be specified as either an element UUID or coordinates. ' +
+      'Useful for reordering lists, moving items, drag-to-delete.',
     parameters: dragAndDropSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/gestures/drag-and-drop.ts
+++ b/src/tools/gestures/drag-and-drop.ts
@@ -26,67 +26,55 @@ const dragAndDropSchema = z.object({
   sourceElementUUID: elementUUIDScheme
     .optional()
     .describe(
-      AI_UUID_HINT +
-        `UUID of source element to drag from. Either sourceElementUUID or sourceX+sourceY must be provided.`
+      AI_UUID_HINT + 'Source element; otherwise provide sourceX + sourceY.'
     ),
   sourceX: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe(
-      'Source X coordinate. Required if sourceElementUUID is not provided.'
-    ),
+    .describe('Source X when no source element.'),
   sourceY: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe(
-      'Source Y coordinate. Required if sourceElementUUID is not provided.'
-    ),
+    .describe('Source Y when no source element.'),
   targetElementUUID: elementUUIDScheme
     .optional()
     .describe(
-      AI_UUID_HINT +
-        `UUID of target element to drop on. Either targetElementUUID or targetX+targetY must be provided.`
+      AI_UUID_HINT + 'Target element; otherwise provide targetX + targetY.'
     ),
   targetX: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe(
-      'Target X coordinate. Required if targetElementUUID is not provided.'
-    ),
+    .describe('Target X when no target element.'),
   targetY: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe(
-      'Target Y coordinate. Required if targetElementUUID is not provided.'
-    ),
+    .describe('Target Y when no target element.'),
   duration: z
     .number()
     .int()
     .min(100)
     .max(5000)
     .optional()
-    .describe('Duration of the drag movement in milliseconds. Default 1200.'),
+    .describe('Drag milliseconds; default 1200.'),
   longPressDuration: z
     .number()
     .int()
     .min(400)
     .max(2000)
     .optional()
-    .describe(
-      'Duration of the long press before dragging in milliseconds. Default 600.'
-    ),
+    .describe('Pre-drag hold milliseconds; default 600.'),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 type DragArgs = z.infer<typeof dragAndDropSchema>;
@@ -95,10 +83,7 @@ export default function dragAndDrop(server: FastMCP): void {
   server.addTool({
     name: 'appium_drag_and_drop',
     description:
-      'Perform a drag-and-drop gesture from a source location to a target location. ' +
-      'The gesture: long press the source (default 600ms), drag to the target (default 1200ms), then release. ' +
-      'Source and target can each be specified as either an element UUID or coordinates. ' +
-      'Useful for reordering lists, moving items, drag-to-delete.',
+      'Drag between element IDs or coordinates; default hold 600ms and movement 1200ms.',
     parameters: dragAndDropSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/gestures/gesture.ts
+++ b/src/tools/gestures/gesture.ts
@@ -28,10 +28,8 @@ export default function gesture(server: FastMCP): void {
   server.addTool({
     name: 'appium_gesture',
     description:
-      `Perform a touch gesture. Use 'action' to choose: ${GESTURE_ACTIONS.join(', ')}. ` +
-      `Choose scroll vs swipe by intent: scroll to browse content in a list or feed; ` +
-      `swipe to dismiss, switch screens, navigate carousels, or pull-to-refresh (speed=fast). ` +
-      `For drag-and-drop use appium_drag_and_drop. For custom multi-touch use appium_perform_actions.`,
+      `Touch gestures: ${GESTURE_ACTIONS.join(', ')}. ` +
+      'Use scroll to browse, swipe to navigate/dismiss, appium_drag_and_drop to drag, and appium_perform_actions for custom multi-touch.',
     parameters: gestureSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/gestures/gesture.ts
+++ b/src/tools/gestures/gesture.ts
@@ -28,8 +28,10 @@ export default function gesture(server: FastMCP): void {
   server.addTool({
     name: 'appium_gesture',
     description:
-      `Touch gestures: ${GESTURE_ACTIONS.join(', ')}. ` +
-      'Use scroll to browse, swipe to navigate/dismiss, appium_drag_and_drop to drag, and appium_perform_actions for custom multi-touch.',
+      `Perform a touch gesture. Use 'action' to choose: ${GESTURE_ACTIONS.join(', ')}. ` +
+      'Choose scroll vs swipe by intent: scroll to browse content in a list or feed; ' +
+      'swipe to dismiss, switch screens, navigate carousels, or pull-to-refresh (speed=fast). ' +
+      'For drag-and-drop use appium_drag_and_drop. For custom multi-touch use appium_perform_actions.',
     parameters: gestureSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/gestures/perform-actions.ts
+++ b/src/tools/gestures/perform-actions.ts
@@ -25,7 +25,7 @@ const actionStepSchema = z.object({
     .int()
     .min(0)
     .optional()
-    .describe('Duration in milliseconds. Required for pause and pointerMove.'),
+    .describe('Milliseconds; required for pause/pointerMove.'),
   x: z.number().int().optional().describe('X coordinate (pointerMove only).'),
   y: z.number().int().optional().describe('Y coordinate (pointerMove only).'),
   button: z
@@ -37,30 +37,20 @@ const actionStepSchema = z.object({
   origin: z
     .string()
     .optional()
-    .describe(
-      'Coordinate origin: "viewport" (default) or "pointer" (relative to current position).'
-    ),
+    .describe('Origin: viewport (default) or pointer-relative.'),
 });
 
 const inputSourceSchema = z.object({
   type: z
     .enum(['pointer', 'key', 'none'])
-    .describe(
-      'Input source type. pointer = touch/mouse, key = keyboard, none = pause/timing.'
-    ),
-  id: z
-    .string()
-    .describe(
-      'Unique identifier for this input source (e.g. "finger1", "finger2").'
-    ),
+    .describe('Source: pointer, key, or none (timing).'),
+  id: z.string().describe('Unique source ID, e.g. finger1.'),
   parameters: z
     .object({
       pointerType: z
         .enum(['touch', 'mouse', 'pen'])
         .optional()
-        .describe(
-          'Pointer type. Use "touch" for mobile gestures. Only for type=pointer.'
-        ),
+        .describe('Pointer source kind; use touch for mobile.'),
     })
     .optional(),
   actions: z
@@ -73,24 +63,19 @@ const performActionsSchema = z.object({
     .array(inputSourceSchema)
     .min(1)
     .describe(
-      `W3C Actions API input source array. Each entry is one input source (pointer/key/none) with its action sequence. ` +
-        `Multiple pointer sources enable multi-touch gestures (e.g. two-finger rotate, three-finger swipe). ` +
-        `All sources execute in parallel, synchronized tick-by-tick.`
+      'W3C input sources. Multiple sources run in parallel, synchronized by action index.'
     ),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 export default function performActionsTool(server: FastMCP): void {
   server.addTool({
     name: 'appium_perform_actions',
     description:
-      `Execute raw W3C Actions API sequences for advanced multi-touch gestures not covered by appium_gesture. ` +
-      `Use this for custom multi-finger gestures (rotate, three-finger swipe, edge swipes), complex timing sequences, ` +
-      `or any gesture requiring precise control over individual touch points. ` +
-      `Prefer appium_gesture for standard gestures (tap, scroll, swipe, pinch) — it handles platform differences automatically.`,
+      'Raw W3C Actions for precise/custom multi-touch. Prefer appium_gesture for standard gestures.',
     parameters: performActionsSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/gestures/perform-actions.ts
+++ b/src/tools/gestures/perform-actions.ts
@@ -25,7 +25,7 @@ const actionStepSchema = z.object({
     .int()
     .min(0)
     .optional()
-    .describe('Milliseconds; required for pause/pointerMove.'),
+    .describe('Duration in milliseconds. Required for pause and pointerMove.'),
   x: z.number().int().optional().describe('X coordinate (pointerMove only).'),
   y: z.number().int().optional().describe('Y coordinate (pointerMove only).'),
   button: z
@@ -37,20 +37,30 @@ const actionStepSchema = z.object({
   origin: z
     .string()
     .optional()
-    .describe('Origin: viewport (default) or pointer-relative.'),
+    .describe(
+      'Coordinate origin: "viewport" (default) or "pointer" (relative to current position).'
+    ),
 });
 
 const inputSourceSchema = z.object({
   type: z
     .enum(['pointer', 'key', 'none'])
-    .describe('Source: pointer, key, or none (timing).'),
-  id: z.string().describe('Unique source ID, e.g. finger1.'),
+    .describe(
+      'Input source type. pointer = touch/mouse, key = keyboard, none = pause/timing.'
+    ),
+  id: z
+    .string()
+    .describe(
+      'Unique identifier for this input source (e.g. "finger1", "finger2").'
+    ),
   parameters: z
     .object({
       pointerType: z
         .enum(['touch', 'mouse', 'pen'])
         .optional()
-        .describe('Pointer source kind; use touch for mobile.'),
+        .describe(
+          'Pointer type. Use "touch" for mobile gestures. Only for type=pointer.'
+        ),
     })
     .optional(),
   actions: z
@@ -63,7 +73,9 @@ const performActionsSchema = z.object({
     .array(inputSourceSchema)
     .min(1)
     .describe(
-      'W3C input sources. Multiple sources run in parallel, synchronized by action index.'
+      'W3C Actions API input source array. Each entry is one input source (pointer/key/none) with its action sequence. ' +
+        'Multiple pointer sources enable multi-touch gestures (e.g. two-finger rotate, three-finger swipe). ' +
+        'All sources execute in parallel, synchronized tick-by-tick.'
     ),
   sessionId: z
     .string()
@@ -75,7 +87,10 @@ export default function performActionsTool(server: FastMCP): void {
   server.addTool({
     name: 'appium_perform_actions',
     description:
-      'Raw W3C Actions for precise/custom multi-touch. Prefer appium_gesture for standard gestures.',
+      'Execute raw W3C Actions API sequences for advanced multi-touch gestures not covered by appium_gesture. ' +
+      'Use this for custom multi-finger gestures (rotate, three-finger swipe, edge swipes), complex timing sequences, ' +
+      'or any gesture requiring precise control over individual touch points. ' +
+      'Prefer appium_gesture for standard gestures (tap, scroll, swipe, pinch) — it handles platform differences automatically.',
     parameters: performActionsSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/gestures/schema.ts
+++ b/src/tools/gestures/schema.ts
@@ -84,7 +84,9 @@ export const gestureSchema = z.object({
   direction: z
     .enum(['up', 'down', 'left', 'right'])
     .optional()
-    .describe('scroll/swipe direction; alternative to x, y, endX, endY.'),
+    .describe(
+      'scroll/swipe direction; alternative to coordinates. scroll_to_element uses up/down, default down.'
+    ),
 
   speed: z
     .enum(SWIPE_SPEEDS)

--- a/src/tools/gestures/schema.ts
+++ b/src/tools/gestures/schema.ts
@@ -41,26 +41,15 @@ export const gestureSchema = z.object({
   action: z
     .enum(GESTURE_ACTIONS)
     .describe(
-      `Gesture to perform. ` +
-        `tap: tap an element or a coordinate. ` +
-        `double_tap: trigger a double-tap action (e.g. zoom in on an image, favorite a post). ` +
-        `long_press: press and hold to open a context menu or initiate drag. ` +
-        `scroll: browse a list, feed, or page to reveal content. ` +
-        `swipe: dismiss a card, switch screens or tabs, navigate a carousel, or pull-to-refresh (use speed=fast). ` +
-        `pinch_zoom: zoom in (scale > 1) or out (scale < 1) on maps, images, or any zoomable view. ` +
-        `scroll_to_element: scroll until a specific element is on screen (strategy + selector + direction up|down). ` +
-        `Stops when the element is found, page source is unchanged after a scroll (end of scrollable content), or maxScrollAttempts is reached. ` +
-        `Optional scrollDistance (0.05–1) or scrollDistancePreset (small|medium|large). ` +
-        `back: triggers the system back navigation (e.g., Android back button or iOS navigation controller pop).`
+      'Gesture action. scroll browses content; swipe navigates or dismisses. ' +
+        'scroll_to_element requires strategy + selector and stops on match, unchanged page, or maxScrollAttempts.'
     ),
 
   elementUUID: elementUUIDScheme
     .optional()
     .describe(
-      `UUID of the element to act on. ` +
-        AI_UUID_HINT +
-        `Used by: tap, double_tap, long_press, pinch_zoom. ` +
-        `For scroll/swipe, when provided with direction, the gesture is calculated relative to this element instead of the whole screen.`
+      AI_UUID_HINT +
+        'Target for tap/double_tap/long_press/pinch_zoom; scopes directional scroll/swipe when set.'
     ),
 
   x: z
@@ -69,10 +58,7 @@ export const gestureSchema = z.object({
     .min(0)
     .optional()
     .describe(
-      `X coordinate. ` +
-        `For tap/double_tap/long_press: tap location (alternative to elementUUID). ` +
-        `For scroll/swipe: starting X for custom-coordinate mode (requires y, endX, endY). ` +
-        `For pinch_zoom: center X of the pinch. Requires y. Ignored if elementUUID is set.`
+      'Tap/start/pinch-center X. Custom scroll/swipe also requires y, endX, endY.'
     ),
   y: z
     .number()
@@ -80,41 +66,31 @@ export const gestureSchema = z.object({
     .min(0)
     .optional()
     .describe(
-      `Y coordinate. ` +
-        `For tap/double_tap/long_press: tap location. ` +
-        `For scroll/swipe: starting Y for custom-coordinate mode. ` +
-        `For pinch_zoom: center Y of the pinch. Requires x. Ignored if elementUUID is set.`
+      'Tap/start/pinch-center Y. Custom scroll/swipe also requires x, endX, endY.'
     ),
   endX: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe(
-      `Ending X coordinate. Used by: scroll, swipe (custom-coordinate mode).`
-    ),
+    .describe('End X for custom scroll/swipe.'),
   endY: z
     .number()
     .int()
     .min(0)
     .optional()
-    .describe(
-      `Ending Y coordinate. Used by: scroll, swipe (custom-coordinate mode).`
-    ),
+    .describe('End Y for custom scroll/swipe.'),
 
   direction: z
     .enum(['up', 'down', 'left', 'right'])
     .optional()
-    .describe(
-      `Direction for scroll or swipe. Coordinates are auto-calculated from screen or element bounds. ` +
-        `Either direction OR custom coordinates (x, y, endX, endY) must be provided for these actions.`
-    ),
+    .describe('scroll/swipe direction; alternative to x, y, endX, endY.'),
 
   speed: z
     .enum(SWIPE_SPEEDS)
     .optional()
     .describe(
-      `Swipe speed. slow = deliberate drag; normal = default navigation speed; fast = flick with no hold, use for pull-to-refresh and other velocity-sensitive UIs. Used by: swipe.`
+      'swipe speed; fast is a flick for pull-to-refresh or velocity-sensitive UI.'
     ),
 
   duration: z
@@ -124,8 +100,7 @@ export const gestureSchema = z.object({
     .max(10000)
     .optional()
     .describe(
-      `Duration in milliseconds. long_press default 2000 (range 500-10000). scroll default 800. ` +
-        `For swipe, prefer the speed parameter; duration overrides it if both are provided.`
+      'Milliseconds. long_press default 2000; scroll default 800; overrides swipe speed.'
     ),
 
   scale: z
@@ -134,29 +109,25 @@ export const gestureSchema = z.object({
     .max(10)
     .optional()
     .describe(
-      `Pinch scale factor. < 1 = zoom out (pinch close), > 1 = zoom in (pinch open). Example: 0.5 = zoom out 50%, 2.0 = zoom in 2x. Required for: pinch_zoom.`
+      'pinch_zoom scale: below 1 zooms out, above 1 zooms in. Required.'
     ),
   velocity: z
     .number()
     .min(0.1)
     .max(20)
     .optional()
-    .describe(
-      `Pinch velocity in scale factor per second. Default 2.2. Used by: pinch_zoom.`
-    ),
+    .describe('pinch_zoom scale/second; default 2.2.'),
 
   strategy: z
     .enum(LOCATOR_STRATEGIES)
     .optional()
     .describe(
-      `Locator strategy. Required for: scroll_to_element. ` +
-        `Priority: accessibility id > id > platform-native (-ios predicate string / -ios class chain on iOS, -android uiautomator on Android) > xpath (LAST RESORT — slow on iOS XCUITest, brittle) > name > class name > css selector (webview only). ` +
-        `Same ranking as appium_find_element.`
+      'scroll_to_element locator. Prefer accessibility id/id, then platform-native; xpath last.'
     ),
   selector: z
     .string()
     .optional()
-    .describe(`Locator selector value. Required for: scroll_to_element.`),
+    .describe('scroll_to_element selector. Required.'),
 
   maxScrollAttempts: z
     .number()
@@ -165,9 +136,7 @@ export const gestureSchema = z.object({
     .max(80)
     .optional()
     .default(10)
-    .describe(
-      `scroll_to_element only: maximum scroll attempts after the element is not yet visible (default 10).`
-    ),
+    .describe('scroll_to_element attempt limit; default 10.'),
 
   scrollDistance: z
     .number()
@@ -175,22 +144,20 @@ export const gestureSchema = z.object({
     .max(1)
     .optional()
     .describe(
-      `scroll_to_element only: vertical swipe length as a fraction 0.05–1 (same scale as legacy scroll). ` +
-        `Ignored when scrollDistancePreset is set. Default 0.45 if neither preset nor scrollDistance is set.`
+      'scroll_to_element distance 0.05–1; default 0.45; preset overrides.'
     ),
 
   scrollDistancePreset: z
     .enum(SCROLL_DISTANCE_PRESETS)
     .optional()
     .describe(
-      `scroll_to_element only: convenience preset — small ≈ light nudge (0.25), medium ≈ 0.45, large = full default swipe (1). ` +
-        `When set, overrides scrollDistance.`
+      'scroll_to_element preset: small=.25, medium=.45, large=1; overrides distance.'
     ),
 
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 export type GestureArgs = z.infer<typeof gestureSchema>;

--- a/src/tools/gestures/schema.ts
+++ b/src/tools/gestures/schema.ts
@@ -41,15 +41,26 @@ export const gestureSchema = z.object({
   action: z
     .enum(GESTURE_ACTIONS)
     .describe(
-      'Gesture action. scroll browses content; swipe navigates or dismisses. ' +
-        'scroll_to_element requires strategy + selector and stops on match, unchanged page, or maxScrollAttempts.'
+      'Gesture to perform. ' +
+        'tap: tap an element or a coordinate. ' +
+        'double_tap: trigger a double-tap action (e.g. zoom in on an image, favorite a post). ' +
+        'long_press: press and hold to open a context menu or initiate drag. ' +
+        'scroll: browse a list, feed, or page to reveal content. ' +
+        'swipe: dismiss a card, switch screens or tabs, navigate a carousel, or pull-to-refresh (use speed=fast). ' +
+        'pinch_zoom: zoom in (scale > 1) or out (scale < 1) on maps, images, or any zoomable view. ' +
+        'scroll_to_element: scroll until a specific element is on screen (strategy + selector + direction up|down). ' +
+        'Stops when the element is found, page source is unchanged after a scroll (end of scrollable content), or maxScrollAttempts is reached. ' +
+        'Optional scrollDistance (0.05–1) or scrollDistancePreset (small|medium|large). ' +
+        'back: triggers the system back navigation (e.g., Android back button or iOS navigation controller pop).'
     ),
 
   elementUUID: elementUUIDScheme
     .optional()
     .describe(
-      AI_UUID_HINT +
-        'Target for tap/double_tap/long_press/pinch_zoom; scopes directional scroll/swipe when set.'
+      'UUID of the element to act on. ' +
+        AI_UUID_HINT +
+        'Used by: tap, double_tap, long_press, pinch_zoom. ' +
+        'For scroll/swipe, when provided with direction, the gesture is calculated relative to this element instead of the whole screen.'
     ),
 
   x: z

--- a/src/tools/interactions/clipboard.ts
+++ b/src/tools/interactions/clipboard.ts
@@ -9,21 +9,12 @@ import {
 } from '../tool-response.js';
 
 const schema = z.object({
-  action: z
-    .enum(['get', 'set'])
-    .describe(
-      'get: read device clipboard as plain text. set: write plain text to the clipboard.'
-    ),
-  content: z
-    .string()
-    .optional()
-    .describe(
-      'Required when action is set. Plain text to put on the clipboard.'
-    ),
+  action: z.enum(['get', 'set']).describe('get reads; set requires content.'),
+  content: z.string().optional().describe('Text required for set.'),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 type ClipboardArgs = z.infer<typeof schema>;
@@ -31,9 +22,7 @@ type ClipboardArgs = z.infer<typeof schema>;
 export default function clipboard(server: FastMCP): void {
   server.addTool({
     name: 'appium_mobile_clipboard',
-    description:
-      'Read or set the device clipboard as plain text (Android UiAutomator2 / iOS XCUITest). ' +
-      'action=get returns current text; action=set requires content.',
+    description: 'Read/set device clipboard text.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/clipboard.ts
+++ b/src/tools/interactions/clipboard.ts
@@ -9,8 +9,17 @@ import {
 } from '../tool-response.js';
 
 const schema = z.object({
-  action: z.enum(['get', 'set']).describe('get reads; set requires content.'),
-  content: z.string().optional().describe('Text required for set.'),
+  action: z
+    .enum(['get', 'set'])
+    .describe(
+      'get: read device clipboard as plain text. set: write plain text to the clipboard.'
+    ),
+  content: z
+    .string()
+    .optional()
+    .describe(
+      'Required when action is set. Plain text to put on the clipboard.'
+    ),
   sessionId: z
     .string()
     .optional()
@@ -22,7 +31,9 @@ type ClipboardArgs = z.infer<typeof schema>;
 export default function clipboard(server: FastMCP): void {
   server.addTool({
     name: 'appium_mobile_clipboard',
-    description: 'Read/set device clipboard text.',
+    description:
+      'Read or set the device clipboard as plain text (Android UiAutomator2 / iOS XCUITest). ' +
+      'action=get returns current text; action=set requires content.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -24,43 +24,27 @@ export const findElementSchema = z.object({
       'css selector',
     ])
     .describe(
-      `Locator strategy. Try in priority order: ` +
-        `(1) accessibility id [cross-platform, fastest, most stable], ` +
-        `(2) id [Android resource-id; iOS aliases accessibility id], ` +
-        `(3) -ios predicate string [iOS native, fast], ` +
-        `(4) -ios class chain [iOS native, hierarchy queries], ` +
-        `(5) -android uiautomator [Android native, expressive UiSelector], ` +
-        `(6) xpath [LAST RESORT — slow on iOS XCUITest, brittle to layout changes], ` +
-        `(7) name [legacy; often aliased on iOS], ` +
-        `(8) class name [too generic, usually multi-match], ` +
-        `(9) css selector [webview/hybrid contexts only]. ` +
-        `Platform tips: iOS prefer (1)→(3)→(4); Android prefer (1)→(2)→(5); xpath last on both. ` +
-        `For natural-language / vision-based find, use the appium_ai tool (action=find_element), not this one.`
+      'Prefer accessibility id (cross-platform, fastest, stable), then id. ' +
+        'iOS: prefer -ios predicate/class chain; Android: prefer -android uiautomator. ' +
+        'Use xpath last. CSS is webview-only; appium_ai handles natural language/vision.'
     ),
   selector: z
     .string()
     .describe(
-      `Selector string for the chosen strategy. ` +
-        `Do not pass natural-language descriptions of the target here; use appium_ai (action=find_element) for that.`
+      'Selector for strategy; not natural language (use appium_ai for that).'
     ),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 export default function findElement(server: FastMCP): void {
   server.addTool({
     name: 'appium_find_element',
-    description: `Find a specific element by strategy and selector which will return a uuid that can be used for interactions.
-
-[PRIORITY 2: Use this to search for a target element.]
-
-**Strategy priority**: accessibility id > id > platform-native (\`-ios predicate string\` / \`-ios class chain\` on iOS, \`-android uiautomator\` on Android) > xpath (last resort — slow & brittle). See the \`strategy\` parameter for the full ranking.
-
-**Scrolling until an element appears**: use \`appium_gesture\` with \`action=scroll_to_element\` (same strategy + selector), not this tool.
-
-**Vision / natural-language find**: use \`appium_ai\` with \`action=find_element\`, not this tool.`,
+    description:
+      'Find one element by strategy and selector; return its interaction UUID. ' +
+      'Prefer accessibility id over id before xpath, which is a last resort. Use appium_gesture scroll_to_element off-screen and appium_ai find_element for vision/natural language.',
     parameters: findElementSchema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/interactions/find.ts
+++ b/src/tools/interactions/find.ts
@@ -24,14 +24,14 @@ export const findElementSchema = z.object({
       'css selector',
     ])
     .describe(
-      'Prefer accessibility id (cross-platform, fastest, stable), then id. ' +
-        'iOS: prefer -ios predicate/class chain; Android: prefer -android uiautomator. ' +
-        'Use xpath last. CSS is webview-only; appium_ai handles natural language/vision.'
+      'Priority: (1) accessibility id (cross-platform, fastest, stable), (2) id, ' +
+        '(3) iOS: prefer -ios predicate/class chain; Android: prefer -android uiautomator, (4) xpath LAST RESORT (slow/brittle). ' +
+        'name/class are fallbacks; CSS is webview-only. Use appium_ai action=find_element for natural language/vision.'
     ),
   selector: z
     .string()
     .describe(
-      'Selector for strategy; not natural language (use appium_ai for that).'
+      'Selector string for the chosen strategy. Do not pass natural-language descriptions; use appium_ai action=find_element.'
     ),
   sessionId: z
     .string()
@@ -44,7 +44,8 @@ export default function findElement(server: FastMCP): void {
     name: 'appium_find_element',
     description:
       'Find one element by strategy and selector; return its interaction UUID. ' +
-      'Prefer accessibility id over id before xpath, which is a last resort. Use appium_gesture scroll_to_element off-screen and appium_ai find_element for vision/natural language.',
+      'Prefer accessibility id over id before xpath, which is a last resort. ' +
+      'This tool does not scroll: use appium_gesture scroll_to_element for off-screen targets. Use appium_ai find_element for vision/natural-language targets.',
     parameters: findElementSchema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/interactions/get-element-attribute.ts
+++ b/src/tools/interactions/get-element-attribute.ts
@@ -16,7 +16,7 @@ export default function getElementAttributeTool(server: FastMCP): void {
     attribute: z
       .string()
       .describe(
-        'Attribute name, e.g. enabled, displayed, text, value, label, resource-id.'
+        'The attribute name to retrieve. Common attributes: "enabled", "selected", "displayed", "checked", "focused", "clickable", "scrollable", "focusable", "name", "value", "label", "text", "content-desc", "resource-id", "class", "package".'
       ),
     sessionId: z
       .string()
@@ -26,7 +26,8 @@ export default function getElementAttributeTool(server: FastMCP): void {
 
   server.addTool({
     name: 'appium_get_element_attribute',
-    description: 'Read an element state/property attribute.',
+    description:
+      'Get the value of an element attribute. Use this to check element state (enabled, selected, checked, focused, displayed, clickable) or read properties (name, value, label, content-desc, resource-id, class).',
     parameters: schema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/interactions/get-element-attribute.ts
+++ b/src/tools/interactions/get-element-attribute.ts
@@ -16,18 +16,17 @@ export default function getElementAttributeTool(server: FastMCP): void {
     attribute: z
       .string()
       .describe(
-        'The attribute name to retrieve. Common attributes: "enabled", "selected", "displayed", "checked", "focused", "clickable", "scrollable", "focusable", "name", "value", "label", "text", "content-desc", "resource-id", "class", "package".'
+        'Attribute name, e.g. enabled, displayed, text, value, label, resource-id.'
       ),
     sessionId: z
       .string()
       .optional()
-      .describe('Session ID to target. If omitted, uses the active session.'),
+      .describe('Target session; defaults to active.'),
   });
 
   server.addTool({
     name: 'appium_get_element_attribute',
-    description:
-      'Get the value of an element attribute. Use this to check element state (enabled, selected, checked, focused, displayed, clickable) or read properties (name, value, label, content-desc, resource-id, class).',
+    description: 'Read an element state/property attribute.',
     parameters: schema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/interactions/keyboard.ts
+++ b/src/tools/interactions/keyboard.ts
@@ -11,21 +11,15 @@ import {
 const schema = z.object({
   action: z
     .enum(['hide', 'is_shown'])
-    .describe(
-      'hide: dismiss the software keyboard (mobile: hideKeyboard). ' +
-        'is_shown: whether the keyboard is visible (mobile: isKeyboardShown).'
-    ),
+    .describe('hide dismisses; is_shown checks visibility.'),
   keys: z
     .array(z.string())
     .optional()
-    .describe(
-      'hide only: optional key names to dismiss the keyboard (e.g. "done"). ' +
-        'Forwarded to mobile: hideKeyboard when non-empty. Ignored for is_shown.'
-    ),
+    .describe('hide-only optional dismissal key names.'),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 type KeyboardArgs = z.infer<typeof schema>;
@@ -33,9 +27,7 @@ type KeyboardArgs = z.infer<typeof schema>;
 export default function keyboard(server: FastMCP): void {
   server.addTool({
     name: 'appium_mobile_keyboard',
-    description:
-      'Hide the software keyboard or check if it is visible (Android UiAutomator2 / iOS XCUITest). ' +
-      'action=hide uses mobile: hideKeyboard; action=is_shown uses mobile: isKeyboardShown.',
+    description: 'Hide the software keyboard or query visibility.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/keyboard.ts
+++ b/src/tools/interactions/keyboard.ts
@@ -11,11 +11,17 @@ import {
 const schema = z.object({
   action: z
     .enum(['hide', 'is_shown'])
-    .describe('hide dismisses; is_shown checks visibility.'),
+    .describe(
+      'hide: dismiss the software keyboard (mobile: hideKeyboard). ' +
+        'is_shown: whether the keyboard is visible (mobile: isKeyboardShown).'
+    ),
   keys: z
     .array(z.string())
     .optional()
-    .describe('hide-only optional dismissal key names.'),
+    .describe(
+      'hide only: optional key names to dismiss the keyboard (e.g. "done"). ' +
+        'Forwarded to mobile: hideKeyboard when non-empty. Ignored for is_shown.'
+    ),
   sessionId: z
     .string()
     .optional()
@@ -27,7 +33,9 @@ type KeyboardArgs = z.infer<typeof schema>;
 export default function keyboard(server: FastMCP): void {
   server.addTool({
     name: 'appium_mobile_keyboard',
-    description: 'Hide the software keyboard or query visibility.',
+    description:
+      'Hide the software keyboard or check if it is visible (Android UiAutomator2 / iOS XCUITest). ' +
+      'action=hide uses mobile: hideKeyboard; action=is_shown uses mobile: isKeyboardShown.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/press-key.ts
+++ b/src/tools/interactions/press-key.ts
@@ -44,7 +44,7 @@ export default function pressKey(server: FastMCP): void {
       sessionId: z
         .string()
         .optional()
-        .describe('Session ID to target. If omitted, uses the active session.'),
+        .describe('Target session; defaults to active.'),
       key: z
         .enum([
           'BACK',
@@ -61,22 +61,16 @@ export default function pressKey(server: FastMCP): void {
           'SELECT',
         ])
         .optional()
-        .describe(
-          `Logical key/button to press. On Android: ${ANDROID_KEYS_DESCRIPTION}. On iOS/tvOS: ${IOS_BUTTONS_DESCRIPTION}.`
-        ),
+        .describe('Logical button; availability differs by platform.'),
       keyCode: z
         .number()
         .int()
         .optional()
-        .describe(
-          'Android keycode to press. If provided, takes precedence over key for Android.'
-        ),
+        .describe('Android keycode; overrides key.'),
       isLongPress: z
         .boolean()
         .optional()
-        .describe(
-          'Android only. Whether to perform a long press. Defaults to false.'
-        ),
+        .describe('Android long press; default false.'),
     })
     .refine((value) => value.key !== undefined || value.keyCode !== undefined, {
       message: 'Either key or keyCode must be provided',
@@ -85,8 +79,7 @@ export default function pressKey(server: FastMCP): void {
 
   server.addTool({
     name: 'appium_mobile_press_key',
-    description:
-      'Press navigation keys (BACK, HOME, APP_SWITCH) on Android or physical buttons (HOME, volume, etc.) on iOS/tvOS.',
+    description: 'Press Android navigation keys or iOS/tvOS physical buttons.',
     parameters: pressKeySchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/press-key.ts
+++ b/src/tools/interactions/press-key.ts
@@ -61,7 +61,9 @@ export default function pressKey(server: FastMCP): void {
           'SELECT',
         ])
         .optional()
-        .describe('Logical button; availability differs by platform.'),
+        .describe(
+          `Android keys: ${ANDROID_KEYS_DESCRIPTION}. iOS/tvOS buttons: ${IOS_BUTTONS_DESCRIPTION}.`
+        ),
       keyCode: z
         .number()
         .int()

--- a/src/tools/interactions/press-key.ts
+++ b/src/tools/interactions/press-key.ts
@@ -62,17 +62,21 @@ export default function pressKey(server: FastMCP): void {
         ])
         .optional()
         .describe(
-          `Android keys: ${ANDROID_KEYS_DESCRIPTION}. iOS/tvOS buttons: ${IOS_BUTTONS_DESCRIPTION}.`
+          `Logical key/button to press. On Android: ${ANDROID_KEYS_DESCRIPTION}. On iOS/tvOS: ${IOS_BUTTONS_DESCRIPTION}.`
         ),
       keyCode: z
         .number()
         .int()
         .optional()
-        .describe('Android keycode; overrides key.'),
+        .describe(
+          'Android keycode to press. If provided, takes precedence over key for Android.'
+        ),
       isLongPress: z
         .boolean()
         .optional()
-        .describe('Android long press; default false.'),
+        .describe(
+          'Android only. Whether to perform a long press. Defaults to false.'
+        ),
     })
     .refine((value) => value.key !== undefined || value.keyCode !== undefined, {
       message: 'Either key or keyCode must be provided',
@@ -81,7 +85,8 @@ export default function pressKey(server: FastMCP): void {
 
   server.addTool({
     name: 'appium_mobile_press_key',
-    description: 'Press Android navigation keys or iOS/tvOS physical buttons.',
+    description:
+      'Press navigation keys (BACK, HOME, APP_SWITCH) on Android or physical buttons (HOME, volume, etc.) on iOS/tvOS.',
     parameters: pressKeySchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/screen-recording.ts
+++ b/src/tools/interactions/screen-recording.ts
@@ -70,77 +70,54 @@ async function saveRecording(base64Video: string): Promise<string> {
 const screenRecordingSchema = z.object({
   action: z
     .enum(['start', 'stop'])
-    .describe(
-      'Use start to begin recording. Use stop to end the current recording, retrieve it from the driver, and save it to disk.'
-    ),
+    .describe('start begins; stop retrieves and saves the recording.'),
   timeLimit: z
     .number()
     .int()
     .min(1)
     .optional()
     .describe(
-      'Maximum recording duration in seconds for the underlying recorder. This does not automatically stop and save the recording through this tool; call action="stop" to retrieve/save the video. iOS default: 180 (max 4200). Android default: 180 (max 1800).'
+      'Recorder limit seconds; stop still retrieves it. Default 180; max iOS 4200/Android 1800.'
     ),
   forceRestart: z
     .boolean()
     .optional()
-    .describe(
-      'If true, stop any active recording immediately and start a new one without returning the previous video. Default: false.'
-    ),
+    .describe('start: discard active recording; default false.'),
   videoQuality: z
     .enum(['low', 'medium', 'high', 'photo'])
     .optional()
-    .describe('iOS only. Video quality preset. Default: medium.'),
+    .describe('iOS quality; default medium.'),
   videoFps: z
     .number()
     .int()
     .min(1)
     .max(60)
     .optional()
-    .describe('iOS only. Frames per second. Default: 10.'),
-  videoType: z
-    .string()
-    .optional()
-    .describe('iOS only. Video codec to use (e.g. libx264).'),
+    .describe('iOS FPS; default 10.'),
+  videoType: z.string().optional().describe('iOS codec, e.g. libx264.'),
   videoFilters: z
     .string()
     .optional()
-    .describe(
-      'iOS only. FFMPEG video filters. Takes precedence over videoScale.'
-    ),
-  videoScale: z
-    .string()
-    .optional()
-    .describe('iOS only. Scaling value (e.g. 1280:720).'),
+    .describe('iOS FFMPEG filters; overrides videoScale.'),
+  videoScale: z.string().optional().describe('iOS scale, e.g. 1280:720.'),
   pixelFormat: z
     .string()
     .optional()
-    .describe('iOS only. Output pixel format (e.g. yuv420p).'),
+    .describe('iOS pixel format, e.g. yuv420p.'),
   hardwareAcceleration: z
     .enum(['videoToolbox', 'cuda', 'amf_dx11', 'qsv', 'vaapi'])
     .optional()
-    .describe('iOS only. FFMPEG hardware acceleration backend.'),
-  videoSize: z
-    .string()
-    .optional()
-    .describe(
-      'Android only. Frame size in WIDTHxHEIGHT format (e.g. 1280x720).'
-    ),
-  bitRate: z
-    .number()
-    .int()
-    .optional()
-    .describe('Android only. Video bit rate in bits per second.'),
+    .describe('iOS FFMPEG hardware acceleration.'),
+  videoSize: z.string().optional().describe('Android WIDTHxHEIGHT.'),
+  bitRate: z.number().int().optional().describe('Android bits/second.'),
   bugReport: z
     .boolean()
     .optional()
-    .describe(
-      'Android only. Display timestamp overlay. Requires API level 27+.'
-    ),
+    .describe('Android timestamp overlay; API 27+.'),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 export default function screenRecording(server: FastMCP): void {

--- a/src/tools/interactions/screen-recording.ts
+++ b/src/tools/interactions/screen-recording.ts
@@ -70,50 +70,73 @@ async function saveRecording(base64Video: string): Promise<string> {
 const screenRecordingSchema = z.object({
   action: z
     .enum(['start', 'stop'])
-    .describe('start begins; stop retrieves and saves the recording.'),
+    .describe(
+      'Use start to begin recording. Use stop to end the current recording, retrieve it from the driver, and save it to disk.'
+    ),
   timeLimit: z
     .number()
     .int()
     .min(1)
     .optional()
     .describe(
-      'Recorder limit seconds; stop still retrieves it. Default 180; max iOS 4200/Android 1800.'
+      'Maximum recording duration in seconds for the underlying recorder. This does not automatically stop and save the recording through this tool; call action="stop" to retrieve/save the video. iOS default: 180 (max 4200). Android default: 180 (max 1800).'
     ),
   forceRestart: z
     .boolean()
     .optional()
-    .describe('start: discard active recording; default false.'),
+    .describe(
+      'If true, stop any active recording immediately and start a new one without returning the previous video. Default: false.'
+    ),
   videoQuality: z
     .enum(['low', 'medium', 'high', 'photo'])
     .optional()
-    .describe('iOS quality; default medium.'),
+    .describe('iOS only. Video quality preset. Default: medium.'),
   videoFps: z
     .number()
     .int()
     .min(1)
     .max(60)
     .optional()
-    .describe('iOS FPS; default 10.'),
-  videoType: z.string().optional().describe('iOS codec, e.g. libx264.'),
+    .describe('iOS only. Frames per second. Default: 10.'),
+  videoType: z
+    .string()
+    .optional()
+    .describe('iOS only. Video codec to use (e.g. libx264).'),
   videoFilters: z
     .string()
     .optional()
-    .describe('iOS FFMPEG filters; overrides videoScale.'),
-  videoScale: z.string().optional().describe('iOS scale, e.g. 1280:720.'),
+    .describe(
+      'iOS only. FFMPEG video filters. Takes precedence over videoScale.'
+    ),
+  videoScale: z
+    .string()
+    .optional()
+    .describe('iOS only. Scaling value (e.g. 1280:720).'),
   pixelFormat: z
     .string()
     .optional()
-    .describe('iOS pixel format, e.g. yuv420p.'),
+    .describe('iOS only. Output pixel format (e.g. yuv420p).'),
   hardwareAcceleration: z
     .enum(['videoToolbox', 'cuda', 'amf_dx11', 'qsv', 'vaapi'])
     .optional()
-    .describe('iOS FFMPEG hardware acceleration.'),
-  videoSize: z.string().optional().describe('Android WIDTHxHEIGHT.'),
-  bitRate: z.number().int().optional().describe('Android bits/second.'),
+    .describe('iOS only. FFMPEG hardware acceleration backend.'),
+  videoSize: z
+    .string()
+    .optional()
+    .describe(
+      'Android only. Frame size in WIDTHxHEIGHT format (e.g. 1280x720).'
+    ),
+  bitRate: z
+    .number()
+    .int()
+    .optional()
+    .describe('Android only. Video bit rate in bits per second.'),
   bugReport: z
     .boolean()
     .optional()
-    .describe('Android timestamp overlay; API 27+.'),
+    .describe(
+      'Android only. Display timestamp overlay. Requires API level 27+.'
+    ),
   sessionId: z
     .string()
     .optional()

--- a/src/tools/interactions/screenshot.ts
+++ b/src/tools/interactions/screenshot.ts
@@ -127,16 +127,24 @@ export async function executeScreenshot(opts: {
 const screenshotSchema = z.object({
   elementUUID: elementUUIDScheme
     .optional()
-    .describe('Element-only capture; omit for full screen.'),
+    .describe(
+      'Optional element UUID. If provided, captures only this element. If omitted, captures full screen.'
+    ),
   maxWidth: z
     .number()
     .optional()
-    .describe('Resize to this max width, preserving aspect ratio.'),
+    .describe(
+      'Optional maximum width in pixels to resize the screenshot. The aspect ratio is preserved. Useful for reducing token usage when sending screenshots to LLMs.'
+    ),
   returnRawBase64: z
     .boolean()
     .default(false)
     .describe(
-      'Manual use only: return PNG inline instead of saving. LLMs must keep false and use the saved path.'
+      'When true, returns the raw base64-encoded PNG image instead of saving it to disk. ' +
+        'This should only be enabled when a human explicitly invokes the tool manually, ' +
+        'typically to view the screenshot on a different machine (e.g. when the server runs ' +
+        'on a remote machine and the saved file is not accessible). ' +
+        'An LLM must always keep this false and rely on the saved file path.'
     ),
   sessionId: z
     .string()
@@ -147,7 +155,8 @@ const screenshotSchema = z.object({
 export default function screenshot(server: FastMCP): void {
   server.addTool({
     name: 'appium_screenshot',
-    description: 'Save a full-screen or element PNG.',
+    description:
+      'Take a screenshot and save as PNG. Optionally provide elementUUID to capture only that element.',
     parameters: screenshotSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/screenshot.ts
+++ b/src/tools/interactions/screenshot.ts
@@ -127,36 +127,27 @@ export async function executeScreenshot(opts: {
 const screenshotSchema = z.object({
   elementUUID: elementUUIDScheme
     .optional()
-    .describe(
-      'Optional element UUID. If provided, captures only this element. If omitted, captures full screen.'
-    ),
+    .describe('Element-only capture; omit for full screen.'),
   maxWidth: z
     .number()
     .optional()
-    .describe(
-      'Optional maximum width in pixels to resize the screenshot. The aspect ratio is preserved. Useful for reducing token usage when sending screenshots to LLMs.'
-    ),
+    .describe('Resize to this max width, preserving aspect ratio.'),
   returnRawBase64: z
     .boolean()
     .default(false)
     .describe(
-      'When true, returns the raw base64-encoded PNG image instead of saving it to disk. ' +
-        'This should only be enabled when a human explicitly invokes the tool manually, ' +
-        'typically to view the screenshot on a different machine (e.g. when the server runs ' +
-        'on a remote machine and the saved file is not accessible). ' +
-        'An LLM must always keep this false and rely on the saved file path.'
+      'Manual use only: return PNG inline instead of saving. LLMs must keep false and use the saved path.'
     ),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 export default function screenshot(server: FastMCP): void {
   server.addTool({
     name: 'appium_screenshot',
-    description:
-      'Take a screenshot and save as PNG. Optionally provide elementUUID to capture only that element.',
+    description: 'Save a full-screen or element PNG.',
     parameters: screenshotSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/set-value.ts
+++ b/src/tools/interactions/set-value.ts
@@ -15,19 +15,17 @@ export default function setValue(server: FastMCP): void {
   const setValueSchema = z
     .object({
       elementUUID: elementUUIDScheme.optional(),
-      text: z.string().describe('The text to enter'),
+      text: z.string().describe('Text to enter.'),
       w3cActions: z
         .boolean()
         .optional()
         .describe(
-          'When true, type text via the W3C Actions API (performActions) instead of ' +
-            'the driver-specific setValue. No elementUUID needed — key events are sent ' +
-            'to whatever element currently has focus. Works on both Android and iOS.'
+          'Type into the focused element via W3C Actions; no elementUUID required.'
         ),
       sessionId: z
         .string()
         .optional()
-        .describe('Session ID to target. If omitted, uses the active session.'),
+        .describe('Target session; defaults to active.'),
     })
     .refine((v) => v.w3cActions === true || v.elementUUID !== undefined, {
       message: 'elementUUID is required when w3cActions is not true',

--- a/src/tools/interactions/set-value.ts
+++ b/src/tools/interactions/set-value.ts
@@ -15,12 +15,14 @@ export default function setValue(server: FastMCP): void {
   const setValueSchema = z
     .object({
       elementUUID: elementUUIDScheme.optional(),
-      text: z.string().describe('Text to enter.'),
+      text: z.string().describe('The text to enter'),
       w3cActions: z
         .boolean()
         .optional()
         .describe(
-          'Type into the focused element via W3C Actions; no elementUUID required.'
+          'When true, type text via the W3C Actions API (performActions) instead of ' +
+            'the driver-specific setValue. No elementUUID needed — key events are sent ' +
+            'to whatever element currently has focus. Works on both Android and iOS.'
         ),
       sessionId: z
         .string()

--- a/src/tools/ios/prepare-ios-real-device.ts
+++ b/src/tools/ios/prepare-ios-real-device.ts
@@ -444,37 +444,24 @@ async function runPipeline(
 // ── Tool registration ──
 
 const prepareRealDeviceSchema = z.object({
-  udid: z
-    .string()
-    .describe(
-      'UDID of the connected iOS real device. Use select_device to discover it.'
-    ),
+  udid: z.string().describe('Real-device UDID from select_device.'),
   provisioningProfileUuid: z
     .string()
     .optional()
     .describe(
-      'UUID of the .mobileprovision profile to sign WDA with. If omitted, the tool returns the list of available profiles so you can ask the user to pick one.'
+      'Signing profile UUID; omit to list profiles for user selection.'
     ),
   forceRebuild: z
     .boolean()
     .optional()
-    .describe(
-      'If true, ignore the cached WDA download and unsigned IPA and start clean. The signed IPA is always rebuilt regardless. Default: false.'
-    ),
+    .describe('Ignore cached WDA/IPA inputs; signed IPA is always rebuilt.'),
 });
 
 export default function prepareIosRealDevice(server: FastMCP): void {
   server.addTool({
     name: 'appium_prepare_ios_real_device',
     description:
-      'Prepare an iOS real device for Appium testing in a single call. Two-mode flow: ' +
-      '(1) Call without provisioningProfileUuid to receive the list of available .mobileprovision profiles — ' +
-      'present them to the user (highlight any with recommendedForWda=true) and ask them to pick one. ' +
-      '(2) Call again with the chosen UUID to download the matching WebDriverAgent release, package it as an IPA, ' +
-      'and resign it with the chosen profile (wildcard "*" profiles are supported — a concrete WDA bundle ID is substituted at sign time). ' +
-      'WDA download and unsigned IPA are cached per WDA version; the signed IPA is rebuilt every call. ' +
-      'Pass the returned capabilitiesHint to appium_session_management (action=create) so Appium installs and launches the signed prebuilt WDA instead of rebuilding. ' +
-      'Requires macOS, Xcode 16+, and a paired developer-mode device.',
+      'Prepare WDA for an iOS real device (macOS/Xcode 16+). First omit provisioningProfileUuid to list profiles; ask the user to choose, preferring recommendedForWda. Then pass the UUID to sign WDA. Pass capabilitiesHint to appium_session_management create.',
     parameters: prepareRealDeviceSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/ios/prepare-ios-real-device.ts
+++ b/src/tools/ios/prepare-ios-real-device.ts
@@ -444,24 +444,37 @@ async function runPipeline(
 // ── Tool registration ──
 
 const prepareRealDeviceSchema = z.object({
-  udid: z.string().describe('Real-device UDID from select_device.'),
+  udid: z
+    .string()
+    .describe(
+      'UDID of the connected iOS real device. Use select_device to discover it.'
+    ),
   provisioningProfileUuid: z
     .string()
     .optional()
     .describe(
-      'Signing profile UUID; omit to list profiles for user selection.'
+      'UUID of the .mobileprovision profile to sign WDA with. If omitted, the tool returns the list of available profiles so you can ask the user to pick one.'
     ),
   forceRebuild: z
     .boolean()
     .optional()
-    .describe('Ignore cached WDA/IPA inputs; signed IPA is always rebuilt.'),
+    .describe(
+      'If true, ignore the cached WDA download and unsigned IPA and start clean. The signed IPA is always rebuilt regardless. Default: false.'
+    ),
 });
 
 export default function prepareIosRealDevice(server: FastMCP): void {
   server.addTool({
     name: 'appium_prepare_ios_real_device',
     description:
-      'Prepare WDA for an iOS real device (macOS/Xcode 16+). First omit provisioningProfileUuid to list profiles; ask the user to choose, preferring recommendedForWda. Then pass the UUID to sign WDA. Pass capabilitiesHint to appium_session_management create.',
+      'Prepare an iOS real device for Appium testing in a single call. Two-mode flow: ' +
+      '(1) Call without provisioningProfileUuid to receive the list of available .mobileprovision profiles — ' +
+      'present them to the user (highlight any with recommendedForWda=true) and ask them to pick one. ' +
+      '(2) Call again with the chosen UUID to download the matching WebDriverAgent release, package it as an IPA, ' +
+      'and resign it with the chosen profile (wildcard "*" profiles are supported — a concrete WDA bundle ID is substituted at sign time). ' +
+      'WDA download and unsigned IPA are cached per WDA version; the signed IPA is rebuilt every call. ' +
+      'Pass the returned capabilitiesHint to appium_session_management (action=create) so Appium installs and launches the signed prebuilt WDA instead of rebuilding. ' +
+      'Requires macOS, Xcode 16+, and a paired developer-mode device.',
     parameters: prepareRealDeviceSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/ios/prepare-ios-simulator.ts
+++ b/src/tools/ios/prepare-ios-simulator.ts
@@ -486,21 +486,37 @@ async function prepareSimulator(
 // ── Tool registration ──
 
 const prepareIosSimulatorSchema = z.object({
-  udid: z.string().describe('Simulator UDID from select_device.'),
+  udid: z
+    .string()
+    .describe(
+      'The UDID of the iOS simulator to prepare. Use select_device to get this.'
+    ),
   platform: z
     .enum(['ios', 'tvos'])
     .optional()
     .default('ios')
-    .describe('WDA platform; default ios.'),
-  skipWda: z.boolean().optional().describe('Boot only; skip WDA.'),
-  forceRefreshWda: z.boolean().optional().describe('Redownload cached WDA.'),
+    .describe(
+      'The simulator platform to download WDA for. Default is "ios". Use "tvos" for Apple TV simulators.'
+    ),
+  skipWda: z
+    .boolean()
+    .optional()
+    .describe(
+      'If true, only boot the simulator without downloading or installing WDA. Default: false.'
+    ),
+  forceRefreshWda: z
+    .boolean()
+    .optional()
+    .describe(
+      'If true, re-download WDA even if already cached. Default: false.'
+    ),
 });
 
 export default function prepareIosSimulator(server: FastMCP): void {
   server.addTool({
     name: 'prepare_ios_simulator',
     description:
-      'Boot an iOS/tvOS simulator and optionally install/launch cached WDA on a free port. Pass capabilitiesHint to appium_session_management create to reuse WDA. skipWda boots only; APPIUM_MCP_WDA_APP_PATH supplies local WDA.',
+      'Prepare an iOS/tvOS simulator for Appium testing in a single call. Automatically boots the simulator, downloads prebuilt WDA (if not cached), and installs/launches WDA on a free per-simulator port (so multiple simulators can run in parallel without colliding on the default 8100). Pass the returned capabilitiesHint (appium:webDriverAgentUrl) to appium_session_management (action=create) so the session reuses this running WDA instead of trying to start its own. Use skipWda=true to only boot without WDA. Set APPIUM_MCP_WDA_APP_PATH to an absolute path to a pre-extracted WebDriverAgentRunner-Runner.app to skip download entirely (useful in environments where external downloads are blocked).',
     parameters: prepareIosSimulatorSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/ios/prepare-ios-simulator.ts
+++ b/src/tools/ios/prepare-ios-simulator.ts
@@ -486,37 +486,21 @@ async function prepareSimulator(
 // ── Tool registration ──
 
 const prepareIosSimulatorSchema = z.object({
-  udid: z
-    .string()
-    .describe(
-      'The UDID of the iOS simulator to prepare. Use select_device to get this.'
-    ),
+  udid: z.string().describe('Simulator UDID from select_device.'),
   platform: z
     .enum(['ios', 'tvos'])
     .optional()
     .default('ios')
-    .describe(
-      'The simulator platform to download WDA for. Default is "ios". Use "tvos" for Apple TV simulators.'
-    ),
-  skipWda: z
-    .boolean()
-    .optional()
-    .describe(
-      'If true, only boot the simulator without downloading or installing WDA. Default: false.'
-    ),
-  forceRefreshWda: z
-    .boolean()
-    .optional()
-    .describe(
-      'If true, re-download WDA even if already cached. Default: false.'
-    ),
+    .describe('WDA platform; default ios.'),
+  skipWda: z.boolean().optional().describe('Boot only; skip WDA.'),
+  forceRefreshWda: z.boolean().optional().describe('Redownload cached WDA.'),
 });
 
 export default function prepareIosSimulator(server: FastMCP): void {
   server.addTool({
     name: 'prepare_ios_simulator',
     description:
-      'Prepare an iOS/tvOS simulator for Appium testing in a single call. Automatically boots the simulator, downloads prebuilt WDA (if not cached), and installs/launches WDA on a free per-simulator port (so multiple simulators can run in parallel without colliding on the default 8100). Pass the returned capabilitiesHint (appium:webDriverAgentUrl) to appium_session_management (action=create) so the session reuses this running WDA instead of trying to start its own. Use skipWda=true to only boot without WDA. Set APPIUM_MCP_WDA_APP_PATH to an absolute path to a pre-extracted WebDriverAgentRunner-Runner.app to skip download entirely (useful in environments where external downloads are blocked).',
+      'Boot an iOS/tvOS simulator and optionally install/launch cached WDA on a free port. Pass capabilitiesHint to session create. skipWda boots only; APPIUM_MCP_WDA_APP_PATH supplies local WDA.',
     parameters: prepareIosSimulatorSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/ios/prepare-ios-simulator.ts
+++ b/src/tools/ios/prepare-ios-simulator.ts
@@ -500,7 +500,7 @@ export default function prepareIosSimulator(server: FastMCP): void {
   server.addTool({
     name: 'prepare_ios_simulator',
     description:
-      'Boot an iOS/tvOS simulator and optionally install/launch cached WDA on a free port. Pass capabilitiesHint to session create. skipWda boots only; APPIUM_MCP_WDA_APP_PATH supplies local WDA.',
+      'Boot an iOS/tvOS simulator and optionally install/launch cached WDA on a free port. Pass capabilitiesHint to appium_session_management create to reuse WDA. skipWda boots only; APPIUM_MCP_WDA_APP_PATH supplies local WDA.',
     parameters: prepareIosSimulatorSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/device-control.ts
+++ b/src/tools/session/device-control.ts
@@ -22,7 +22,11 @@ const deviceControlSchema = z.object({
   action: z
     .enum(['lock', 'unlock', 'shake', 'open_notifications'])
     .describe(
-      'lock/unlock; shake is iOS-only; open_notifications is Android-only.'
+      'Action to perform. ' +
+        'lock: lock the device (optional seconds for timed lock). ' +
+        'unlock: unlock the device. ' +
+        'shake: perform shake gesture (iOS only). ' +
+        'open_notifications: open notifications panel (Android only).'
     ),
   sessionId: z
     .string()
@@ -33,13 +37,16 @@ const deviceControlSchema = z.object({
     .int()
     .min(1)
     .optional()
-    .describe('Timed lock seconds; omit to remain locked.'),
+    .describe(
+      'Only for action=lock: lock duration in seconds before auto-unlock. Omit to remain locked until unlock.'
+    ),
 });
 
 export default function mobileDeviceControl(server: FastMCP): void {
   server.addTool({
     name: 'appium_mobile_device_control',
-    description: 'Lock/unlock, shake, or open notifications.',
+    description:
+      'Control device behavior: lock/unlock the screen, shake the device, or open the notifications panel. Use the action parameter to choose what to do.',
     parameters: deviceControlSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/device-control.ts
+++ b/src/tools/session/device-control.ts
@@ -22,31 +22,24 @@ const deviceControlSchema = z.object({
   action: z
     .enum(['lock', 'unlock', 'shake', 'open_notifications'])
     .describe(
-      'Action to perform. ' +
-        'lock: lock the device (optional seconds for timed lock). ' +
-        'unlock: unlock the device. ' +
-        'shake: perform shake gesture (iOS only). ' +
-        'open_notifications: open notifications panel (Android only).'
+      'lock/unlock; shake is iOS-only; open_notifications is Android-only.'
     ),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
   seconds: z
     .number()
     .int()
     .min(1)
     .optional()
-    .describe(
-      'Only for action=lock: lock duration in seconds before auto-unlock. Omit to remain locked until unlock.'
-    ),
+    .describe('Timed lock seconds; omit to remain locked.'),
 });
 
 export default function mobileDeviceControl(server: FastMCP): void {
   server.addTool({
     name: 'appium_mobile_device_control',
-    description:
-      'Control device behavior: lock/unlock the screen, shake the device, or open the notifications panel. Use the action parameter to choose what to do.',
+    description: 'Lock/unlock, shake, or open notifications.',
     parameters: deviceControlSchema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/device-info.ts
+++ b/src/tools/session/device-info.ts
@@ -31,25 +31,20 @@ export default function deviceInfo(server: FastMCP): void {
   const schema = z.object({
     action: z
       .enum(['info', 'battery', 'time'])
-      .describe(
-        'Action to perform: "info" returns device model/OS/locale/etc., "battery" returns battery level and charging state, "time" returns the current device time.'
-      ),
+      .describe('info, battery, or device time.'),
     format: z
       .string()
       .optional()
-      .describe(
-        'Only used when action is "time". moment.js format string for the returned time. Defaults to ISO 8601 (YYYY-MM-DDTHH:mm:ssZ).'
-      ),
+      .describe('time-only moment.js format; default ISO 8601.'),
     sessionId: z
       .string()
       .optional()
-      .describe('Session ID to target. If omitted, uses the active session.'),
+      .describe('Target session; defaults to active.'),
   });
 
   server.addTool({
     name: 'appium_mobile_device_info',
-    description:
-      'Get device information, battery status, or current device time in a single call. Use the "action" parameter to select which data to retrieve. Works on both iOS and Android.',
+    description: 'Read device metadata, battery, or time on iOS/Android.',
     parameters: schema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/session/device-info.ts
+++ b/src/tools/session/device-info.ts
@@ -31,11 +31,15 @@ export default function deviceInfo(server: FastMCP): void {
   const schema = z.object({
     action: z
       .enum(['info', 'battery', 'time'])
-      .describe('info, battery, or device time.'),
+      .describe(
+        'Action to perform: "info" returns device model/OS/locale/etc., "battery" returns battery level and charging state, "time" returns the current device time.'
+      ),
     format: z
       .string()
       .optional()
-      .describe('time-only moment.js format; default ISO 8601.'),
+      .describe(
+        'Only used when action is "time". moment.js format string for the returned time. Defaults to ISO 8601 (YYYY-MM-DDTHH:mm:ssZ).'
+      ),
     sessionId: z
       .string()
       .optional()
@@ -44,7 +48,8 @@ export default function deviceInfo(server: FastMCP): void {
 
   server.addTool({
     name: 'appium_mobile_device_info',
-    description: 'Read device metadata, battery, or time on iOS/Android.',
+    description:
+      'Get device information, battery status, or current device time in a single call. Use the "action" parameter to select which data to retrieve. Works on both iOS and Android.',
     parameters: schema,
     annotations: {
       readOnlyHint: true,

--- a/src/tools/session/driver-settings.ts
+++ b/src/tools/session/driver-settings.ts
@@ -14,11 +14,18 @@ import {
 const schema = z.object({
   action: z
     .enum(['get', 'update'])
-    .describe('get reads; update requires settings and merges them.'),
+    .describe(
+      'get: read current Appium driver session settings (timeouts, selector waits, flags). ' +
+        'update: merge a settings map into the session (requires settings).'
+    ),
   settings: z
     .record(z.string(), z.any())
     .optional()
-    .describe('Driver-specific settings map; inspect with get first.'),
+    .describe(
+      'Required when action is update. Driver-specific keys (e.g. Android UiAutomator2: ' +
+        'waitForIdleTimeout, waitForSelectorTimeout, ignoreUnimportantViews; iOS XCUITest has its own set). ' +
+        'Use action=get first to inspect current values.'
+    ),
   sessionId: z
     .string()
     .optional()
@@ -31,7 +38,9 @@ export default function driverSettings(server: FastMCP): void {
   server.addTool({
     name: 'appium_driver_settings',
     description:
-      'Get or update Appium driver settings for embedded or supporting remote sessions.',
+      'Read or update Appium driver session settings (e.g. idle timeouts, selector waits). ' +
+      'Use action=get to return JSON settings; action=update merges a map into the session. ' +
+      'Works for embedded UiAutomator2/XCUITest sessions and remote WebDriver clients that support Appium settings.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/driver-settings.ts
+++ b/src/tools/session/driver-settings.ts
@@ -14,22 +14,15 @@ import {
 const schema = z.object({
   action: z
     .enum(['get', 'update'])
-    .describe(
-      'get: read current Appium driver session settings (timeouts, selector waits, flags). ' +
-        'update: merge a settings map into the session (requires settings).'
-    ),
+    .describe('get reads; update requires settings and merges them.'),
   settings: z
     .record(z.string(), z.any())
     .optional()
-    .describe(
-      'Required when action is update. Driver-specific keys (e.g. Android UiAutomator2: ' +
-        'waitForIdleTimeout, waitForSelectorTimeout, ignoreUnimportantViews; iOS XCUITest has its own set). ' +
-        'Use action=get first to inspect current values.'
-    ),
+    .describe('Driver-specific settings map; inspect with get first.'),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 type DriverSettingsArgs = z.infer<typeof schema>;
@@ -38,9 +31,7 @@ export default function driverSettings(server: FastMCP): void {
   server.addTool({
     name: 'appium_driver_settings',
     description:
-      'Read or update Appium driver session settings (e.g. idle timeouts, selector waits). ' +
-      'Use action=get to return JSON settings; action=update merges a map into the session. ' +
-      'Works for embedded UiAutomator2/XCUITest sessions and remote WebDriver clients that support Appium settings.',
+      'Get or update Appium driver settings for embedded or supporting remote sessions.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/file-transfer.ts
+++ b/src/tools/session/file-transfer.ts
@@ -29,18 +29,21 @@ function normalizePullResult(result: unknown): string {
 }
 
 const remotePathDescription =
-  'Device path: absolute Android path (e.g. /sdcard/Download/a.txt) or XCUITest form (e.g. @com.example.app:documents/a.txt).';
+  'Path to the file on the device. ' +
+  'Android (UiAutomator2): use an absolute path (e.g. /data/local/tmp/foo.txt or /sdcard/Download/foo.txt). ' +
+  'iOS (XCUITest): use the formats described in the Appium XCUITest file transfer guide ' +
+  '(e.g. @com.example.app:documents/file.txt or simulator-relative paths).';
 
 export default function fileTransfer(server: FastMCP): void {
   const schema = z.object({
     action: z
       .enum(['push', 'pull'])
-      .describe('push uploads; pull returns base64.'),
+      .describe('push uploads a file to device; pull downloads from device.'),
     remotePath: z.string().min(1).describe(remotePathDescription),
     payloadBase64: z
       .string()
       .optional()
-      .describe('Base64 payload required for push.'),
+      .describe('Required when action=push. Ignored when action=pull.'),
     sessionId: z
       .string()
       .optional()
@@ -49,7 +52,8 @@ export default function fileTransfer(server: FastMCP): void {
 
   server.addTool({
     name: 'appium_mobile_file',
-    description: 'Push/pull device files; pull returns contentBase64.',
+    description:
+      'Push or pull a file using Appium mobile extensions. action=push uses payloadBase64, action=pull returns contentBase64.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/file-transfer.ts
+++ b/src/tools/session/file-transfer.ts
@@ -29,31 +29,27 @@ function normalizePullResult(result: unknown): string {
 }
 
 const remotePathDescription =
-  'Path to the file on the device. ' +
-  'Android (UiAutomator2): use an absolute path (e.g. /data/local/tmp/foo.txt or /sdcard/Download/foo.txt). ' +
-  'iOS (XCUITest): use the formats described in the Appium XCUITest file transfer guide ' +
-  '(e.g. @com.example.app:documents/file.txt or simulator-relative paths).';
+  'Device path: absolute Android path or XCUITest container/simulator path.';
 
 export default function fileTransfer(server: FastMCP): void {
   const schema = z.object({
     action: z
       .enum(['push', 'pull'])
-      .describe('push uploads a file to device; pull downloads from device.'),
+      .describe('push uploads; pull returns base64.'),
     remotePath: z.string().min(1).describe(remotePathDescription),
     payloadBase64: z
       .string()
       .optional()
-      .describe('Required when action=push. Ignored when action=pull.'),
+      .describe('Base64 payload required for push.'),
     sessionId: z
       .string()
       .optional()
-      .describe('Session ID to target. If omitted, uses the active session.'),
+      .describe('Target session; defaults to active.'),
   });
 
   server.addTool({
     name: 'appium_mobile_file',
-    description:
-      'Push or pull a file using Appium mobile extensions. action=push uses payloadBase64, action=pull returns contentBase64.',
+    description: 'Push/pull device files; pull returns contentBase64.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/file-transfer.ts
+++ b/src/tools/session/file-transfer.ts
@@ -29,7 +29,7 @@ function normalizePullResult(result: unknown): string {
 }
 
 const remotePathDescription =
-  'Device path: absolute Android path or XCUITest container/simulator path.';
+  'Device path: absolute Android path (e.g. /sdcard/Download/a.txt) or XCUITest form (e.g. @com.example.app:documents/a.txt).';
 
 export default function fileTransfer(server: FastMCP): void {
   const schema = z.object({

--- a/src/tools/session/geolocation.ts
+++ b/src/tools/session/geolocation.ts
@@ -13,20 +13,27 @@ const schema = z.object({
   action: z
     .enum(['get', 'set', 'reset'])
     .describe(
-      'get reads; set requires latitude + longitude; reset is unsupported on Android emulators.'
+      'Action to perform. ' +
+        'get: read the current device geolocation. ' +
+        'set: set the device geolocation (requires latitude and longitude; optional altitude for Android). ' +
+        'reset: reset the geolocation to the default/system value. Not supported on Android emulators — use action=set instead.'
     ),
   latitude: z.coerce
     .number()
     .min(-90)
     .max(90)
     .optional()
-    .describe('Latitude -90..90; required for set.'),
+    .describe(
+      'Latitude value (-90 to 90). Measurement of distance north or south of the Equator. Required for: set.'
+    ),
   longitude: z.coerce
     .number()
     .min(-180)
     .max(180)
     .optional()
-    .describe('Longitude -180..180; required for set.'),
+    .describe(
+      'Longitude value (-180 to 180). Measurement of distance east or west of the prime meridian. Required for: set.'
+    ),
   altitude: z.coerce
     .number()
     .optional()
@@ -34,7 +41,9 @@ const schema = z.object({
       (v) => v === undefined || !isNaN(v),
       'altitude must be a valid number'
     )
-    .describe('Android set altitude meters; default 0.'),
+    .describe(
+      'Altitude value in meters. Android only, defaults to 0. Ignored on iOS. Used with: set.'
+    ),
   sessionId: z
     .string()
     .optional()
@@ -47,7 +56,7 @@ export default function geolocation(server: FastMCP): void {
   server.addTool({
     name: 'appium_geolocation',
     description:
-      'Get/set/reset device GPS on iOS and Android. Android emulators cannot reset; set coordinates instead.',
+      'Get, set, or reset the device geolocation (GPS coordinates). Works on both iOS (simulators and real devices) and Android (emulators and real devices with mock location enabled). Use action=get to read current coordinates, action=set with latitude/longitude (and optional altitude for Android) to simulate a location, or action=reset to restore the system default. Note: On Android emulators, reset is not supported — use action=set to manually restore coordinates instead. On Android real devices, the mocked location may persist until the GPS cache refreshes.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/geolocation.ts
+++ b/src/tools/session/geolocation.ts
@@ -13,27 +13,20 @@ const schema = z.object({
   action: z
     .enum(['get', 'set', 'reset'])
     .describe(
-      'Action to perform. ' +
-        'get: read the current device geolocation. ' +
-        'set: set the device geolocation (requires latitude and longitude; optional altitude for Android). ' +
-        'reset: reset the geolocation to the default/system value. Not supported on Android emulators — use action=set instead.'
+      'get reads; set requires latitude + longitude; reset is unsupported on Android emulators.'
     ),
   latitude: z.coerce
     .number()
     .min(-90)
     .max(90)
     .optional()
-    .describe(
-      'Latitude value (-90 to 90). Measurement of distance north or south of the Equator. Required for: set.'
-    ),
+    .describe('Latitude -90..90; required for set.'),
   longitude: z.coerce
     .number()
     .min(-180)
     .max(180)
     .optional()
-    .describe(
-      'Longitude value (-180 to 180). Measurement of distance east or west of the prime meridian. Required for: set.'
-    ),
+    .describe('Longitude -180..180; required for set.'),
   altitude: z.coerce
     .number()
     .optional()
@@ -41,13 +34,11 @@ const schema = z.object({
       (v) => v === undefined || !isNaN(v),
       'altitude must be a valid number'
     )
-    .describe(
-      'Altitude value in meters. Android only, defaults to 0. Ignored on iOS. Used with: set.'
-    ),
+    .describe('Android set altitude meters; default 0.'),
   sessionId: z
     .string()
     .optional()
-    .describe('Session ID to target. If omitted, uses the active session.'),
+    .describe('Target session; defaults to active.'),
 });
 
 type GeolocationArgs = z.infer<typeof schema>;
@@ -56,7 +47,7 @@ export default function geolocation(server: FastMCP): void {
   server.addTool({
     name: 'appium_geolocation',
     description:
-      'Get, set, or reset the device geolocation (GPS coordinates). Works on both iOS (simulators and real devices) and Android (emulators and real devices with mock location enabled). Use action=get to read current coordinates, action=set with latitude/longitude (and optional altitude for Android) to simulate a location, or action=reset to restore the system default. Note: On Android emulators, reset is not supported — use action=set to manually restore coordinates instead. On Android real devices, the mocked location may persist until the GPS cache refreshes.',
+      'Get/set/reset device GPS on iOS and Android. Android emulators cannot reset; set coordinates instead.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -83,7 +83,8 @@ export default function selectDevice(server: any): void {
     description:
       'LOCAL servers ONLY; NEVER use for REMOTE/remoteServerUrl. ASK THE USER Android or iOS—do not assume. ' +
       'Call without deviceUdid to list: one result auto-selects; for multiple results ask the user, then call again with the chosen deviceUdid. ' +
-      'For iOS require iosDeviceType and run prepare_ios_simulator before appium_session_management create. ' +
+      'For iOS require iosDeviceType. After selection run prepare_ios_simulator for a simulator or appium_prepare_ios_real_device for a real device, ' +
+      'then pass its full capabilitiesHint to appium_session_management create. ' +
       'Remote devices are selected through session capabilities.',
     parameters: z
       .object({
@@ -292,14 +293,18 @@ function selectIOSDevice(
  */
 function formatIOSSelectionResponse(
   deviceName: string,
-  deviceUdid: string
+  deviceUdid: string,
+  iosDeviceType: 'simulator' | 'real'
 ): ContentResult {
+  const prepareTool =
+    iosDeviceType === 'simulator'
+      ? 'prepare_ios_simulator'
+      : 'appium_prepare_ios_real_device';
   return textResult(
     JSON.stringify(
       {
         message: `✅ Device selected: ${deviceName} (${deviceUdid})`,
-        instructions:
-          '🚀 You can now call the prepare_ios_simulator tool to boot and setup WDA on the simulator or the appium_prepare_ios_real_device tool to setup WDA on ios real device.',
+        instructions: `🚀 Next call ${prepareTool}, then JSON-serialize its full capabilitiesHint as capabilities for appium_session_management with action=create.`,
         platform: 'ios',
         capabilities: {
           'appium:udid': deviceUdid,
@@ -400,7 +405,11 @@ async function handleIOSDeviceSelection(
     if (!selected.ok) {
       return selected.result;
     }
-    return formatIOSSelectionResponse(selected.device.info.name, deviceUdid);
+    return formatIOSSelectionResponse(
+      selected.device.info.name,
+      deviceUdid,
+      iosDeviceType!
+    );
   }
 
   // Auto-select when only one device is available
@@ -411,7 +420,8 @@ async function handleIOSDeviceSelection(
     }
     return formatIOSSelectionResponse(
       selected.device.info.name,
-      devices[0].udid
+      devices[0].udid,
+      iosDeviceType!
     );
   }
 

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -81,14 +81,15 @@ export default function selectDevice(server: any): void {
   server.addTool({
     name: 'select_device',
     description:
-      'LOCAL servers only: ask the user for platform, list devices, then select deviceUdid; one result auto-selects. ' +
-      'For iOS also pass iosDeviceType and prepare simulators before session create. ' +
-      'Skip for REMOTE servers; pass device capabilities to appium_session_management.',
+      'LOCAL servers ONLY; NEVER use for REMOTE/remoteServerUrl. ASK THE USER Android or iOS—do not assume. ' +
+      'Call without deviceUdid to list: one result auto-selects; for multiple results ask the user, then call again with the chosen deviceUdid. ' +
+      'For iOS require iosDeviceType and run prepare_ios_simulator before appium_session_management create. ' +
+      'Remote devices are selected through session capabilities.',
     parameters: z
       .object({
         platform: z
           .enum(['ios', 'android'])
-          .describe('Platform selected by the user.'),
+          .describe('User-selected platform; never assume.'),
         iosDeviceType: z
           .enum(['simulator', 'real'])
           .optional()
@@ -96,7 +97,7 @@ export default function selectDevice(server: any): void {
         deviceUdid: z
           .string()
           .optional()
-          .describe('Chosen UDID; omit to list devices.'),
+          .describe('Chosen UDID; omit to list, then ask if multiple.'),
       })
       .refine(
         (data) => data.platform !== 'ios' || data.iosDeviceType !== undefined,

--- a/src/tools/session/select-device.ts
+++ b/src/tools/session/select-device.ts
@@ -80,38 +80,23 @@ export function clearSelectedDevice(): void {
 export default function selectDevice(server: any): void {
   server.addTool({
     name: 'select_device',
-    description: `Discover and select a device for LOCAL Appium servers ONLY.
-      DO NOT use this tool for REMOTE Appium servers - remoteServerUrl indicates a remote server.
-      WORKFLOW FOR LOCAL SERVERS:
-      1. ASK THE USER which platform they want (Android or iOS) - do not assume
-      2. Call this tool with the chosen platform (and iosDeviceType for iOS)
-      3. If only one device is found, it is auto-selected - proceed to appium_session_management (action=create) (or prepare_ios_simulator for iOS simulators)
-      4. If multiple devices are found, ask the user which one they want, then call this tool again with deviceUdid
-      5. After selection, proceed to appium_session_management (action=create) (or prepare_ios_simulator for iOS simulators, then appium_session_management with action=create)
-      WORKFLOW FOR REMOTE SERVERS:
-      - SKIP this tool entirely
-      - Device selection should be handled via capabilities on appium_session_management (action=create) (e.g., appium:deviceName, appium:udid)
-      - The remote Appium server is already configured for specific device(s)
-      `,
+    description:
+      'LOCAL servers only: ask the user for platform, list devices, then select deviceUdid; one result auto-selects. ' +
+      'For iOS also pass iosDeviceType and prepare simulators before session create. ' +
+      'Skip for REMOTE servers; pass device capabilities to appium_session_management.',
     parameters: z
       .object({
         platform: z
           .enum(['ios', 'android'])
-          .describe(
-            'The platform to list devices for (must match previously selected platform)'
-          ),
+          .describe('Platform selected by the user.'),
         iosDeviceType: z
           .enum(['simulator', 'real'])
           .optional()
-          .describe(
-            "For iOS only: Specify whether to use 'simulator' or 'real' device. REQUIRED when platform is 'ios'."
-          ),
+          .describe('Required for iOS: simulator or real.'),
         deviceUdid: z
           .string()
           .optional()
-          .describe(
-            'The UDID of the device selected by the user. If not provided, this tool will list available devices for the user to choose from.'
-          ),
+          .describe('Chosen UDID; omit to list devices.'),
       })
       .refine(
         (data) => data.platform !== 'ios' || data.iosDeviceType !== undefined,

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -20,62 +20,40 @@ const SESSION_ACTIONS = [
   'select',
 ] as const;
 
-const CREATE_SESSION_DESCRIPTION = `Create a new Appium session with Android, iOS or any device/driver Appium supports.
-      DEFAULT MODE (no remoteServerUrl) — USE THIS UNLESS THE USER EXPLICITLY PROVIDES A SERVER URL:
-      - Drivers run embedded inside this MCP server; no separate Appium process is needed
-      - Use select_device tool FIRST to discover devices and let the user choose platform and device
-      - Then call action=create with the selected platform (do NOT pass remoteServerUrl)
-      - For iOS simulators, call prepare_ios_simulator before action=create
-      - DO NOT assume or default to any platform
-      - NEVER invent a localhost URL (e.g. http://localhost:4723) — omitting remoteServerUrl IS the local/embedded mode
-      REMOTE SERVER MODE (only when user explicitly provides a URL like http://localhost:4723):
-      - SKIP select_device tool entirely
-      - Infer the platform from the user's request (e.g., 'ios', 'android', or 'general')
-      - If platform is 'general', treat the provided capabilities as a pass-through W3C/Appium capability set (useful for non-Android/iOS drivers like Windows, macOS, or custom drivers)
-      - Infer device type from context when possible (e.g., 'simulator', 'real device')
-      - Call session with action=create directly with platform, remoteServerUrl, and any other capabilities from the user's request
-      - Example: User says 'start session with http://localhost:4723 for ios with iphone 17' → infer platform='ios' and call session(action=create) with remoteServerUrl and platform parameters`;
-
 const schema = z.object({
   action: z
     .enum(SESSION_ACTIONS)
     .describe(
-      'Action to perform. ' +
-        `create: ${CREATE_SESSION_DESCRIPTION}` +
-        'attach: Attach MCP Appium to an existing remote Appium session without taking ownership of its lifecycle. Requires remoteServerUrl and sessionId. Always pass capabilities with at least platformName (e.g. \'{"platformName":"iOS"}\' or \'{"platformName":"Android"}\') so the client is configured with the correct protocol commands.' +
-        'detach: Remove an attached Appium session from MCP Appium without deleting the real remote session. Defaults to the active session.' +
-        'delete: Delete a mobile session and clean up resources. If sessionId is omitted, deletes the active session.' +
-        'list: List all active Appium sessions managed by this MCP server, including active flag, ownership, and current context.' +
-        'select: Set an existing Appium session as the active session for subsequent tool calls (requires sessionId).'
+      'Action. DEFAULT MODE: create without remoteServerUrl uses an embedded driver; no separate Appium process is needed. ' +
+        'Run select_device tool FIRST, pass platform, do NOT pass remoteServerUrl, and NEVER invent a localhost URL. ' +
+        'REMOTE SERVER MODE: only when the user explicitly provides a URL; create with that URL/capabilities. ' +
+        'attach requires URL + sessionId (+ platformName capabilities) and connects without taking ownership. ' +
+        'detach forgets an attached session without deleting the real remote session. delete stops; list shows; select activates.'
     ),
   platform: z
     .enum(DRIVER_MODE_PLATFORMS)
     .optional()
     .describe(
-      'Required for create. ' +
-        'For local servers, must match the platform selected via select_device. ' +
-        'Use "general" for non-Android/iOS drivers (Windows, macOS, custom). ' +
-        'For remote servers, infer from context.'
+      'create platform; match select_device locally. Use general for other remote drivers.'
     ),
   capabilities: z
     .string()
     .optional()
     .describe(
-      'Optional W3C capabilities for create. Provide as a JSON string (e.g. \'{"appium:app":"/path/to/app","appium:platformVersion":"17.0"}\'). ' +
-        'For create: applied on top of defaults for ios/android, or used as-is for general. Common: appium:app, appium:deviceName, appium:platformVersion, appium:bundleId. When passing from a capabilitiesHint result, serialize the full object to JSON — do NOT drop boolean or numeric values. ' +
-        'For attach: always include platformName ("iOS" or "Android") so the WebDriver client loads the correct Appium protocol commands (e.g. \'{"platformName":"iOS"}\').'
+      'JSON W3C capabilities. create merges iOS/Android defaults or passes general through. ' +
+        'Serialize full capabilitiesHint values. attach must include platformName.'
     ),
   remoteServerUrl: z
     .string()
     .optional()
     .describe(
-      'Remote Appium server URL for create or attach (e.g. http://localhost:4723). Omit to use local server for create.'
+      'Explicit remote server URL for create/attach; omit for embedded create.'
     ),
   sessionId: z
     .string()
     .optional()
     .describe(
-      'For attach: existing session to connect to. For delete: session to remove (defaults to active). For detach: attached session to remove from MCP (defaults to active). For select: session to activate. Required for attach and select.'
+      'Target session; required for attach/select, otherwise defaults to active.'
     ),
 });
 
@@ -83,7 +61,7 @@ export default function session(server: FastMCP): void {
   server.addTool({
     name: 'appium_session_management',
     description:
-      'Manage Appium sessions. Use action=create to start a session, attach to connect to an existing one, detach to forget an attached session, delete to stop one, list to see all active sessions, or select to switch the active session.',
+      'Create, attach, detach, delete, list, or select Appium sessions.',
     parameters: schema,
     annotations: {
       destructiveHint: true,

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -24,10 +24,13 @@ const schema = z.object({
   action: z
     .enum(SESSION_ACTIONS)
     .describe(
-      'Action. DEFAULT MODE: create without remoteServerUrl uses an embedded driver; no separate Appium process is needed. ' +
-        'Run select_device tool FIRST, pass platform, do NOT pass remoteServerUrl, and NEVER invent a localhost URL. ' +
-        'For iOS simulators, run prepare_ios_simulator before create. ' +
-        'REMOTE SERVER MODE: only when the user explicitly provides a URL; create with that URL/capabilities. ' +
+      'Action. DEFAULT/LOCAL MODE: create without remoteServerUrl uses an embedded driver; no separate Appium process is needed. ' +
+        'Normally run select_device first and pass its platform; explicit target capabilities such as appium:udid can be used instead. ' +
+        'Do NOT pass remoteServerUrl for local create, and NEVER invent a localhost URL. ' +
+        'For a selected iOS simulator run prepare_ios_simulator; for a selected iOS real device run appium_prepare_ios_real_device. ' +
+        'Then JSON-serialize the full returned capabilitiesHint as capabilities for create. ' +
+        'REMOTE SERVER MODE: only when the user explicitly provides a URL; skip select_device and create with that URL/capabilities. ' +
+        'platform=general is remote-only and requires remoteServerUrl. ' +
         'attach requires URL + sessionId (+ platformName capabilities) and connects without taking ownership. ' +
         'detach forgets an attached session without deleting the real remote session. delete stops; list shows; select activates.'
     ),
@@ -35,14 +38,14 @@ const schema = z.object({
     .enum(DRIVER_MODE_PLATFORMS)
     .optional()
     .describe(
-      'Required for create; match select_device locally. Use general for other remote drivers.'
+      'Required for create. For local create, match select_device when used. general is for other remote drivers and requires remoteServerUrl.'
     ),
   capabilities: z
     .string()
     .optional()
     .describe(
-      'JSON W3C capabilities. create merges iOS/Android defaults or passes general through. ' +
-        'Serialize full capabilitiesHint values. attach must include platformName.'
+      'JSON-stringified W3C capabilities. create merges these over iOS/Android defaults or passes general through. ' +
+        'When using a capabilitiesHint, serialize the full object without dropping boolean or numeric values. attach must include platformName.'
     ),
   remoteServerUrl: z
     .string()

--- a/src/tools/session/session.ts
+++ b/src/tools/session/session.ts
@@ -26,6 +26,7 @@ const schema = z.object({
     .describe(
       'Action. DEFAULT MODE: create without remoteServerUrl uses an embedded driver; no separate Appium process is needed. ' +
         'Run select_device tool FIRST, pass platform, do NOT pass remoteServerUrl, and NEVER invent a localhost URL. ' +
+        'For iOS simulators, run prepare_ios_simulator before create. ' +
         'REMOTE SERVER MODE: only when the user explicitly provides a URL; create with that URL/capabilities. ' +
         'attach requires URL + sessionId (+ platformName capabilities) and connects without taking ownership. ' +
         'detach forgets an attached session without deleting the real remote session. delete stops; list shows; select activates.'
@@ -34,7 +35,7 @@ const schema = z.object({
     .enum(DRIVER_MODE_PLATFORMS)
     .optional()
     .describe(
-      'create platform; match select_device locally. Use general for other remote drivers.'
+      'Required for create; match select_device locally. Use general for other remote drivers.'
     ),
   capabilities: z
     .string()


### PR DESCRIPTION
## Summary

- remove repetitive MCP tool-description boilerplate without changing tool handlers or validation constraints
- retain detailed workflow, conditional-input, platform-specific, example, and advanced-option guidance
- preserve the full local/remote session-creation flow, including iOS simulator/real-device preparation and `capabilitiesHint` handoff
- lower the CI-enforced `tools/list` hard limit from 47,000 to 42,000 characters while prioritizing correct LLM interpretation

## Result

- before: 46,111 characters (~11,528 tokens)
- after: 40,365 characters (~10,092 tokens)
- reduction: 5,746 characters (~12%)
- budget headroom: 1,635 characters

## Verification

- `npm run build`
- `npm run audit:tools`
- `npm run check`
- `npm test -- --runInBand` (332 tests)

Part of #470.
