### PR TITLE
fix(app-management): surface app list failures instead of caching an empty list

### DIFF
--- a/src/tests/tools/app-management/resolve-app-id.test.ts
+++ b/src/tests/tools/app-management/resolve-app-id.test.ts
@@ -4,13 +4,15 @@ const rehydratedDriver = {rehydrated: true};
 
 const mockResolveDriver = jest.fn<(sessionId?: string) => Promise<any>>();
 const mockListAppsFromDevice = jest.fn<(...args: any[]) => Promise<{packageName: string; appName: string}[]>>();
+const mockGetPlatformName = jest.fn<() => string>();
+const mockIsXCUITestDriverSession = jest.fn<() => boolean>();
 
 jest.unstable_mockModule('../../../session-store', () => ({
   // The in-memory cache is empty after an MCP process recycle.
   getDriver: jest.fn(() => null),
   getSessionId: jest.fn(() => undefined),
-  getPlatformName: jest.fn(() => 'Android'),
-  isXCUITestDriverSession: jest.fn(() => false),
+  getPlatformName: mockGetPlatformName,
+  isXCUITestDriverSession: mockIsXCUITestDriverSession,
   PLATFORM: {ios: 'iOS', android: 'Android'},
 }));
 
@@ -26,12 +28,14 @@ jest.unstable_mockModule('../../../tools/app-management/list-apps.js', () => ({
 
 const {resolveAppId} = await import('../../../tools/app-management/resolve-app-id.js');
 
-describe('resolveAppId on a persisted session', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockListAppsFromDevice.mockResolvedValue([{packageName: 'com.example.calc', appName: 'Calculator'}]);
-  });
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPlatformName.mockReturnValue('Android');
+  mockIsXCUITestDriverSession.mockReturnValue(false);
+  mockListAppsFromDevice.mockResolvedValue([{packageName: 'com.example.calc', appName: 'Calculator'}]);
+});
 
+describe('resolveAppId on a persisted session', () => {
   test('rehydrates the session instead of failing on an empty driver cache', async () => {
     mockResolveDriver.mockResolvedValue({ok: true, driver: rehydratedDriver});
 
@@ -46,5 +50,32 @@ describe('resolveAppId on a persisted session', () => {
 
     await expect(resolveAppId('Calculator', 'missing')).rejects.toThrow(/No active driver session/);
     expect(mockListAppsFromDevice).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveAppId on a real iOS device', () => {
+  const deviceDriver = {isSimulator: () => false};
+
+  beforeEach(() => {
+    mockGetPlatformName.mockReturnValue('iOS');
+    mockIsXCUITestDriverSession.mockReturnValue(true);
+    mockResolveDriver.mockResolvedValue({ok: true, driver: deviceDriver});
+  });
+
+  test('keeps the apps that were listed when only one app type fails', async () => {
+    mockListAppsFromDevice
+      .mockResolvedValueOnce([{packageName: 'com.example.calc', appName: 'Calculator'}])
+      .mockRejectedValueOnce(new Error('System app list unavailable'));
+
+    await expect(resolveAppId('Calculator', 'device-1')).resolves.toBe('com.example.calc');
+  });
+
+  test('reports the device failure instead of caching an empty app list', async () => {
+    mockListAppsFromDevice.mockRejectedValue(new Error('Could not list applications on the device'));
+
+    await expect(resolveAppId('Calculator', 'device-2')).rejects.toThrow(/Could not list applications/);
+
+    mockListAppsFromDevice.mockResolvedValue([{packageName: 'com.example.calc', appName: 'Calculator'}]);
+    await expect(resolveAppId('Calculator', 'device-2')).resolves.toBe('com.example.calc');
   });
 });

--- a/src/tools/app-management/resolve-app-id.ts
+++ b/src/tools/app-management/resolve-app-id.ts
@@ -107,6 +107,10 @@ async function getInstalledApps(sessionId?: string): Promise<{packageName: strin
       listAppsFromDevice(driver, 'User'),
       listAppsFromDevice(driver, 'System'),
     ]);
+    const failures = results.filter((result) => result.status === 'rejected');
+    if (failures.length === results.length) {
+      throw failures[0].reason;
+    }
     const seen = new Set<string>();
     apps = [];
     for (const result of results) {


### PR DESCRIPTION
On a real iOS device `getInstalledApps` fetches the User and System app lists through `Promise.allSettled` so that a failure on one type does not discard the other. When both lookups fail, the loop still produces an empty array and that empty list is cached for the full 60s TTL.

Two things go wrong from there:

- the caller gets `No installed app matched the name <name>` instead of the actual device error, which points at the wrong problem
- every later `name`-based lookup keeps failing the same way for a minute, even after the device recovers, because the empty list is served from the cache

Rethrow the first rejection when every lookup failed, so the driver error reaches the caller and nothing is cached. Partial failures keep the existing behaviour. This also matches the Android/simulator branch, which already lets the failure propagate.