### PR TITLE
fix(alert): read W3C element id for Android custom button clicks

### DIFF
--- a/src/tests/tools/interactions/handle-alert.test.ts
+++ b/src/tests/tools/interactions/handle-alert.test.ts
@@ -81,7 +81,7 @@ describe('appium_alert Android custom button', () => {
     expect(mockElementClick).not.toHaveBeenCalled();
   });
 
-  test('clicks the resolved element when findElement succeeds', async () => {
+  test('clicks the resolved W3C element id when findElement succeeds', async () => {
     mockFindElement.mockResolvedValue({
       'element-6066-11e4-a52e-4f735466cecf': 'el-1',
     });
@@ -90,6 +90,16 @@ describe('appium_alert Android custom button', () => {
     const result = await tool.execute({action: 'accept', buttonLabel: 'OK'}, undefined);
 
     expect(result.isError).toBeFalsy();
-    expect(mockElementClick).toHaveBeenCalledTimes(1);
+    expect(mockElementClick).toHaveBeenCalledWith(expect.anything(), 'el-1');
+  });
+
+  test('clicks the legacy ELEMENT id when findElement returns it', async () => {
+    mockFindElement.mockResolvedValue({ELEMENT: 'legacy-el-1'});
+
+    const tool = await loadTool();
+    const result = await tool.execute({action: 'accept', buttonLabel: 'OK'}, undefined);
+
+    expect(result.isError).toBeFalsy();
+    expect(mockElementClick).toHaveBeenCalledWith(expect.anything(), 'legacy-el-1');
   });
 });

--- a/src/tools/interactions/handle-alert.ts
+++ b/src/tools/interactions/handle-alert.ts
@@ -5,7 +5,7 @@ import {elementClick, execute, findElement, getPageSource} from '../../command.j
 import {generateAllElementLocators} from '../../locators/generate-all-locators.js';
 import {getPlatformName, PLATFORM} from '../../session-store.js';
 import type {DriverInstance} from '../../session-store.js';
-import {resolveDriver, textResult, errorResult, toolErrorMessage} from '../tool-response.js';
+import {readWebElementId, resolveDriver, textResult, errorResult, toolErrorMessage} from '../tool-response.js';
 
 const ANDROID_LOCATOR_STRATEGY_ORDER = ['accessibility id', 'id', 'xpath', '-android uiautomator', 'class name'];
 
@@ -99,8 +99,11 @@ async function handleAndroidAlert(driver: DriverInstance, action: string, button
     if (!button) {
       throw new Error('Could not find element with any generated locator; it may have disappeared');
     }
-    const buttonUUID = button.ELEMENT || button;
-    await elementClick(driver, buttonUUID);
+    const buttonId = readWebElementId(button);
+    if (!buttonId) {
+      throw new Error('Element was returned without a valid element ID');
+    }
+    await elementClick(driver, buttonId);
   } else {
     if (action === 'accept') {
       await execute(driver, 'mobile: acceptAlert', {});


### PR DESCRIPTION
On remote Android sessions, `findElement` returns the W3C element payload `{ 'element-6066-11e4-a52e-4f735466cecf': '…' }`. The custom `buttonLabel` path still used `button.ELEMENT || button`, so `elementClick` received the whole object instead of the string id.

Use `readWebElementId` (same helper as `appium_find_element` and `appium_active_element`) and fail clearly when no id is present. Tests now assert the id passed to `elementClick` for both W3C and legacy `ELEMENT` shapes.