### PR TITLE
feat: avoid duplicate page source UI payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ This will automatically configure the MCP server for use with Claude Code. Make 
 | `CAPABILITIES_CONFIG`                     | Optional                               | Absolute path to a `capabilities.json` file with per-platform capability presets                                                                                                                                                                                                                                                                   |
 | `SCREENSHOTS_DIR`                         | Optional                               | Directory where screenshots and screen recordings are saved. Defaults to the current working directory                                                                                                                                                                                                                                             |
 | `NO_UI`                                   | Optional                               | Set to `true` or `1` to disable HTML UI components — faster responses, fewer tokens. See [NO_UI Mode](#no_ui-mode)                                                                                                                                                                                                                                 |
+| `APPIUM_MCP_APPS_ENABLED`                 | Optional                               | MCP Apps static UI mode. Enabled by default. Set to `false` or `0` to force the embedded UI compatibility fallback. See [MCP Apps Mode](#mcp-apps-mode)                                                                                                                                                                                            |
 | `APPIUM_MCP_ON_CLIENT_DISCONNECT`         | Optional                               | Session cleanup when the MCP client disconnects: `delete_all` (default) deletes **MCP-owned** Appium sessions (`safeDeleteAllSessions`); `skip` keeps those sessions across disconnects (e.g. HTTP/stream clients that reconnect). Attached/remote sessions are not removed by this path. See [MCP disconnect behavior](#mcp-disconnect-behavior). |
 | `APPIUM_MCP_WDA_APP_PATH`                 | Optional                               | Absolute path to a pre-extracted `WebDriverAgentRunner-Runner.app` bundle. When set, `prepare_ios_simulator` skips all GitHub downloads and uses this bundle directly — useful in environments where external downloads are blocked                                                                                                                |
 | `REMOTE_SERVER_URL_ALLOW_REGEX`           | Optional                               | Regex pattern that remote Appium server URLs must match. Defaults to `^https?://`                                                                                                                                                                                                                                                                  |
@@ -328,6 +329,30 @@ More models benchmarked can be found [here](src/tests/benchmark_model/TEST_REPOR
 
 ### Performance Optimization
 
+#### MCP Apps Mode
+
+`appium_get_page_source` uses a static MCP App inspector by default when the client advertises MCP Apps support.
+The XML remains in the normal text result for the LLM, while the inspector reads that same result instead of
+receiving a duplicated XML copy.
+
+For clients with unreliable MCP Apps rendering, set `APPIUM_MCP_APPS_ENABLED` to `false` or `0`:
+
+```json
+{
+  "appium-mcp": {
+    "env": {
+      "APPIUM_MCP_APPS_ENABLED": "false"
+    }
+  }
+}
+```
+
+This keeps interactive UI enabled but forces the previous embedded page-source inspector. The compatibility mode
+duplicates the XML inside the inspector HTML and therefore uses more result tokens and bandwidth. With a synthetic
+95,000-character page source, the static mode reduced the result from approximately 267 KB to 95 KB (about 64%).
+
+`NO_UI=true` or `NO_UI=1` takes precedence over this setting and disables both static and embedded UI.
+
 #### NO_UI Mode
 
 Set the `NO_UI` environment variable to `true` or `1` to disable UI components and improve performance:
@@ -342,11 +367,6 @@ Set the `NO_UI` environment variable to `true` or `1` to disable UI components a
   }
 }
 ```
-
-When UI is enabled, `appium_get_page_source` automatically uses a cached static MCP App inspector for clients
-that advertise MCP Apps support. The page source remains in the normal text result for the LLM and text-only
-clients, while the inspector reads that same result instead of receiving a duplicated XML copy. Clients without
-MCP Apps support continue to receive the embedded inspector compatibility fallback.
 
 **Benefits:**
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ Set the `NO_UI` environment variable to `true` or `1` to disable UI components a
 }
 ```
 
+When UI is enabled, `appium_get_page_source` automatically uses a cached static MCP App inspector for clients
+that advertise MCP Apps support. The page source remains in the normal text result for the LLM and text-only
+clients, while the inspector reads that same result instead of receiving a duplicated XML copy. Clients without
+MCP Apps support continue to receive the embedded inspector compatibility fallback.
+
 **Benefits:**
 
 - **Significantly Faster Response Times**: UI rendering and data processing are completely skipped, resulting in 50-80% faster tool responses depending on the operation.

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,12 +1,12 @@
 import log from '../logger.js';
-import {isUIEnabled} from '../ui/mcp-apps.js';
+import {isMcpAppsEnabled} from '../ui/mcp-apps.js';
 // Export all resources
 import javaTemplatesResource from './java/template.js';
 import pageSourceInspectorResource from './page-source-inspector.js';
 
 export default function registerResources(server: any) {
   javaTemplatesResource(server);
-  if (isUIEnabled()) {
+  if (isMcpAppsEnabled()) {
     pageSourceInspectorResource(server);
   }
   log.info('All resources registered');

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,8 +1,13 @@
 import log from '../logger.js';
+import {isUIEnabled} from '../ui/mcp-apps.js';
 // Export all resources
 import javaTemplatesResource from './java/template.js';
+import pageSourceInspectorResource from './page-source-inspector.js';
 
 export default function registerResources(server: any) {
   javaTemplatesResource(server);
+  if (isUIEnabled()) {
+    pageSourceInspectorResource(server);
+  }
   log.info('All resources registered');
 }

--- a/src/resources/page-source-inspector.ts
+++ b/src/resources/page-source-inspector.ts
@@ -1,9 +1,11 @@
+import type {FastMCP} from 'fastmcp';
+
 import {MCP_APP_MIME_TYPE} from '../ui/mcp-apps.js';
 import {createPageSourceInspectorAppUI} from '../ui/page-source-inspector-app.js';
 
 export const PAGE_SOURCE_INSPECTOR_URI = 'ui://appium-mcp/page-source-inspector';
 
-export default function pageSourceInspectorResource(server: any): void {
+export default function pageSourceInspectorResource(server: FastMCP): void {
   server.addResource({
     uri: PAGE_SOURCE_INSPECTOR_URI,
     name: 'Appium Page Source Inspector',

--- a/src/resources/page-source-inspector.ts
+++ b/src/resources/page-source-inspector.ts
@@ -1,0 +1,16 @@
+import {MCP_APP_MIME_TYPE} from '../ui/mcp-apps.js';
+import {createPageSourceInspectorAppUI} from '../ui/page-source-inspector-app.js';
+
+export const PAGE_SOURCE_INSPECTOR_URI = 'ui://appium-mcp/page-source-inspector';
+
+export default function pageSourceInspectorResource(server: any): void {
+  server.addResource({
+    uri: PAGE_SOURCE_INSPECTOR_URI,
+    name: 'Appium Page Source Inspector',
+    description: 'Interactive inspector for appium_get_page_source results',
+    mimeType: MCP_APP_MIME_TYPE,
+    async load() {
+      return {text: createPageSourceInspectorAppUI()};
+    },
+  });
+}

--- a/src/tests/mcp-apps.test.ts
+++ b/src/tests/mcp-apps.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, test} from '@jest/globals';
+
+import {
+  clientSupportsMcpApps,
+  MCP_APPS_EXTENSION_ID,
+  MCP_APP_MIME_TYPE,
+  supportsMcpAppsCapability,
+} from '../ui/mcp-apps.js';
+import {createPageSourceInspectorAppUI} from '../ui/page-source-inspector-app.js';
+
+describe('MCP Apps capability detection', () => {
+  const supportedCapabilities = {
+    extensions: {
+      [MCP_APPS_EXTENSION_ID]: {
+        mimeTypes: [MCP_APP_MIME_TYPE],
+      },
+    },
+  };
+
+  test('accepts clients advertising the stable MCP Apps MIME type', () => {
+    expect(supportsMcpAppsCapability(supportedCapabilities)).toBe(true);
+  });
+
+  test.each([
+    undefined,
+    {},
+    {extensions: {}},
+    {extensions: {[MCP_APPS_EXTENSION_ID]: {}}},
+    {extensions: {[MCP_APPS_EXTENSION_ID]: {mimeTypes: ['text/html']}}},
+  ])('rejects unsupported capabilities %#', (capabilities) => {
+    expect(supportsMcpAppsCapability(capabilities)).toBe(false);
+  });
+
+  test('matches the HTTP session from the tool context', () => {
+    const server = {
+      sessions: [
+        {sessionId: 'first', clientCapabilities: {}},
+        {sessionId: 'second', clientCapabilities: supportedCapabilities},
+      ],
+    };
+
+    expect(clientSupportsMcpApps(server as never, {sessionId: 'second'})).toBe(true);
+    expect(clientSupportsMcpApps(server as never, {sessionId: 'missing'})).toBe(false);
+  });
+
+  test('uses the only session for transports without a session ID', () => {
+    const server = {
+      sessions: [{sessionId: undefined, clientCapabilities: supportedCapabilities}],
+    };
+
+    expect(clientSupportsMcpApps(server as never, undefined)).toBe(true);
+  });
+});
+
+describe('page source inspector MCP App', () => {
+  test('uses the tool result instead of embedding page source data', () => {
+    const html = createPageSourceInspectorAppUI();
+
+    expect(html).toContain("message.method === 'ui/notifications/tool-result'");
+    expect(html).toContain("'ui/initialize'");
+    expect(html).toContain("'ui/notifications/initialized'");
+    expect(html).not.toContain('<hierarchy>');
+  });
+
+  test('contains valid JavaScript', () => {
+    const html = createPageSourceInspectorAppUI();
+    const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
+
+    expect(script).toBeDefined();
+    expect(() => Function(script ?? '')).not.toThrow();
+  });
+});

--- a/src/tests/mcp-apps.test.ts
+++ b/src/tests/mcp-apps.test.ts
@@ -1,12 +1,44 @@
-import {describe, expect, test} from '@jest/globals';
+import {afterEach, describe, expect, test} from '@jest/globals';
 
 import {
   clientSupportsMcpApps,
+  isMcpAppsEnabled,
   MCP_APPS_EXTENSION_ID,
   MCP_APP_MIME_TYPE,
   supportsMcpAppsCapability,
 } from '../ui/mcp-apps.js';
 import {createPageSourceInspectorAppUI} from '../ui/page-source-inspector-app.js';
+
+describe('MCP Apps feature flag', () => {
+  const originalMcpAppsEnabled = process.env.APPIUM_MCP_APPS_ENABLED;
+  const originalNoUI = process.env.NO_UI;
+
+  afterEach(() => {
+    restoreEnv('APPIUM_MCP_APPS_ENABLED', originalMcpAppsEnabled);
+    restoreEnv('NO_UI', originalNoUI);
+  });
+
+  test('is enabled by default', () => {
+    delete process.env.APPIUM_MCP_APPS_ENABLED;
+    delete process.env.NO_UI;
+
+    expect(isMcpAppsEnabled()).toBe(true);
+  });
+
+  test.each(['false', '0'])('is disabled by APPIUM_MCP_APPS_ENABLED=%s', (value) => {
+    process.env.APPIUM_MCP_APPS_ENABLED = value;
+    delete process.env.NO_UI;
+
+    expect(isMcpAppsEnabled()).toBe(false);
+  });
+
+  test.each(['true', '1'])('is disabled when NO_UI=%s', (value) => {
+    process.env.APPIUM_MCP_APPS_ENABLED = 'true';
+    process.env.NO_UI = value;
+
+    expect(isMcpAppsEnabled()).toBe(false);
+  });
+});
 
 describe('MCP Apps capability detection', () => {
   const supportedCapabilities = {
@@ -51,6 +83,14 @@ describe('MCP Apps capability detection', () => {
     expect(clientSupportsMcpApps(server as never, undefined)).toBe(true);
   });
 });
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
 
 describe('page source inspector MCP App', () => {
   test('uses the tool result instead of embedding page source data', () => {

--- a/src/tests/mcp-apps.test.ts
+++ b/src/tests/mcp-apps.test.ts
@@ -54,6 +54,23 @@ describe('MCP Apps capability detection', () => {
   });
 
   test.each([
+    ' text/html;profile=mcp-app ',
+    'text/html; profile=mcp-app',
+    'text/html; profile="mcp-app"',
+    'TEXT/HTML; PROFILE="MCP-APP"',
+  ])('normalizes the advertised MIME type %s', (mimeType) => {
+    const capabilities = {
+      extensions: {
+        [MCP_APPS_EXTENSION_ID]: {
+          mimeTypes: [mimeType],
+        },
+      },
+    };
+
+    expect(supportsMcpAppsCapability(capabilities)).toBe(true);
+  });
+
+  test.each([
     undefined,
     {},
     {extensions: {}},

--- a/src/tests/tools/interactions/get-page-source.test.ts
+++ b/src/tests/tools/interactions/get-page-source.test.ts
@@ -2,6 +2,7 @@ import {beforeEach, describe, expect, jest, test} from '@jest/globals';
 
 const mockGetPageSource = jest.fn(async () => '<hierarchy><node/></hierarchy>');
 const mockClientSupportsMcpApps = jest.fn(() => false);
+const mockIsMcpAppsEnabled = jest.fn(() => true);
 const mockCreatePageSourceInspectorUI = jest.fn((_pageSource: string) => '<html>legacy inspector</html>');
 const mockCreateUIResource = jest.fn((_uri: string, text: string) => ({
   type: 'resource',
@@ -18,7 +19,7 @@ jest.unstable_mockModule('../../../command.js', () => ({
 jest.unstable_mockModule('../../../ui/mcp-apps.js', () => ({
   MCP_APP_MIME_TYPE: 'text/html;profile=mcp-app',
   clientSupportsMcpApps: mockClientSupportsMcpApps,
-  isUIEnabled: jest.fn(() => true),
+  isMcpAppsEnabled: mockIsMcpAppsEnabled,
 }));
 
 jest.unstable_mockModule('../../../ui/mcp-ui-utils.js', () => ({
@@ -56,6 +57,8 @@ describe('appium_get_page_source MCP Apps response', () => {
     mockGetPageSource.mockClear();
     mockClientSupportsMcpApps.mockReset();
     mockClientSupportsMcpApps.mockReturnValue(false);
+    mockIsMcpAppsEnabled.mockReset();
+    mockIsMcpAppsEnabled.mockReturnValue(true);
     mockCreatePageSourceInspectorUI.mockClear();
     mockCreateUIResource.mockClear();
     mockAddUIResourceToResponse.mockClear();
@@ -83,6 +86,19 @@ describe('appium_get_page_source MCP Apps response', () => {
 
     expect(result.content).toHaveLength(2);
     expect(result.content[1]).toMatchObject({type: 'resource'});
+    expect(mockAddUIResourceToResponse).toHaveBeenCalledTimes(1);
+    expect(mockCreatePageSourceInspectorUI).toHaveBeenCalledWith('<hierarchy><node/></hierarchy>');
+  });
+
+  test('omits MCP Apps metadata and forces the embedded fallback when disabled', async () => {
+    mockIsMcpAppsEnabled.mockReturnValue(false);
+    mockClientSupportsMcpApps.mockReturnValue(true);
+    const tool = registerTool();
+
+    const result = await tool.execute({}, {});
+
+    expect(tool._meta).toBeUndefined();
+    expect(result.content).toHaveLength(2);
     expect(mockAddUIResourceToResponse).toHaveBeenCalledTimes(1);
     expect(mockCreatePageSourceInspectorUI).toHaveBeenCalledWith('<hierarchy><node/></hierarchy>');
   });

--- a/src/tests/tools/interactions/get-page-source.test.ts
+++ b/src/tests/tools/interactions/get-page-source.test.ts
@@ -1,0 +1,89 @@
+import {beforeEach, describe, expect, jest, test} from '@jest/globals';
+
+const mockGetPageSource = jest.fn(async () => '<hierarchy><node/></hierarchy>');
+const mockClientSupportsMcpApps = jest.fn(() => false);
+const mockCreatePageSourceInspectorUI = jest.fn((_pageSource: string) => '<html>legacy inspector</html>');
+const mockCreateUIResource = jest.fn((_uri: string, text: string) => ({
+  type: 'resource',
+  resource: {uri: 'ui://legacy', mimeType: 'text/html', text},
+}));
+const mockAddUIResourceToResponse = jest.fn((response: any, factory: () => unknown) => ({
+  content: [...response.content, factory()],
+}));
+
+jest.unstable_mockModule('../../../command.js', () => ({
+  getPageSource: mockGetPageSource,
+}));
+
+jest.unstable_mockModule('../../../ui/mcp-apps.js', () => ({
+  MCP_APP_MIME_TYPE: 'text/html;profile=mcp-app',
+  clientSupportsMcpApps: mockClientSupportsMcpApps,
+  isUIEnabled: jest.fn(() => true),
+}));
+
+jest.unstable_mockModule('../../../ui/mcp-ui-utils.js', () => ({
+  addUIResourceToResponse: mockAddUIResourceToResponse,
+  createPageSourceInspectorUI: mockCreatePageSourceInspectorUI,
+  createUIResource: mockCreateUIResource,
+}));
+
+jest.unstable_mockModule('../../../tools/tool-response.js', () => ({
+  resolveDriver: jest.fn(async () => ({ok: true, driver: {}})),
+  textResult: jest.fn((text: string) => ({content: [{type: 'text', text}]})),
+  errorResult: jest.fn((text: string) => ({content: [{type: 'text', text}], isError: true})),
+  toolErrorMessage: jest.fn((error: unknown) => String(error)),
+}));
+
+const {default: registerGetPageSource} = await import('../../../tools/interactions/get-page-source.js');
+
+function registerTool(): {
+  execute: (args: {sessionId?: string}, context?: Record<string, unknown>) => Promise<any>;
+  _meta?: unknown;
+} {
+  let definition: any;
+  const server = {
+    addTool(tool: any) {
+      definition = tool;
+    },
+    sessions: [],
+  };
+  registerGetPageSource(server as any);
+  return definition;
+}
+
+describe('appium_get_page_source MCP Apps response', () => {
+  beforeEach(() => {
+    mockGetPageSource.mockClear();
+    mockClientSupportsMcpApps.mockReset();
+    mockClientSupportsMcpApps.mockReturnValue(false);
+    mockCreatePageSourceInspectorUI.mockClear();
+    mockCreateUIResource.mockClear();
+    mockAddUIResourceToResponse.mockClear();
+  });
+
+  test('returns one XML copy when the client supports MCP Apps', async () => {
+    mockClientSupportsMcpApps.mockReturnValue(true);
+    const tool = registerTool();
+
+    const result = await tool.execute({}, {});
+
+    expect(tool._meta).toEqual({
+      ui: {resourceUri: 'ui://appium-mcp/page-source-inspector'},
+    });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toContain('<hierarchy><node/></hierarchy>');
+    expect(mockAddUIResourceToResponse).not.toHaveBeenCalled();
+    expect(mockCreatePageSourceInspectorUI).not.toHaveBeenCalled();
+  });
+
+  test('keeps the embedded inspector fallback for other clients', async () => {
+    const tool = registerTool();
+
+    const result = await tool.execute({}, {});
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[1]).toMatchObject({type: 'resource'});
+    expect(mockAddUIResourceToResponse).toHaveBeenCalledTimes(1);
+    expect(mockCreatePageSourceInspectorUI).toHaveBeenCalledWith('<hierarchy><node/></hierarchy>');
+  });
+});

--- a/src/tools/interactions/get-page-source.ts
+++ b/src/tools/interactions/get-page-source.ts
@@ -48,7 +48,7 @@ export default function getPageSource(server: FastMCP): void {
         // Add interactive page source inspector UI
         return addUIResourceToResponse(textResponse, () =>
           createUIResource(
-            `ui://appium-mcp/page-source-inspector/${Date.now()}`,
+            `${PAGE_SOURCE_INSPECTOR_URI}/${Date.now()}`,
             createPageSourceInspectorUI(pageSource),
           ),
         );

--- a/src/tools/interactions/get-page-source.ts
+++ b/src/tools/interactions/get-page-source.ts
@@ -2,16 +2,20 @@ import type {ContentResult, FastMCP} from 'fastmcp';
 import {z} from 'zod';
 
 import {getPageSource as _getPageSource} from '../../command.js';
+import {PAGE_SOURCE_INSPECTOR_URI} from '../../resources/page-source-inspector.js';
+import {clientSupportsMcpApps, isUIEnabled} from '../../ui/mcp-apps.js';
 import {createUIResource, createPageSourceInspectorUI, addUIResourceToResponse} from '../../ui/mcp-ui-utils.js';
 import {resolveDriver, textResult, errorResult, toolErrorMessage} from '../tool-response.js';
 
 export default function getPageSource(server: FastMCP): void {
+  const uiEnabled = isUIEnabled();
   const pageSourceSchema = z.object({
     sessionId: z.string().optional().describe('Session ID to target. If omitted, uses the active session.'),
   });
   server.addTool({
     name: 'appium_get_page_source',
     description: 'Get the page source (XML) from the current screen',
+    _meta: uiEnabled ? {ui: {resourceUri: PAGE_SOURCE_INSPECTOR_URI}} : undefined,
     parameters: pageSourceSchema,
     annotations: {
       readOnlyHint: true,
@@ -19,7 +23,7 @@ export default function getPageSource(server: FastMCP): void {
     },
     execute: async (
       args: z.infer<typeof pageSourceSchema>,
-      _context: Record<string, unknown> | undefined,
+      context: Record<string, unknown> | undefined,
     ): Promise<ContentResult> => {
       const resolved = await resolveDriver(args.sessionId);
       if (!resolved.ok) {
@@ -34,6 +38,12 @@ export default function getPageSource(server: FastMCP): void {
         }
 
         const textResponse = textResult('Page source retrieved successfully: \n' + '```xml ' + pageSource + '```');
+
+        // MCP Apps-capable clients fetch the static inspector once and pass
+        // this existing text result to it, avoiding a second copy of the XML.
+        if (uiEnabled && clientSupportsMcpApps(server, context)) {
+          return textResponse;
+        }
 
         // Add interactive page source inspector UI
         return addUIResourceToResponse(textResponse, () =>

--- a/src/tools/interactions/get-page-source.ts
+++ b/src/tools/interactions/get-page-source.ts
@@ -3,19 +3,19 @@ import {z} from 'zod';
 
 import {getPageSource as _getPageSource} from '../../command.js';
 import {PAGE_SOURCE_INSPECTOR_URI} from '../../resources/page-source-inspector.js';
-import {clientSupportsMcpApps, isUIEnabled} from '../../ui/mcp-apps.js';
+import {clientSupportsMcpApps, isMcpAppsEnabled} from '../../ui/mcp-apps.js';
 import {createUIResource, createPageSourceInspectorUI, addUIResourceToResponse} from '../../ui/mcp-ui-utils.js';
 import {resolveDriver, textResult, errorResult, toolErrorMessage} from '../tool-response.js';
 
 export default function getPageSource(server: FastMCP): void {
-  const uiEnabled = isUIEnabled();
+  const mcpAppsEnabled = isMcpAppsEnabled();
   const pageSourceSchema = z.object({
     sessionId: z.string().optional().describe('Session ID to target. If omitted, uses the active session.'),
   });
   server.addTool({
     name: 'appium_get_page_source',
     description: 'Get the page source (XML) from the current screen',
-    _meta: uiEnabled ? {ui: {resourceUri: PAGE_SOURCE_INSPECTOR_URI}} : undefined,
+    _meta: mcpAppsEnabled ? {ui: {resourceUri: PAGE_SOURCE_INSPECTOR_URI}} : undefined,
     parameters: pageSourceSchema,
     annotations: {
       readOnlyHint: true,
@@ -41,7 +41,7 @@ export default function getPageSource(server: FastMCP): void {
 
         // MCP Apps-capable clients fetch the static inspector once and pass
         // this existing text result to it, avoiding a second copy of the XML.
-        if (uiEnabled && clientSupportsMcpApps(server, context)) {
+        if (mcpAppsEnabled && clientSupportsMcpApps(server, context)) {
           return textResponse;
         }
 

--- a/src/tools/interactions/get-page-source.ts
+++ b/src/tools/interactions/get-page-source.ts
@@ -47,10 +47,7 @@ export default function getPageSource(server: FastMCP): void {
 
         // Add interactive page source inspector UI
         return addUIResourceToResponse(textResponse, () =>
-          createUIResource(
-            `${PAGE_SOURCE_INSPECTOR_URI}/${Date.now()}`,
-            createPageSourceInspectorUI(pageSource),
-          ),
+          createUIResource(`${PAGE_SOURCE_INSPECTOR_URI}/${Date.now()}`, createPageSourceInspectorUI(pageSource)),
         );
       } catch (err: unknown) {
         return errorResult(`Failed to get page source. Error: ${toolErrorMessage(err)}`);

--- a/src/ui/mcp-apps.ts
+++ b/src/ui/mcp-apps.ts
@@ -1,0 +1,39 @@
+import type {FastMCP} from 'fastmcp';
+
+export const MCP_APPS_EXTENSION_ID = 'io.modelcontextprotocol/ui';
+export const MCP_APP_MIME_TYPE = 'text/html;profile=mcp-app';
+
+export function isUIEnabled(): boolean {
+  return process.env.NO_UI !== 'true' && process.env.NO_UI !== '1';
+}
+
+export function supportsMcpAppsCapability(capabilities: unknown): boolean {
+  if (!isRecord(capabilities) || !isRecord(capabilities.extensions)) {
+    return false;
+  }
+
+  const uiCapability = capabilities.extensions[MCP_APPS_EXTENSION_ID];
+  if (!isRecord(uiCapability) || !Array.isArray(uiCapability.mimeTypes)) {
+    return false;
+  }
+
+  return uiCapability.mimeTypes.includes(MCP_APP_MIME_TYPE);
+}
+
+export function clientSupportsMcpApps(
+  server: Pick<FastMCP, 'sessions'>,
+  context: {sessionId?: string} | undefined,
+): boolean {
+  const session =
+    context?.sessionId !== undefined
+      ? server.sessions.find((candidate) => candidate.sessionId === context.sessionId)
+      : server.sessions.length === 1
+        ? server.sessions[0]
+        : undefined;
+
+  return supportsMcpAppsCapability(session?.clientCapabilities);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/ui/mcp-apps.ts
+++ b/src/ui/mcp-apps.ts
@@ -27,7 +27,13 @@ export function supportsMcpAppsCapability(capabilities: unknown): boolean {
     return false;
   }
 
-  return uiCapability.mimeTypes.includes(MCP_APP_MIME_TYPE);
+  return uiCapability.mimeTypes.some((mimeType) => {
+    if (typeof mimeType !== 'string') {
+      return false;
+    }
+
+    return normalizeMimeType(mimeType) === MCP_APP_MIME_TYPE;
+  });
 }
 
 export function clientSupportsMcpApps(
@@ -46,4 +52,8 @@ export function clientSupportsMcpApps(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function normalizeMimeType(mimeType: string): string {
+  return mimeType.replace(/[\s"]/g, '').toLowerCase();
 }

--- a/src/ui/mcp-apps.ts
+++ b/src/ui/mcp-apps.ts
@@ -7,6 +7,16 @@ export function isUIEnabled(): boolean {
   return process.env.NO_UI !== 'true' && process.env.NO_UI !== '1';
 }
 
+/**
+ * MCP Apps are enabled by default when UI is enabled. Set
+ * APPIUM_MCP_APPS_ENABLED=false or 0 to force the embedded UI compatibility
+ * path for clients whose MCP Apps renderer is unreliable.
+ */
+export function isMcpAppsEnabled(): boolean {
+  const configuredValue = process.env.APPIUM_MCP_APPS_ENABLED;
+  return isUIEnabled() && configuredValue !== 'false' && configuredValue !== '0';
+}
+
 export function supportsMcpAppsCapability(capabilities: unknown): boolean {
   if (!isRecord(capabilities) || !isRecord(capabilities.extensions)) {
     return false;

--- a/src/ui/page-source-inspector-app.ts
+++ b/src/ui/page-source-inspector-app.ts
@@ -1,0 +1,249 @@
+/**
+ * Static MCP App used by appium_get_page_source.
+ *
+ * The page source is read from the tool's existing text result, so it is sent
+ * to the client only once instead of being duplicated inside inline HTML.
+ */
+export function createPageSourceInspectorAppUI(): string {
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Source Inspector</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      overflow: hidden;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      font-family: Monaco, Menlo, "Courier New", monospace;
+    }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px 16px;
+      border-bottom: 1px solid #3e3e3e;
+      background: #2d2d2d;
+    }
+    .toolbar-left, .toolbar-right {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .title { font-size: 14px; font-weight: 500; }
+    .info { color: #999; font-size: 12px; }
+    .btn {
+      padding: 6px 12px;
+      border: 0;
+      border-radius: 4px;
+      background: #007aff;
+      color: #fff;
+      cursor: pointer;
+      font: 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .btn:hover { background: #0056b3; }
+    .btn-secondary { background: #444; }
+    .btn-secondary:hover { background: #555; }
+    .search-box {
+      width: 200px;
+      padding: 6px 12px;
+      border: 1px solid #555;
+      border-radius: 4px;
+      outline: none;
+      background: #3e3e3e;
+      color: #d4d4d4;
+      font-size: 13px;
+    }
+    .search-box:focus { border-color: #007aff; }
+    .viewer {
+      height: calc(100vh - 50px);
+      overflow: auto;
+      padding: 16px;
+    }
+    .xml-content {
+      margin: 0;
+      white-space: pre;
+      color: #d4d4d4;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    mark {
+      border-radius: 2px;
+      background: #ffd54f;
+      color: #1e1e1e;
+    }
+    .empty {
+      color: #999;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <div class="toolbar-left">
+      <span class="title">📄 Page Source Inspector</span>
+      <span class="info" id="sourceInfo">Waiting for page source…</span>
+    </div>
+    <div class="toolbar-right">
+      <input type="text" class="search-box" id="searchBox" placeholder="Search…">
+      <button class="btn btn-secondary" id="copyButton">Copy</button>
+      <button class="btn btn-secondary" id="formatButton">Format</button>
+      <button class="btn" id="generateButton">Generate Locators</button>
+    </div>
+  </div>
+  <div class="viewer">
+    <pre class="xml-content empty" id="xmlContent">Waiting for page source…</pre>
+  </div>
+  <script>
+    (() => {
+      const PAGE_SOURCE_PREFIX = 'Page source retrieved successfully: \\n\\\`\\\`\\\`xml ';
+      const xmlContent = document.getElementById('xmlContent');
+      const sourceInfo = document.getElementById('sourceInfo');
+      const searchBox = document.getElementById('searchBox');
+      let source = '';
+      let nextRequestId = 1;
+      const pendingRequests = new Map();
+
+      function sendRequest(method, params) {
+        const id = nextRequestId++;
+        window.parent.postMessage({jsonrpc: '2.0', id, method, params}, '*');
+        return new Promise((resolve, reject) => pendingRequests.set(id, {resolve, reject}));
+      }
+
+      function sendNotification(method, params) {
+        window.parent.postMessage({jsonrpc: '2.0', method, params}, '*');
+      }
+
+      function sourceFromToolResult(result) {
+        const textBlock = result && Array.isArray(result.content)
+          ? result.content.find((item) => item && item.type === 'text' && typeof item.text === 'string')
+          : undefined;
+        if (!textBlock) {
+          return '';
+        }
+
+        let text = textBlock.text;
+        if (text.startsWith(PAGE_SOURCE_PREFIX) && text.endsWith('\`\`\`')) {
+          text = text.slice(PAGE_SOURCE_PREFIX.length, -3);
+        }
+        return text;
+      }
+
+      function appendHighlightedText(container, text, query) {
+        const lowerText = text.toLowerCase();
+        const lowerQuery = query.toLowerCase();
+        let position = 0;
+
+        while (position < text.length) {
+          const matchIndex = lowerText.indexOf(lowerQuery, position);
+          if (matchIndex === -1) {
+            container.appendChild(document.createTextNode(text.slice(position)));
+            return;
+          }
+          if (matchIndex > position) {
+            container.appendChild(document.createTextNode(text.slice(position, matchIndex)));
+          }
+          const mark = document.createElement('mark');
+          mark.textContent = text.slice(matchIndex, matchIndex + query.length);
+          container.appendChild(mark);
+          position = matchIndex + query.length;
+        }
+      }
+
+      function renderSource() {
+        const query = searchBox.value.trim();
+        xmlContent.textContent = '';
+        xmlContent.classList.toggle('empty', source.length === 0);
+        if (!source) {
+          xmlContent.textContent = 'No page source was returned.';
+        } else if (!query) {
+          xmlContent.textContent = source;
+        } else {
+          appendHighlightedText(xmlContent, source, query);
+        }
+        sourceInfo.textContent = source.length + ' characters';
+      }
+
+      function setSource(nextSource) {
+        source = nextSource;
+        renderSource();
+      }
+
+      function formatXML() {
+        if (!source) return;
+        try {
+          const parser = new DOMParser();
+          const documentNode = parser.parseFromString(source, 'text/xml');
+          if (documentNode.querySelector('parsererror')) {
+            throw new Error('Invalid XML');
+          }
+          source = new XMLSerializer().serializeToString(documentNode);
+          renderSource();
+        } catch {
+          window.alert('Failed to format XML');
+        }
+      }
+
+      async function copyToClipboard() {
+        if (!source) return;
+        try {
+          await navigator.clipboard.writeText(source);
+        } catch {
+          window.alert('Failed to copy page source');
+        }
+      }
+
+      async function generateLocators() {
+        try {
+          await sendRequest('tools/call', {name: 'generate_locators', arguments: {}});
+        } catch {
+          window.alert('Failed to generate locators');
+        }
+      }
+
+      window.addEventListener('message', (event) => {
+        if (event.source !== window.parent) return;
+        const message = event.data;
+        if (!message || message.jsonrpc !== '2.0') return;
+
+        if (message.id !== undefined && pendingRequests.has(message.id)) {
+          const pending = pendingRequests.get(message.id);
+          pendingRequests.delete(message.id);
+          if (message.error) {
+            pending.reject(new Error(message.error.message || 'MCP App request failed'));
+          } else {
+            pending.resolve(message.result);
+          }
+          return;
+        }
+
+        if (message.method === 'ui/notifications/tool-result') {
+          setSource(sourceFromToolResult(message.params));
+        }
+      });
+
+      searchBox.addEventListener('input', renderSource);
+      document.getElementById('copyButton').addEventListener('click', copyToClipboard);
+      document.getElementById('formatButton').addEventListener('click', formatXML);
+      document.getElementById('generateButton').addEventListener('click', generateLocators);
+
+      sendRequest('ui/initialize', {
+        protocolVersion: '2026-01-26',
+        appInfo: {name: 'Appium Page Source Inspector', version: '1.0.0'},
+        appCapabilities: {availableDisplayModes: ['inline', 'fullscreen']},
+      })
+        .then(() => sendNotification('ui/notifications/initialized', {}))
+        .catch(() => {
+          sourceInfo.textContent = 'Unable to initialize inspector';
+        });
+    })();
+  </script>
+</body>
+</html>
+  `;
+}


### PR DESCRIPTION
## Summary

- register a static MCP App resource for the page-source inspector
- reuse the existing XML text result as the inspector data for MCP Apps-capable clients
- retain the current embedded HTML inspector for clients that do not advertise MCP Apps support
- add `APPIUM_MCP_APPS_ENABLED=false/0` to force the embedded compatibility path
- keep `NO_UI=true/1` behavior unchanged

## Why

`appium_get_page_source` currently returns the full XML as text and duplicates it inside an inline HTML resource. This makes a large page source substantially larger in the model-visible tool result.

MCP Apps-capable clients can fetch and cache a static inspector, then pass the existing tool result to it. A synthetic 95,000-character page source measured:

- current embedded result: about 267 KB
- static MCP App result: about 95 KB
- per-call reduction: about 172 KB (64%)

MCP Apps remain enabled by default. Clients with unreliable MCP Apps rendering can set:

```bash
APPIUM_MCP_APPS_ENABLED=false
```

This keeps interactive UI enabled but removes the static resource metadata and forces the previous embedded inspector. The fallback favors compatibility at the cost of duplicating the XML and using more result tokens and bandwidth. `NO_UI=true/1` still takes precedence and disables all UI.

Part of #470.

## Validation

- `npm run build`
- `npm run check`
- `npm run audit:tools`
- `npm test -- --runInBand` (31 suites, 350 tests)
- verified enabled discovery exposes the `text/html;profile=mcp-app` inspector and tool UI metadata
- verified disabled discovery omits both the inspector resource and tool UI metadata
- enabled UI discovery: 44,658 chars
- disabled/`NO_UI` discovery: 44,587 chars (45,000-char budget)

<img width="829" height="501" alt="Screenshot 2026-07-26 at 5 47 13 PM" src="https://github.com/user-attachments/assets/2eff3383-b9b7-4e4b-b45b-6c2bb43b33ef" />
