### PR TITLE
fix(stdio): keep Appium and WebDriver logs off JSON-RPC stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,8 @@ const server = await createAppiumMcpServer({
 await server.start({ transportType: 'stdio' });
 ```
 
+`start({ transportType: 'stdio' })` keeps Appium and WebDriver logs off stdout so JSON-RPC stays intact. httpStream is unchanged.
+
 Plugin lifecycle:
 
 - `register(registry, core)`: called during server construction. Register custom tools, prompts, resources, and resource templates here.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@appium/support": "^7.0.2",
     "@modelcontextprotocol/sdk": "^1.22.0",
+    "@wdio/logger": "^9.29.1",
     "@xmldom/xmldom": "^0.9.8",
     "appium-adb": "^16.0.0",
     "appium-ios-device": "^3.1.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,12 +1,17 @@
-import log from '../logger.js';
+import log, {configureStdioTransportLogging} from '../logger.js';
 
 export async function runCli(args: string[] = process.argv.slice(2)): Promise<void> {
   const command = args[0];
   if (command === '--help' || command === '-h' || command === 'help') {
     printHelp();
-  } else {
-    await startServer(args);
+    return;
   }
+
+  if (!args.includes('--httpStream')) {
+    configureStdioTransportLogging();
+  }
+
+  await startServer(args);
 }
 
 function printHelp(): void {

--- a/src/core.ts
+++ b/src/core.ts
@@ -7,6 +7,7 @@
  */
 export {createAppiumMcpServer} from './create-server.js';
 export type {CreateAppiumMcpServerOptions} from './create-server.js';
+export {configureStdioTransportLogging} from './logger.js';
 export {evaluatePolicyTarget} from './policy.js';
 export type {AppiumMcpPolicy, PolicyDecision, PolicyDecisionReason, PolicyTargetKind} from './policy.js';
 export {AppiumMcpCore, formatVerificationReport, McpRegistry, PluginManager, verifyAppiumMcpNames} from './plugin.js';

--- a/src/create-server.ts
+++ b/src/create-server.ts
@@ -16,7 +16,7 @@
 import {FastMCP} from 'fastmcp';
 
 import pkg from '../package.json' with {type: 'json'};
-import log from './logger.js';
+import log, {configureStdioTransportLogging} from './logger.js';
 import {PluginManager} from './plugin.js';
 import type {AppiumMcpPlugin} from './plugin.js';
 import {installPolicy, type AppiumMcpPolicy} from './policy.js';
@@ -118,6 +118,7 @@ export async function createAppiumMcpServer(options: CreateAppiumMcpServerOption
       enabled: false,
     },
   });
+  wrapStartForStdioLogging(server);
 
   installPolicy(server, policy);
   try {
@@ -261,6 +262,16 @@ export async function createAppiumMcpServer(options: CreateAppiumMcpServerOption
   });
 
   return server;
+}
+
+function wrapStartForStdioLogging(server: FastMCP): void {
+  const originalStart = server.start.bind(server);
+  server.start = (async (startOptions) => {
+    if ((startOptions?.transportType ?? 'stdio') === 'stdio') {
+      configureStdioTransportLogging();
+    }
+    return originalStart(startOptions);
+  }) as FastMCP['start'];
 }
 
 function disconnectSessionPolicyFromEnv(): DisconnectSessionPolicy {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,29 @@
 import {logger} from '@appium/support';
 
+import {isStdioTransportLoggingConfigured, markStdioTransportLoggingConfigured} from './stdio-logging-state.js';
+
 const log = logger.getLogger('appium-mcp');
+
+/** npmlog must not write to stdout (stdio JSON-RPC). Skip if the host already set a custom stream. */
+export function ensureLoggerWritesToStderr(): void {
+  const root = log.unwrap();
+  if (root.stream === process.stdout) {
+    root.stream = process.stderr;
+  }
+}
+
+/** stdio transport: drop info/debug so they cannot sit on stdout. */
+export function configureStdioTransportLogging(): void {
+  if (isStdioTransportLoggingConfigured()) {
+    return;
+  }
+  markStdioTransportLoggingConfigured();
+  ensureLoggerWritesToStderr();
+  log.level = 'warn';
+  if (!process.env.WDIO_LOG_LEVEL) {
+    process.env.WDIO_LOG_LEVEL = 'warn';
+  }
+}
 
 export default log;
 export {log};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,7 @@
 import {logger} from '@appium/support';
 
 import {isStdioTransportLoggingConfigured, markStdioTransportLoggingConfigured} from './stdio-logging-state.js';
+import {quietExistingWdioLoggers} from './utils/wdio-logging.js';
 
 const log = logger.getLogger('appium-mcp');
 
@@ -20,9 +21,7 @@ export function configureStdioTransportLogging(): void {
   markStdioTransportLoggingConfigured();
   ensureLoggerWritesToStderr();
   log.level = 'warn';
-  if (!process.env.WDIO_LOG_LEVEL) {
-    process.env.WDIO_LOG_LEVEL = 'warn';
-  }
+  quietExistingWdioLoggers();
 }
 
 export default log;

--- a/src/stdio-logging-state.ts
+++ b/src/stdio-logging-state.ts
@@ -1,0 +1,9 @@
+let stdioLoggingConfigured = false;
+
+export function isStdioTransportLoggingConfigured(): boolean {
+  return stdioLoggingConfigured;
+}
+
+export function markStdioTransportLoggingConfigured(): void {
+  stdioLoggingConfigured = true;
+}

--- a/src/tests/__mocks__/@appium/support.ts
+++ b/src/tests/__mocks__/@appium/support.ts
@@ -2,6 +2,10 @@ import {constants, existsSync, promises as fsPromises} from 'node:fs';
 
 const noop = () => {};
 
+const npmlog = {
+  stream: process.stderr as NodeJS.WritableStream | null,
+};
+
 export const logger = {
   getLogger: (_name: string) => ({
     debug: noop,
@@ -9,6 +13,8 @@ export const logger = {
     warn: noop,
     error: noop,
     trace: noop,
+    level: 'info' as string,
+    unwrap: () => npmlog,
   }),
 };
 

--- a/src/tests/create-server.test.ts
+++ b/src/tests/create-server.test.ts
@@ -93,6 +93,8 @@ class MockFastMCP {
       await handler(event);
     }
   }
+
+  async start(_options?: unknown): Promise<void> {}
 }
 
 await jest.unstable_mockModule('fastmcp', () => ({
@@ -147,6 +149,8 @@ await jest.unstable_mockModule('../session-store', () => ({
   safeDeleteAllSessions,
 }));
 
+const configureStdioTransportLogging = jest.fn();
+
 await jest.unstable_mockModule('../logger', () => ({
   default: {
     debug: jest.fn(),
@@ -154,6 +158,7 @@ await jest.unstable_mockModule('../logger', () => ({
     warn: jest.fn(),
     error: jest.fn(),
   },
+  configureStdioTransportLogging,
 }));
 
 const {createAppiumMcpServer} = await import('../create-server.js');
@@ -167,6 +172,7 @@ afterEach(() => {
   jest.mocked(log.error).mockReset();
   jest.mocked(log.info).mockReset();
   jest.mocked(log.warn).mockReset();
+  configureStdioTransportLogging.mockReset();
   delete process.env.APPIUM_MCP_ON_CLIENT_DISCONNECT;
 });
 
@@ -193,6 +199,24 @@ describe('createAppiumMcpServer plugin lifecycle', () => {
 
     expect(log.debug).toHaveBeenCalledWith('fastmcp debug');
     expect(log.info).toHaveBeenCalledWith('fastmcp log');
+  });
+
+  test('stdio start quiets logging; httpStream does not', async () => {
+    const server = await createAppiumMcpServer();
+
+    await server.start();
+    expect(configureStdioTransportLogging).toHaveBeenCalledTimes(1);
+
+    configureStdioTransportLogging.mockClear();
+    await server.start({transportType: 'stdio'});
+    expect(configureStdioTransportLogging).toHaveBeenCalledTimes(1);
+
+    configureStdioTransportLogging.mockClear();
+    await server.start({
+      transportType: 'httpStream',
+      httpStream: {port: 8080},
+    });
+    expect(configureStdioTransportLogging).not.toHaveBeenCalled();
   });
 
   test('registers plugin capabilities during construction but initializes lazily', async () => {

--- a/src/tests/fixtures/programmatic-stdio-wdio-child.ts
+++ b/src/tests/fixtures/programmatic-stdio-wdio-child.ts
@@ -1,0 +1,43 @@
+import http from 'node:http';
+
+import {createAppiumMcpServer} from '../../core.js';
+import {attachToRemoteSession} from '../../utils/url.js';
+
+const mockServer = http.createServer((_req, res) => {
+  res.writeHead(200, {'Content-Type': 'application/json; charset=utf-8'});
+  res.end(
+    JSON.stringify({
+      value: {
+        sessionId: 'test-session',
+        capabilities: {platformName: 'Android'},
+      },
+    }),
+  );
+});
+
+await new Promise<void>((resolve) => {
+  mockServer.listen(0, '127.0.0.1', () => resolve());
+});
+
+const {port} = mockServer.address() as {port: number};
+const remoteServerUrl = `http://127.0.0.1:${port}/`;
+
+try {
+  const server = await createAppiumMcpServer();
+  void server.start({transportType: 'stdio'});
+
+  const client = await attachToRemoteSession({
+    remoteServerUrl,
+    sessionId: 'test-session',
+    capabilities: {platformName: 'Android'},
+  });
+
+  await client.deleteSession();
+  process.stderr.write('child-done\n');
+  process.exit(0);
+} catch (err) {
+  process.stderr.write(`${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exit(1);
+} finally {
+  mockServer.close();
+}

--- a/src/tests/logger.test.ts
+++ b/src/tests/logger.test.ts
@@ -1,0 +1,73 @@
+import {afterEach, describe, expect, test} from '@jest/globals';
+
+import {configureStdioTransportLogging, ensureLoggerWritesToStderr, log} from '../logger.js';
+import {isStdioTransportLoggingConfigured, markStdioTransportLoggingConfigured} from '../stdio-logging-state.js';
+import {QUIET_WEBDRIVER_LOG_LEVEL, withQuietWebDriverLogging} from '../utils/webdriver-client-options.js';
+
+describe('stdio transport logging', () => {
+  const originalWdioLogLevel = process.env.WDIO_LOG_LEVEL;
+
+  afterEach(() => {
+    if (originalWdioLogLevel === undefined) {
+      delete process.env.WDIO_LOG_LEVEL;
+    } else {
+      process.env.WDIO_LOG_LEVEL = originalWdioLogLevel;
+    }
+  });
+
+  test('ensureLoggerWritesToStderr only replaces stdout', () => {
+    log.unwrap().stream = process.stdout;
+    ensureLoggerWritesToStderr();
+    expect(log.unwrap().stream).toBe(process.stderr);
+  });
+
+  test('ensureLoggerWritesToStderr leaves stderr and custom sinks in place', () => {
+    log.unwrap().stream = process.stderr;
+    ensureLoggerWritesToStderr();
+    expect(log.unwrap().stream).toBe(process.stderr);
+
+    const custom = {write: () => {}} as unknown as NodeJS.WriteStream;
+    log.unwrap().stream = custom;
+    ensureLoggerWritesToStderr();
+    expect(log.unwrap().stream).toBe(custom);
+  });
+
+  test('withQuietWebDriverLogging is a no-op until stdio logging is configured', () => {
+    expect(isStdioTransportLoggingConfigured()).toBe(false);
+    expect(
+      withQuietWebDriverLogging({
+        hostname: '127.0.0.1',
+        port: 4723,
+      }),
+    ).toEqual({
+      hostname: '127.0.0.1',
+      port: 4723,
+    });
+  });
+
+  test('configureStdioTransportLogging quiets info logs and WDIO when unset', () => {
+    delete process.env.WDIO_LOG_LEVEL;
+    log.unwrap().stream = process.stdout;
+
+    configureStdioTransportLogging();
+
+    expect(isStdioTransportLoggingConfigured()).toBe(true);
+    expect(log.unwrap().stream).toBe(process.stderr);
+    expect(log.level).toBe('warn');
+    expect(process.env.WDIO_LOG_LEVEL).toBe('warn');
+  });
+
+  test('withQuietWebDriverLogging sets warn after stdio logging is configured', () => {
+    markStdioTransportLoggingConfigured();
+    expect(
+      withQuietWebDriverLogging({
+        hostname: '127.0.0.1',
+        port: 4723,
+      }),
+    ).toEqual({
+      hostname: '127.0.0.1',
+      port: 4723,
+      logLevel: QUIET_WEBDRIVER_LOG_LEVEL,
+    });
+  });
+});

--- a/src/tests/logger.test.ts
+++ b/src/tests/logger.test.ts
@@ -1,4 +1,5 @@
 import {afterEach, describe, expect, test} from '@jest/globals';
+import wdioLogger from '@wdio/logger';
 
 import {configureStdioTransportLogging, ensureLoggerWritesToStderr, log} from '../logger.js';
 import {isStdioTransportLoggingConfigured, markStdioTransportLoggingConfigured} from '../stdio-logging-state.js';
@@ -48,6 +49,11 @@ describe('stdio transport logging', () => {
   test('configureStdioTransportLogging quiets info logs and WDIO when unset', () => {
     delete process.env.WDIO_LOG_LEVEL;
     log.unwrap().stream = process.stdout;
+    const utilsLogger = wdioLogger('@wdio/utils');
+    const webdriverLogger = wdioLogger('webdriver');
+    utilsLogger.setLevel('info');
+    webdriverLogger.setLevel('info');
+    const infoLevel = utilsLogger.getLevel();
 
     configureStdioTransportLogging();
 
@@ -55,6 +61,8 @@ describe('stdio transport logging', () => {
     expect(log.unwrap().stream).toBe(process.stderr);
     expect(log.level).toBe('warn');
     expect(process.env.WDIO_LOG_LEVEL).toBe('warn');
+    expect(utilsLogger.getLevel()).toBeGreaterThan(infoLevel);
+    expect(webdriverLogger.getLevel()).toBeGreaterThan(infoLevel);
   });
 
   test('withQuietWebDriverLogging sets warn after stdio logging is configured', () => {

--- a/src/tests/stdio-wdio-logging.test.ts
+++ b/src/tests/stdio-wdio-logging.test.ts
@@ -1,0 +1,69 @@
+import {spawn} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {describe, expect, test} from '@jest/globals';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const fixturePath = path.join(rootDir, 'dist/tests/fixtures/programmatic-stdio-wdio-child.js');
+
+function isJsonRpcLine(line: string): boolean {
+  if (!line.trim()) {
+    return true;
+  }
+  try {
+    const message = JSON.parse(line);
+    return typeof message === 'object' && message !== null && 'jsonrpc' in message;
+  } catch {
+    return false;
+  }
+}
+
+describe('programmatic stdio WDIO logging', () => {
+  test('keeps non-JSON-RPC output off stdout after core stdio start', async () => {
+    if (!existsSync(fixturePath)) {
+      throw new Error(`Compiled fixture missing at ${fixturePath}. Run npm run build first.`);
+    }
+
+    const {WDIO_LOG_LEVEL: _wdioLogLevel, ...env} = process.env;
+    const child = spawn(process.execPath, [fixturePath], {
+      cwd: rootDir,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error(`child process timed out\nstdout: ${stdout}\nstderr: ${stderr}`));
+      }, 15_000);
+
+      child.on('error', reject);
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        resolve(code ?? 1);
+      });
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain('child-done');
+
+    const nonEmptyStdoutLines = stdout.split('\n').filter((line) => line.trim().length > 0);
+    for (const line of nonEmptyStdoutLines) {
+      expect(isJsonRpcLine(line)).toBe(true);
+    }
+
+    expect(stdout).not.toMatch(/INFO\s+@wdio\/utils:/);
+    expect(stdout).not.toMatch(/INFO\s+webdriver:/);
+  }, 20_000);
+});

--- a/src/tools/session/create-session.ts
+++ b/src/tools/session/create-session.ts
@@ -12,6 +12,7 @@ import {setSession, listSessions} from '../../session-store.js';
 import {createUIResource, createSessionDashboardUI, addUIResourceToResponse} from '../../ui/mcp-ui-utils.js';
 import {findFreePort, releaseReservedPorts} from '../../utils/ports.js';
 import {getPortFromUrl} from '../../utils/url.js';
+import {withQuietWebDriverLogging} from '../../utils/webdriver-client-options.js';
 import {errorResult, textResult, toolErrorMessage} from '../tool-response.js';
 import {clearSelectedDevice, getSelectedLocalDevice} from './select-device.js';
 
@@ -355,14 +356,16 @@ export async function createSessionAction(args: {
       log.info(
         `Sending capabilities to remote server: ${protocol}://${remoteUrl.hostname}:${port}${remoteUrl.pathname}`,
       );
-      const client = await WebDriver.newSession({
-        protocol,
-        hostname: remoteUrl.hostname,
-        port,
-        path: remoteUrl.pathname,
-        ...(user && key ? {user, key} : {}),
-        capabilities: finalCapabilities,
-      });
+      const client = await WebDriver.newSession(
+        withQuietWebDriverLogging({
+          protocol,
+          hostname: remoteUrl.hostname,
+          port,
+          path: remoteUrl.pathname,
+          ...(user && key ? {user, key} : {}),
+          capabilities: finalCapabilities,
+        }),
+      );
       sessionId = client.sessionId;
       await setSession(client, client.sessionId, finalCapabilities, 'owned', args.remoteServerUrl);
     } else {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,7 @@
 import WebDriver, {type Client} from 'webdriver';
 
+import {withQuietWebDriverLogging} from './webdriver-client-options.js';
+
 export interface RemoteAttachOptions {
   remoteServerUrl: string;
   sessionId: string;
@@ -29,13 +31,15 @@ export async function attachToRemoteSession(options: RemoteAttachOptions): Promi
   const port = getPortFromUrl(url);
   const user = url.username ? decodeURIComponent(url.username) : undefined;
   const key = url.password ? decodeURIComponent(url.password) : undefined;
-  return WebDriver.attachToSession({
-    sessionId: options.sessionId,
-    protocol,
-    hostname: url.hostname,
-    port,
-    path: url.pathname,
-    capabilities: options.capabilities,
-    ...(user && key ? {user, key} : {}),
-  });
+  return WebDriver.attachToSession(
+    withQuietWebDriverLogging({
+      sessionId: options.sessionId,
+      protocol,
+      hostname: url.hostname,
+      port,
+      path: url.pathname,
+      capabilities: options.capabilities,
+      ...(user && key ? {user, key} : {}),
+    }),
+  );
 }

--- a/src/utils/wdio-logging.ts
+++ b/src/utils/wdio-logging.ts
@@ -1,0 +1,12 @@
+import wdioLogger from '@wdio/logger';
+
+import {QUIET_WEBDRIVER_LOG_LEVEL} from './webdriver-client-options.js';
+
+type WdioLogLevel = NonNullable<Parameters<typeof wdioLogger.setLogLevelsConfig>[1]>;
+
+/** Quiet every WDIO logger that was created before stdio config ran. */
+export function quietExistingWdioLoggers(
+  level: WdioLogLevel = (process.env.WDIO_LOG_LEVEL as WdioLogLevel | undefined) ?? QUIET_WEBDRIVER_LOG_LEVEL,
+): void {
+  wdioLogger.setLogLevelsConfig({}, level);
+}

--- a/src/utils/webdriver-client-options.ts
+++ b/src/utils/webdriver-client-options.ts
@@ -1,0 +1,16 @@
+import {isStdioTransportLoggingConfigured} from '../stdio-logging-state.js';
+
+export const QUIET_WEBDRIVER_LOG_LEVEL = 'warn' as const;
+
+/** `logLevel: warn` only after stdio logging is configured. */
+export function withQuietWebDriverLogging<T extends Record<string, unknown>>(
+  options: T,
+): T | (T & {logLevel: typeof QUIET_WEBDRIVER_LOG_LEVEL}) {
+  if (!isStdioTransportLoggingConfigured()) {
+    return options;
+  }
+  return {
+    ...options,
+    logLevel: QUIET_WEBDRIVER_LOG_LEVEL,
+  };
+}


### PR DESCRIPTION
Fixes #492.

Stdio MCP clients (Cursor included) treat stdout as JSON-RPC. Appium `info` lines, XCUITest page source, and WebDriver `ELEMENT` dumps were ending up on that stream, so the client failed to parse even when the tool itself succeeded.

Pin npmlog to stderr, quiet the stdio CLI to `warn` before startup, and create/attach WebDriver clients with `logLevel: warn`.