### PR TITLE
fix(app-management): resolve app names against rehydrated sessions

### DIFF
--- a/src/tests/tools/app-management/resolve-app-id.test.ts
+++ b/src/tests/tools/app-management/resolve-app-id.test.ts
@@ -1,0 +1,50 @@
+import {beforeEach, describe, expect, jest, test} from '@jest/globals';
+
+const rehydratedDriver = {rehydrated: true};
+
+const mockResolveDriver = jest.fn<(sessionId?: string) => Promise<any>>();
+const mockListAppsFromDevice = jest.fn<(...args: any[]) => Promise<{packageName: string; appName: string}[]>>();
+
+jest.unstable_mockModule('../../../session-store', () => ({
+  // The in-memory cache is empty after an MCP process recycle.
+  getDriver: jest.fn(() => null),
+  getSessionId: jest.fn(() => undefined),
+  getPlatformName: jest.fn(() => 'Android'),
+  isXCUITestDriverSession: jest.fn(() => false),
+  PLATFORM: {ios: 'iOS', android: 'Android'},
+}));
+
+jest.unstable_mockModule('../../../tools/tool-response', () => ({
+  resolveDriver: mockResolveDriver,
+  noActiveDriverSessionMessage: (sessionId?: string) =>
+    `No active driver session${sessionId ? ` for session '${sessionId}'` : ''}.`,
+}));
+
+jest.unstable_mockModule('../../../tools/app-management/list-apps.js', () => ({
+  listAppsFromDevice: mockListAppsFromDevice,
+}));
+
+const {resolveAppId} = await import('../../../tools/app-management/resolve-app-id.js');
+
+describe('resolveAppId on a persisted session', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListAppsFromDevice.mockResolvedValue([{packageName: 'com.example.calc', appName: 'Calculator'}]);
+  });
+
+  test('rehydrates the session instead of failing on an empty driver cache', async () => {
+    mockResolveDriver.mockResolvedValue({ok: true, driver: rehydratedDriver});
+
+    await expect(resolveAppId('Calculator', 'persisted-1')).resolves.toBe('com.example.calc');
+
+    expect(mockResolveDriver).toHaveBeenCalledWith('persisted-1');
+    expect(mockListAppsFromDevice).toHaveBeenCalledWith(rehydratedDriver, 'User');
+  });
+
+  test('reports no active driver session when the session cannot be resolved', async () => {
+    mockResolveDriver.mockResolvedValue({ok: false, result: {content: [], isError: true}});
+
+    await expect(resolveAppId('Calculator', 'missing')).rejects.toThrow(/No active driver session/);
+    expect(mockListAppsFromDevice).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/app-management/resolve-app-id.ts
+++ b/src/tools/app-management/resolve-app-id.ts
@@ -1,7 +1,7 @@
 import type {XCUITestDriver} from 'appium-xcuitest-driver';
 
-import {getSessionId, getDriver, getPlatformName, PLATFORM, isXCUITestDriverSession} from '../../session-store.js';
-import {noActiveDriverSessionMessage} from '../tool-response.js';
+import {getSessionId, getPlatformName, PLATFORM, isXCUITestDriverSession} from '../../session-store.js';
+import {noActiveDriverSessionMessage, resolveDriver} from '../tool-response.js';
 import {listAppsFromDevice} from './list-apps.js';
 
 interface CacheEntry {
@@ -89,10 +89,11 @@ async function getInstalledApps(sessionId?: string): Promise<{packageName: strin
     return cached.apps;
   }
 
-  const driver = getDriver(sessionId);
-  if (!driver) {
+  const resolved = await resolveDriver(sessionId);
+  if (!resolved.ok) {
     throw new Error(noActiveDriverSessionMessage(sessionId));
   }
+  const {driver} = resolved;
 
   const platform = getPlatformName(driver);
 


### PR DESCRIPTION
### Problem

`getInstalledApps` looks the driver up with the raw store getter:

```ts
const driver = getDriver(sessionId);
if (!driver) {
  throw new Error(noActiveDriverSessionMessage(sessionId));
}
```

That skips `resolveDriver`, so it never re-attaches a persisted remote session. After an MCP process recycle, `appium_app_lifecycle` resolved **by name** fails with "No active driver session" while the same action **by id** succeeds on the same session, because the lifecycle handlers (`activate`, `terminate`, `uninstall`, …) call `resolveDriver` themselves but only after `resolveId` has already run.

`permissions.ts` does not hit this, since it calls `resolveDriver` before `resolveAppId`.

### Fix

Resolve the driver through `resolveDriver` so name lookups rehydrate the session like every other tool. The thrown message is unchanged when the session genuinely cannot be resolved.

### Test

Added `src/tests/tools/app-management/resolve-app-id.test.ts`:

- with an empty in-memory driver cache, the name is resolved against the rehydrated driver
- an unresolvable session still reports "No active driver session" and never queries the device
