### PR TITLE
fix(app-management): use simctl --json instead of a shell pipe for simulator app list

### DIFF
--- a/src/tests/tools/app-management/list-apps.test.ts
+++ b/src/tests/tools/app-management/list-apps.test.ts
@@ -1,0 +1,74 @@
+import {beforeEach, describe, expect, jest, test} from '@jest/globals';
+
+const SIMULATOR_LISTAPPS_JSON = JSON.stringify({
+  'com.example.app': {CFBundleDisplayName: 'Example', CFBundleName: 'ExampleApp'},
+  'com.example.other': {CFBundleName: 'Other'},
+});
+
+const mockExec = jest.fn(
+  async (_cmd: string, _args: string[]): Promise<{stdout: string}> => ({
+    stdout: SIMULATOR_LISTAPPS_JSON,
+  }),
+);
+
+jest.unstable_mockModule('teen_process', () => ({
+  exec: mockExec,
+}));
+
+jest.unstable_mockModule('../../../command.js', () => ({
+  execute: jest.fn(async () => ({})),
+}));
+
+jest.unstable_mockModule('../../../session-store.js', () => ({
+  getPlatformName: jest.fn(() => 'iOS'),
+  isRemoteDriverSession: jest.fn(() => false),
+  isAndroidUiautomator2DriverSession: jest.fn(() => false),
+  isXCUITestDriverSession: jest.fn(() => true),
+  PLATFORM: {ios: 'iOS', android: 'Android'},
+}));
+
+jest.unstable_mockModule('../../../ui/mcp-ui-utils.js', () => ({
+  createUIResource: jest.fn(() => ({})),
+  createAppListUI: jest.fn(() => ''),
+  addUIResourceToResponse: jest.fn((response: unknown) => response),
+}));
+
+jest.unstable_mockModule('../../../tools/tool-response.js', () => ({
+  resolveDriver: jest.fn(async () => ({ok: true, driver: {}})),
+  textResult: jest.fn((text: string) => ({content: [{type: 'text', text}]})),
+  errorResult: jest.fn((text: string) => ({content: [{type: 'text', text}], isError: true})),
+  toolErrorMessage: jest.fn((error: unknown) => String(error)),
+}));
+
+const {listAppsFromDevice} = await import('../../../tools/app-management/list-apps.js');
+
+const simulatorDriver = {
+  isSimulator: () => true,
+  caps: {udid: 'SIM-UDID'},
+};
+
+describe('listAppsFromDevice on an iOS simulator', () => {
+  beforeEach(() => {
+    mockExec.mockClear();
+  });
+
+  test('asks simctl for json directly instead of piping to plutil', async () => {
+    // teen_process spawns without a shell, so a '|' argument would be passed
+    // through to simctl as a literal rather than creating a pipeline.
+    await listAppsFromDevice(simulatorDriver as never);
+
+    expect(mockExec).toHaveBeenCalledWith('xcrun', ['simctl', 'listapps', 'SIM-UDID', '--json']);
+    const args = mockExec.mock.calls[0][1];
+    expect(args).not.toContain('|');
+    expect(args).not.toContain('plutil');
+  });
+
+  test('normalizes the simctl payload into package/app names', async () => {
+    const apps = await listAppsFromDevice(simulatorDriver as never);
+
+    expect(apps).toEqual([
+      {packageName: 'com.example.app', appName: 'Example'},
+      {packageName: 'com.example.other', appName: 'Other'},
+    ]);
+  });
+});

--- a/src/tools/app-management/list-apps.ts
+++ b/src/tools/app-management/list-apps.ts
@@ -43,18 +43,7 @@ export async function listAppsFromDevice(
       if (!udid) {
         throw new Error('Could not determine simulator UDID from session capabilities');
       }
-      const {stdout} = await exec('xcrun', [
-        'simctl',
-        'listapps',
-        udid,
-        '|',
-        'plutil',
-        '-convert',
-        'json',
-        '-o',
-        '-',
-        '-',
-      ]);
+      const {stdout} = await exec('xcrun', ['simctl', 'listapps', udid, '--json']);
       const result = JSON.parse(stdout);
       return normalizeListAppsResult(result || {});
     }


### PR DESCRIPTION
### Problem

Listing apps on an iOS simulator passes a shell pipe as `spawn` arguments:

```js
exec('xcrun', ['simctl', 'listapps', udid, '|', 'plutil', '-convert', 'json', '-o', '-', '-'])
```

`teen_process.exec` spawns without a shell, so `|`, `plutil` and the rest are handed to `simctl listapps` as literal arguments instead of forming a pipeline. The simulator app list never gets converted to JSON, so `appium_app_lifecycle action=list` and name-based app resolution fail on local simulator sessions.

This regressed in #423, which converted the original `child_process.exec` shell string (`xcrun simctl listapps "$udid" | plutil -convert json -o - -`) into an argv array. The pipe was preserved as an argument.

### Fix

Ask `simctl` for JSON directly with `--json`, which is what `prepare-ios-simulator.ts` already does when it reads the simulator app list:

https://github.com/appium/appium-mcp/blob/main/src/tools/ios/prepare-ios-simulator.ts#L180

This drops the `plutil` dependency entirely and keeps the two simulator code paths consistent.

### Test

Added `src/tests/tools/app-management/list-apps.test.ts` covering the simulator branch:

- `simctl` is invoked as `['simctl', 'listapps', udid, '--json']`, with no `|` or `plutil` argument
- the returned payload is normalized into package/app name pairs
