### PR TITLE
feat: add payload-free tool result size telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ OTEL_TRACES_SAMPLER=parentbased_always_on
 
 When enabled, appium-mcp creates spans for MCP tool calls, prompt loads, resource reads, and resource template reads. Error status is recorded for thrown operation errors and MCP tool results marked with `isError`. Span attributes intentionally avoid raw screenshots, XML page source, prompts, credentials, and other high-cardinality or sensitive payloads.
 
+Tool spans include payload-free result-size attributes: `mcp.tool.result.content_count`, `content_types`, `text_chars`, `resource_count`, `resource_text_chars`, `image_count`, `audio_count`, `base64_chars`, and `base64_bytes_estimate` (all prefixed with `mcp.tool.result.`). `content_types` contains only known MCP types or `other`; payload values, resource URIs, MIME types, and unknown type strings are never recorded. Sizes are counted directly from known result fields without serializing or copying the complete result.
+
 For local trace inspection, use the Jaeger setup in `tools/telemetry`:
 
 ```bash

--- a/src/telemetry/wrapOperations.ts
+++ b/src/telemetry/wrapOperations.ts
@@ -21,6 +21,8 @@ type PromptLoad = NonNullable<PromptDef['load']>;
 type ResourceLoad = NonNullable<ResourceDef['load']>;
 type ResourceTemplateLoad = NonNullable<ResourceTemplateDef['load']>;
 
+const SAFE_TOOL_CONTENT_TYPES = new Set(['audio', 'image', 'resource', 'resource_link', 'text']);
+
 /**
  * Installs telemetry wrappers on the given FastMCP server instance. This should be
  * called early in the server setup process, before registering any tools, prompts,
@@ -77,13 +79,96 @@ export function wrapToolWithTelemetry(toolDef: ToolDef): ToolDef {
     execute: async (args, context) =>
       withSpan(`tools/call ${toolName}`, toolAttributes(toolName, args), async () => {
         const result = await execute(args, context);
+        const span = getActiveSpan();
+        span?.setAttributes(safeToolResultSizeAttributes(result));
         if (isErrorResult(result)) {
-          getActiveSpan()?.setStatus({code: SpanStatusCode.ERROR});
-          getActiveSpan()?.setAttribute('mcp.tool.result.is_error', true);
+          span?.setStatus({code: SpanStatusCode.ERROR});
+          span?.setAttribute('mcp.tool.result.is_error', true);
         }
         return result;
       }),
   };
+}
+
+/**
+ * Builds payload-free size attributes for a tool result.
+ *
+ * This intentionally counts known MCP content fields directly instead of
+ * serializing the whole result. Large page sources, UI HTML, and base64 data
+ * therefore are not copied or recorded in telemetry.
+ */
+export function safeToolResultSizeAttributes(result: unknown): Record<string, number | string[]> {
+  if (typeof result === 'string') {
+    return {'mcp.tool.result.text_chars': result.length};
+  }
+  if (!isRecord(result) || !Array.isArray(result.content)) {
+    return {};
+  }
+
+  const contentTypes = new Set<string>();
+  let textChars = 0;
+  let resourceCount = 0;
+  let resourceTextChars = 0;
+  let imageCount = 0;
+  let audioCount = 0;
+  let base64Chars = 0;
+  let base64BytesEstimate = 0;
+
+  for (const content of result.content) {
+    if (!isRecord(content)) {
+      contentTypes.add('other');
+      continue;
+    }
+
+    const contentType =
+      typeof content.type === 'string' && SAFE_TOOL_CONTENT_TYPES.has(content.type) ? content.type : 'other';
+    contentTypes.add(contentType);
+
+    if (contentType === 'text' && typeof content.text === 'string') {
+      textChars += content.text.length;
+      continue;
+    }
+
+    if (contentType === 'image' || contentType === 'audio') {
+      if (contentType === 'image') {
+        imageCount += 1;
+      } else {
+        audioCount += 1;
+      }
+      if (typeof content.data === 'string') {
+        base64Chars += content.data.length;
+        base64BytesEstimate += estimateBase64DecodedBytes(content.data);
+      }
+      continue;
+    }
+
+    if (contentType === 'resource') {
+      resourceCount += 1;
+      if (isRecord(content.resource)) {
+        if (typeof content.resource.text === 'string') {
+          resourceTextChars += content.resource.text.length;
+        }
+        if (typeof content.resource.blob === 'string') {
+          base64Chars += content.resource.blob.length;
+          base64BytesEstimate += estimateBase64DecodedBytes(content.resource.blob);
+        }
+      }
+    }
+  }
+
+  const attributes: Record<string, number | string[]> = {
+    'mcp.tool.result.content_count': result.content.length,
+    'mcp.tool.result.content_types': [...contentTypes].sort(),
+    'mcp.tool.result.text_chars': textChars,
+    'mcp.tool.result.resource_count': resourceCount,
+    'mcp.tool.result.resource_text_chars': resourceTextChars,
+    'mcp.tool.result.image_count': imageCount,
+    'mcp.tool.result.audio_count': audioCount,
+    'mcp.tool.result.base64_chars': base64Chars,
+    'mcp.tool.result.base64_bytes_estimate': base64BytesEstimate,
+  };
+
+  return attributes;
 }
 
 export function safeInputValueAttributes(args: unknown): Record<string, string | number | boolean | string[]> {
@@ -212,4 +297,26 @@ function isErrorResult(result: unknown): boolean {
   return (
     !!result && typeof result === 'object' && 'isError' in result && (result as {isError?: unknown}).isError === true
   );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function estimateBase64DecodedBytes(value: string): number {
+  const commaIndex = value.indexOf(',');
+  const hasDataUriPrefix = commaIndex >= 7 && value.slice(commaIndex - 7, commaIndex).toLowerCase() === ';base64';
+  const contentStart = hasDataUriPrefix ? commaIndex + 1 : 0;
+  const encodedLength = value.length - contentStart;
+  if (encodedLength <= 0) {
+    return 0;
+  }
+
+  let padding = 0;
+  if (value.endsWith('==')) {
+    padding = 2;
+  } else if (value.endsWith('=')) {
+    padding = 1;
+  }
+  return Math.max(0, Math.floor((encodedLength * 3) / 4) - padding);
 }

--- a/src/tests/telemetry.test.ts
+++ b/src/tests/telemetry.test.ts
@@ -8,7 +8,11 @@ import {
   safeSessionId,
 } from '../telemetry/attributes.js';
 import {initializeOpenTelemetry, shutdownOpenTelemetry} from '../telemetry/init.js';
-import {installTelemetryWrappers, safeInputValueAttributes} from '../telemetry/wrapOperations.js';
+import {
+  installTelemetryWrappers,
+  safeInputValueAttributes,
+  safeToolResultSizeAttributes,
+} from '../telemetry/wrapOperations.js';
 import {startOtlpHttpReceiver} from './telemetry-tools/otlp-http-receiver.js';
 
 const originalEnv = {...process.env};
@@ -181,6 +185,57 @@ describe('telemetry attributes', () => {
     ).toEqual(['platformName', 'sessionId']);
   });
 
+  test('counts tool result sizes without exposing payload contents', () => {
+    const secretText = 'private page source';
+    const secretHtml = '<html>private screenshot</html>';
+    const attributes = safeToolResultSizeAttributes({
+      content: [
+        {type: 'text', text: secretText},
+        {type: 'resource', resource: {text: secretHtml}},
+        {type: 'resource', resource: {blob: 'YWJj'}},
+        {type: 'image', data: 'c2VjcmV0'},
+        {type: 'audio', data: 'YQ=='},
+        {type: 'resource_link', uri: 'private://resource'},
+        {type: 'private payload type', value: 'must not be recorded'},
+      ],
+    });
+
+    expect(attributes).toEqual({
+      'mcp.tool.result.audio_count': 1,
+      'mcp.tool.result.base64_bytes_estimate': 10,
+      'mcp.tool.result.base64_chars': 16,
+      'mcp.tool.result.content_count': 7,
+      'mcp.tool.result.content_types': ['audio', 'image', 'other', 'resource', 'resource_link', 'text'],
+      'mcp.tool.result.image_count': 1,
+      'mcp.tool.result.resource_count': 2,
+      'mcp.tool.result.resource_text_chars': secretHtml.length,
+      'mcp.tool.result.text_chars': secretText.length,
+    });
+
+    const attributeValues = Object.values(attributes).flat().join(' ');
+    expect(attributeValues).not.toContain(secretText);
+    expect(attributeValues).not.toContain(secretHtml);
+    expect(attributeValues).not.toContain('private payload type');
+    expect(attributeValues).not.toContain('must not be recorded');
+    expect(attributeValues).not.toContain('YWJj');
+    expect(attributeValues).not.toContain('c2VjcmV0');
+  });
+
+  test('measures string tool results and ignores unrelated result shapes', () => {
+    expect(safeToolResultSizeAttributes('tool-result')).toEqual({
+      'mcp.tool.result.text_chars': 11,
+    });
+    expect(safeToolResultSizeAttributes(undefined)).toEqual({});
+    expect(safeToolResultSizeAttributes({messages: []})).toEqual({});
+
+    const circular: Record<string, unknown> = {content: [{type: 'text', text: 'ok'}]};
+    circular.self = circular;
+    expect(safeToolResultSizeAttributes(circular)).toMatchObject({
+      'mcp.tool.result.content_count': 1,
+      'mcp.tool.result.text_chars': 2,
+    });
+  });
+
   test('extracts only string session IDs', () => {
     expect(safeSessionId({sessionId: 'session-1'})).toBe('session-1');
     expect(safeSessionId({sessionId: 123})).toBeUndefined();
@@ -233,6 +288,9 @@ describe('telemetry attributes', () => {
 
   test('exports actual OTLP span data for wrapped MCP operations', async () => {
     const receiver = await startOtlpHttpReceiver();
+    const privateToolText = 'private tool output';
+    const privateResourceText = '<html>private resource</html>';
+    const privateImageData = 'c2VjcmV0';
 
     process.env.APPIUM_MCP_OTEL_ENABLED = 'true';
     process.env.APPIUM_MCP_OTEL_INCLUDE_ARGUMENT_VALUES = 'true';
@@ -265,7 +323,13 @@ describe('telemetry attributes', () => {
 
       server.addTool({
         name: 'plugin_tool',
-        execute: async () => ({content: [{type: 'text', text: 'ok'}]}),
+        execute: async () => ({
+          content: [
+            {type: 'text', text: privateToolText},
+            {type: 'resource', resource: {text: privateResourceText}},
+            {type: 'image', data: privateImageData},
+          ],
+        }),
       });
       server.addPrompt({
         name: 'plugin_prompt',
@@ -315,8 +379,20 @@ describe('telemetry attributes', () => {
         'mcp.input.value.capabilities': '{"platformName":"iOS","deviceName":"iPhone 15"}',
         'mcp.input.value.platformName': 'iOS',
         'mcp.tool.name': 'plugin_tool',
+        'mcp.tool.result.base64_bytes_estimate': 6,
+        'mcp.tool.result.base64_chars': 8,
+        'mcp.tool.result.content_count': 3,
+        'mcp.tool.result.content_types': ['image', 'resource', 'text'],
+        'mcp.tool.result.image_count': 1,
+        'mcp.tool.result.resource_count': 1,
+        'mcp.tool.result.resource_text_chars': privateResourceText.length,
+        'mcp.tool.result.text_chars': privateToolText.length,
       });
       expect(otlpAttributes(toolSpan)).not.toHaveProperty('mcp.input.value.apiKey');
+      const exportedTelemetry = JSON.stringify(receiver.requests[0].body);
+      expect(exportedTelemetry).not.toContain(privateToolText);
+      expect(exportedTelemetry).not.toContain(privateResourceText);
+      expect(exportedTelemetry).not.toContain(privateImageData);
 
       const promptSpan = spans.find((span) => span.name === 'prompts/get plugin_prompt');
       expect(otlpAttributes(promptSpan)).toMatchObject({


### PR DESCRIPTION
## Summary

- add payload-free result-size attributes to OpenTelemetry tool-call spans
- count MCP content blocks/types, text characters, resource text characters, image/audio blocks, and base64 encoded/estimated decoded sizes
- allow-list known MCP content types and map unknown type strings to `other`
- count known fields directly without serializing or copying the complete tool result
- document the exported attributes and add unit plus real OTLP export privacy coverage

## Why

Before migrating inline UI viewers to static MCP Apps resources, we need production-safe measurements that identify which tool results duplicate the most text, HTML, and base64 data. Existing telemetry recorded operation metadata and errors but not result sizes.

## Safety and compatibility

- no screenshot, page-source XML, HTML, base64, URI, MIME type, or unknown content-type value is exported
- the OTLP integration test verifies private text, resource HTML, and image base64 are absent from the exported request body
- circular results are handled without whole-result serialization
- tool responses, schemas, UI behavior, and Appium/WebDriver execution are unchanged
- telemetry remains opt-in through `APPIUM_MCP_OTEL_ENABLED`

## Verification

- `npm run check`
- `npm run build`
- `npm run audit:tools` — unchanged at 44,587 characters (~11,147 tokens)
- `npm test -- --runInBand` — 29 suites, 332 tests passed

Part of #470.
