### PR TITLE
perf: cap tool discovery at 45k characters

### DIFF
--- a/scripts/audit-tool-footprint.mjs
+++ b/scripts/audit-tool-footprint.mjs
@@ -7,7 +7,7 @@ import {fileURLToPath} from 'node:url';
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 
-const MAX_DISCOVERY_CHARS = 47_000;
+const MAX_DISCOVERY_CHARS = 45_000;
 const ESTIMATED_CHARS_PER_TOKEN = 4;
 const LARGEST_TOOL_COUNT = 10;
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,3 @@
 import {z} from 'zod';
 
-export const elementUUIDScheme = z
-  .string()
-  .describe('The uuid of the element returned by appium_find_element to click');
+export const elementUUIDScheme = z.string().describe('Element ID from appium_find_element.');

--- a/src/tests/tools/llm-wording.test.ts
+++ b/src/tests/tools/llm-wording.test.ts
@@ -9,14 +9,21 @@ jest.unstable_mockModule('../../tools/tool-response', () => ({
     content: [{type: 'text', text}],
     isError: true,
   })),
+  noActiveDriverSessionMessage: jest.fn(),
   readWebElementId: jest.fn(),
   resolveDriver: jest.fn(),
+  textResult: jest.fn(),
   textResultWithPrimaryElementId: jest.fn(),
   toolErrorMessage: jest.fn(mockToolErrorMessage),
 }));
 
 jest.unstable_mockModule('../../command', () => ({
+  activateApp: jest.fn(),
+  execute: jest.fn(),
   findElement: jest.fn(),
+  queryAppState: jest.fn(),
+  startRecordingScreen: jest.fn(),
+  stopRecordingScreen: jest.fn(),
 }));
 
 jest.unstable_mockModule('../../tools/session/attach-session', () => ({
@@ -117,5 +124,51 @@ describe('LLM-facing MCP tool wording', () => {
     expect(remoteServerUrlDescription).toMatch(/Omit to use local server/i);
     expect(sessionIdDescription).toMatch(/Required for attach and select/i);
     expect(tool.annotations?.destructiveHint).toBe(true);
+  });
+
+  test('appium_app_lifecycle retains action requirements and special values', async () => {
+    const tool = await registerTool('../../tools/app-management/app.js');
+    const actionDescription = normalizeText(paramDescription(tool, 'action'));
+
+    expect(actionDescription).toMatch(/activate.*terminate.*is_installed.*clear.*require id or name/i);
+    expect(actionDescription).toMatch(/install.*requires path/i);
+    expect(actionDescription).toMatch(/uninstall.*id\/name.*keepData/i);
+    expect(actionDescription).toMatch(/list.*applicationType/i);
+    expect(actionDescription).toMatch(/query_state.*0=not installed.*4=foreground.*id or name/i);
+    expect(actionDescription).toMatch(/background.*default 5/i);
+    expect(actionDescription).toMatch(/deep_link.*requires url.*id\/name.*optional/i);
+
+    expect(normalizeText(paramDescription(tool, 'id'))).toMatch(
+      /Android package.*iOS bundle ID.*precedence over name/i,
+    );
+    expect(normalizeText(paramDescription(tool, 'seconds'))).toMatch(/default 5.*-1.*remain in background/i);
+    expect(normalizeText(paramDescription(tool, 'waitForLaunch'))).toMatch(/Android deep_link.*default true/i);
+  });
+
+  test('appium_screen_recording retains stop and platform limit semantics', async () => {
+    const tool = await registerTool('../../tools/interactions/screen-recording.js');
+
+    expect(normalizeText(paramDescription(tool, 'action'))).toMatch(/start.*recording.*stop.*retrieves.*saves/i);
+    expect(normalizeText(paramDescription(tool, 'timeLimit'))).toMatch(
+      /does not retrieve\/save automatically.*call stop.*iOS.*180.*4200.*Android.*180.*1800/i,
+    );
+    expect(normalizeText(paramDescription(tool, 'forceRestart'))).toMatch(
+      /restart.*discard.*active recording.*default false/i,
+    );
+    expect(normalizeText(paramDescription(tool, 'videoQuality'))).toMatch(/iOS only.*default.*medium/i);
+    expect(normalizeText(paramDescription(tool, 'videoSize'))).toMatch(/Android only.*WIDTHxHEIGHT/i);
+  });
+
+  test('appium_mobile_permissions retains action-specific requirements', async () => {
+    const tool = await registerTool('../../tools/app-management/permissions.js');
+
+    expect(normalizeText(paramDescription(tool, 'action'))).toMatch(
+      /get.*Android.*iOS.*update.*Android.*iOS.*reset.*iOS/i,
+    );
+    expect(normalizeText(paramDescription(tool, 'service'))).toMatch(
+      /iOS get.*service name.*iOS reset.*service name or numeric/i,
+    );
+    expect(normalizeText(paramDescription(tool, 'permissions'))).toMatch(/Android update.*permission.*Required/i);
+    expect(normalizeText(paramDescription(tool, 'access'))).toMatch(/iOS update.*yes.*no.*unset.*limited.*Required/i);
   });
 });

--- a/src/tests/tools/llm-wording.test.ts
+++ b/src/tests/tools/llm-wording.test.ts
@@ -130,12 +130,13 @@ describe('LLM-facing MCP tool wording', () => {
     const tool = await registerTool('../../tools/app-management/app.js');
     const actionDescription = normalizeText(paramDescription(tool, 'action'));
 
-    expect(actionDescription).toMatch(/activate.*terminate.*is_installed.*clear.*require id or name/i);
+    expect(actionDescription).toMatch(/activate.*foreground.*terminate.*stop.*is_installed.*check installation/i);
+    expect(actionDescription).toMatch(/clear.*app data.*without uninstalling.*require id or name/i);
     expect(actionDescription).toMatch(/install.*requires path/i);
     expect(actionDescription).toMatch(/uninstall.*id\/name.*keepData/i);
     expect(actionDescription).toMatch(/list.*applicationType/i);
     expect(actionDescription).toMatch(/query_state.*0=not installed.*4=foreground.*id or name/i);
-    expect(actionDescription).toMatch(/background.*default 5/i);
+    expect(actionDescription).toMatch(/background.*foreground app.*background.*default 5/i);
     expect(actionDescription).toMatch(/deep_link.*requires url.*id\/name.*optional/i);
 
     expect(normalizeText(paramDescription(tool, 'id'))).toMatch(

--- a/src/tools/app-management/app.ts
+++ b/src/tools/app-management/app.ts
@@ -33,11 +33,13 @@ const schema = z.object({
   action: z
     .enum(APP_ACTIONS)
     .describe(
-      'activate/terminate/is_installed/clear: require id or name. ' +
+      'activate: foreground app; terminate: stop app; is_installed: check installation; ' +
+        'clear: clear app data without uninstalling (all require id or name). ' +
         'install: requires path. uninstall: requires id/name; Android keepData is optional. ' +
         'list: optional iOS applicationType. ' +
         'query_state: get state 0=not installed,1=not running,2=background suspended,3=background,4=foreground (requires id or name). ' +
-        'background: optional seconds (default 5). deep_link: requires url; id/name is optional.',
+        'background: send foreground app to background; optional seconds (default 5). ' +
+        'deep_link: requires url; id/name is optional.',
     ),
   id: z.string().optional().describe('Android package or iOS bundle ID; takes precedence over name.'),
   name: z.string().optional().describe('Human-readable app name resolved to an ID; alternative to id.'),

--- a/src/tools/app-management/app.ts
+++ b/src/tools/app-management/app.ts
@@ -33,64 +33,32 @@ const schema = z.object({
   action: z
     .enum(APP_ACTIONS)
     .describe(
-      'Action to perform. ' +
-        'activate: bring app to foreground (requires id or name). ' +
-        'terminate: stop a running app (requires id or name). ' +
-        'install: install from file path (requires path). ' +
-        'uninstall: remove from device (requires id or name; optional keepData for Android). ' +
-        'list: list installed apps (optional applicationType for iOS). ' +
-        'is_installed: check if app is installed (requires id or name). ' +
+      'activate/terminate/is_installed/clear: require id or name. ' +
+        'install: requires path. uninstall: requires id/name; Android keepData is optional. ' +
+        'list: optional iOS applicationType. ' +
         'query_state: get state 0=not installed,1=not running,2=background suspended,3=background,4=foreground (requires id or name). ' +
-        'background: send foreground app to background (optional seconds, default 5). ' +
-        'clear: clear app data without uninstalling (requires id or name). ' +
-        'deep_link: open a URL with an app (requires url; optional id or name).',
+        'background: optional seconds (default 5). deep_link: requires url; id/name is optional.',
     ),
-  id: z
-    .string()
-    .optional()
-    .describe(
-      'App identifier (package name for Android, bundle ID for iOS). Takes precedence over name. Required for: activate, terminate, uninstall, is_installed, query_state, clear.',
-    ),
-  name: z
-    .string()
-    .optional()
-    .describe(
-      'Human-readable app name (e.g. "Spotify"). Used to resolve the app id. Required (as alternative to id) for: activate, terminate, uninstall, is_installed, query_state, clear.',
-    ),
-  path: z.string().optional().describe('Path to the app file to install. Required for: install.'),
-  keepData: z
-    .boolean()
-    .optional()
-    .describe('Keep app data and cache after uninstall. Android only. Used with: uninstall.'),
-  applicationType: z
-    .enum(['User', 'System'])
-    .optional()
-    .describe('iOS only: filter by "User" (default) or "System" apps. Used with: list.'),
+  id: z.string().optional().describe('Android package or iOS bundle ID; takes precedence over name.'),
+  name: z.string().optional().describe('Human-readable app name resolved to an ID; alternative to id.'),
+  path: z.string().optional().describe('App file path; required for install.'),
+  keepData: z.boolean().optional().describe('Android uninstall: preserve app data and cache.'),
+  applicationType: z.enum(['User', 'System']).optional().describe('iOS list filter: User (default) or System.'),
   seconds: z
     .number()
     .min(-1)
     .max(86400)
     .optional()
-    .describe(
-      `Seconds to keep the app in the background. Defaults to ${DEFAULT_BACKGROUND_SECONDS}. Use -1 to stay in background without auto-resuming. Used with: background.`,
-    ),
-  url: z
-    .string()
-    .optional()
-    .describe('Deep link URL to open (e.g. https://example.com, myapp://path). Required for: deep_link.'),
-  waitForLaunch: z
-    .boolean()
-    .optional()
-    .describe(
-      'Android only. If false, ADB does not wait for the activity to return. Defaults to true. Used with: deep_link.',
-    ),
+    .describe(`Background duration; default ${DEFAULT_BACKGROUND_SECONDS}. Use -1 to remain in background.`),
+  url: z.string().optional().describe('URL for deep_link (e.g. https://example.com or myapp://path).'),
+  waitForLaunch: z.boolean().optional().describe('Android deep_link: wait for the activity to return; default true.'),
   sessionId: z.string().optional().describe('Session ID to target. If omitted, uses the active session.'),
 });
 
 export default function app(server: FastMCP): void {
   server.addTool({
     name: 'appium_app_lifecycle',
-    description: `Manage apps on the device. Use the action parameter to choose what to do: ${APP_ACTIONS.join(', ')}.`,
+    description: 'Manage app lifecycle, installation, state, data, and deep links.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/app-management/permissions.ts
+++ b/src/tools/app-management/permissions.ts
@@ -20,16 +20,12 @@ export default function mobilePermissions(server: FastMCP): void {
     id: z
       .string()
       .optional()
-      .describe(
-        'App identifier (package name for Android, bundle ID for iOS). Takes precedence over name. ' +
-          'Optional for Android (defaults to the app under test). Required for iOS get and update.',
-      ),
+      .describe('App ID; overrides name. Android defaults to the app under test; required for iOS get/update.'),
     name: z
       .string()
       .optional()
       .describe(
-        'Human-readable app name (e.g. "Spotify"). Used to resolve the app id. ' +
-          'Optional for Android (defaults to the app under test). Required (as alternative to id) for iOS get and update.',
+        'App name resolved to an ID. Android defaults to the app under test; alternative to id for iOS get/update.',
       ),
     sessionId: z.string().optional().describe('Session ID to target. If omitted, uses the active session.'),
     permissionFilter: z
@@ -65,7 +61,7 @@ export default function mobilePermissions(server: FastMCP): void {
   server.addTool({
     name: 'appium_mobile_permissions',
     description:
-      'Manage mobile app permissions in one place. action=get: Android lists runtime permissions for a package; iOS Simulator reads one service state for an app (needs id or name + service). action=update: Android changes permissions (grant/revoke or AppOps); iOS Simulator sets privacy via access map (needs id or name + access). action=reset: iOS only — resets one privacy service for the AUT (needs service).',
+      'Get/update Android app permissions or iOS Simulator privacy services; reset iOS privacy prompts. See action-specific parameters.',
     parameters: schema,
     annotations: {
       readOnlyHint: false,

--- a/src/tools/interactions/screen-recording.ts
+++ b/src/tools/interactions/screen-recording.ts
@@ -62,25 +62,16 @@ async function saveRecording(base64Video: string): Promise<string> {
 }
 
 const screenRecordingSchema = z.object({
-  action: z
-    .enum(['start', 'stop'])
-    .describe(
-      'Use start to begin recording. Use stop to end the current recording, retrieve it from the driver, and save it to disk.',
-    ),
+  action: z.enum(['start', 'stop']).describe('start begins recording; stop ends, retrieves, and saves it.'),
   timeLimit: z
     .number()
     .int()
     .min(1)
     .optional()
     .describe(
-      'Maximum recording duration in seconds for the underlying recorder. This does not automatically stop and save the recording through this tool; call action="stop" to retrieve/save the video. iOS default: 180 (max 4200). Android default: 180 (max 1800).',
+      'Recorder limit in seconds; it does not retrieve/save automatically, so call stop. iOS default 180/max 4200; Android default 180/max 1800.',
     ),
-  forceRestart: z
-    .boolean()
-    .optional()
-    .describe(
-      'If true, stop any active recording immediately and start a new one without returning the previous video. Default: false.',
-    ),
+  forceRestart: z.boolean().optional().describe('Restart and discard any active recording; default false.'),
   videoQuality: z
     .enum(['low', 'medium', 'high', 'photo'])
     .optional()


### PR DESCRIPTION
## Summary

- lower the CI-enforced `tools/list` budget from 47,000 to 45,000 characters
- compact only low-risk repeated wording in app lifecycle, permissions, screen recording, and the shared element-ID description
- keep `src/tools/session/session.ts`, `src/tools/interactions/find.ts`, and `src/tools/session/select-device.ts` unchanged
- retain explicit app lifecycle action semantics and add wording regression tests for requirements, special values, platform limits, and recording behavior

## Why

PR #473 reduced the discovery payload more aggressively than needed. This smaller follow-up targets a modest reduction while prioritizing correct LLM interpretation and keeping detailed session, element-finding, and device-selection guidance intact.

## Result

- before: 46,111 characters (~11,528 tokens)
- after: 44,587 characters (~11,147 tokens)
- reduction: 1,524 characters (~3.3%)
- budget headroom: 413 characters

## Verification

- `npm run build`
- `npm run audit:tools`
- `npm run check`
- `npm test -- --runInBand` (330 tests)

Part of #470.
