### PR TITLE
fix(locator): prefer accessibility id

### DIFF
--- a/src/locators/locator-generation.ts
+++ b/src/locators/locator-generation.ts
@@ -124,11 +124,11 @@ export function getSuggestedLocators(
   let priorityOrder: string[];
 
   if (isNative && (automationName === 'xcuitest' || automationName === 'mac2')) {
-    // iOS priority: Accessibility Id > Predicate > Class Chain > XPath > Class Name
-    priorityOrder = ['id', 'accessibility id', '-ios predicate string', '-ios class chain', 'xpath', 'class name'];
+    // iOS priority: Accessibility Id > Id > Predicate > Class Chain > XPath > Class Name
+    priorityOrder = ['accessibility id', 'id', '-ios predicate string', '-ios class chain', 'xpath', 'class name'];
   } else if (isNative && automationName === 'uiautomator2') {
-    // Android priority: Accessibility Id > UiAutomator > XPath > Class Name
-    priorityOrder = ['id', 'accessibility id', 'xpath', '-android uiautomator', 'class name'];
+    // Android priority: Accessibility Id > Id > XPath > UiAutomator > Class Name
+    priorityOrder = ['accessibility id', 'id', 'xpath', '-android uiautomator', 'class name'];
   } else {
     priorityOrder = ['id', 'class name', 'xpath'];
   }

--- a/src/tools/interactions/handle-alert.ts
+++ b/src/tools/interactions/handle-alert.ts
@@ -7,7 +7,7 @@ import {getPlatformName, PLATFORM} from '../../session-store.js';
 import type {DriverInstance} from '../../session-store.js';
 import {resolveDriver, textResult, errorResult, toolErrorMessage} from '../tool-response.js';
 
-const ANDROID_LOCATOR_STRATEGY_ORDER = ['id', 'accessibility id', 'xpath', '-android uiautomator', 'class name'];
+const ANDROID_LOCATOR_STRATEGY_ORDER = ['accessibility id', 'id', 'xpath', '-android uiautomator', 'class name'];
 
 export default function alert(server: FastMCP): void {
   const appiumAlertSchema = z.object({


### PR DESCRIPTION
Prefer accessibility id as first priority, new order:

Android - `['accessibility id', 'id', 'xpath', '-android uiautomator', 'class name']`
iOS - `['accessibility id', 'id', '-ios predicate string', '-ios class chain', 'xpath', 'class name']`