### PR TITLE
fix(context): surface driver errors instead of empty context list

### DIFF
--- a/src/tests/tools/context/context.test.ts
+++ b/src/tests/tools/context/context.test.ts
@@ -29,9 +29,10 @@ jest.unstable_mockModule('../../../ui/mcp-ui-utils', () => ({
   addUIResourceToResponse: jest.fn((_result: unknown) => _result),
 }));
 
-const {getCurrentContext} = await import('../../../command.js');
+const {getCurrentContext, getContexts} = await import('../../../command.js');
 
 const mockGetCurrentContext = getCurrentContext as jest.MockedFunction<typeof getCurrentContext>;
+const mockGetContexts = getContexts as jest.MockedFunction<typeof getContexts>;
 
 describe('appium_context tool', () => {
   const mockServer = {addTool: jest.fn()} as any;
@@ -45,6 +46,7 @@ describe('appium_context tool', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetCurrentContext.mockResolvedValue('NATIVE_APP');
+    mockGetContexts.mockResolvedValue(['NATIVE_APP', 'WEBVIEW_com.example']);
   });
 
   test('setCurrentContext uses sessionId on list', async () => {
@@ -69,5 +71,16 @@ describe('appium_context tool', () => {
     );
 
     expect(mockSetCurrentContext).toHaveBeenLastCalledWith('WEBVIEW_com.example', 'session-b');
+  });
+
+  test('surfaces driver errors instead of reporting no contexts', async () => {
+    const tool = await getToolExecute();
+    mockGetContexts.mockRejectedValue(new Error('session is not started'));
+
+    const result = await tool.execute({action: 'list', sessionId: 'session-b'}, undefined);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('session is not started');
+    expect(result.content[0].text).not.toContain('No contexts available');
   });
 });

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -36,10 +36,7 @@ export default function context(server: FastMCP): void {
       const {driver} = resolved;
 
       try {
-        const [currentContext, availableContexts] = await Promise.all([
-          getCurrentContext(driver),
-          getContexts(driver),
-        ]);
+        const [currentContext, availableContexts] = await Promise.all([getCurrentContext(driver), getContexts(driver)]);
 
         if (currentContext) {
           setCurrentContext(currentContext, args.sessionId);

--- a/src/tools/context/context.ts
+++ b/src/tools/context/context.ts
@@ -37,8 +37,8 @@ export default function context(server: FastMCP): void {
 
       try {
         const [currentContext, availableContexts] = await Promise.all([
-          getCurrentContext(driver).catch(() => null),
-          getContexts(driver).catch(() => [] as string[]),
+          getCurrentContext(driver),
+          getContexts(driver),
         ]);
 
         if (currentContext) {


### PR DESCRIPTION
### Problem

`appium_context` swallowed failures from `getCurrentContext` / `getContexts` with `.catch(() => null)` / `.catch(() => [])`, so a real driver/session error was reported as "No contexts available."

### Fix

Let those calls reject into the existing try/catch so the tool returns the actual error.

### Test

Extended `context.test.ts` to assert a driver failure surfaces the error message and does not report an empty context list.