### PR TITLE
fix(device-control): shake remote iOS sessions

### DIFF
--- a/src/tests/tools/session/device-control.test.ts
+++ b/src/tests/tools/session/device-control.test.ts
@@ -1,0 +1,101 @@
+import {beforeEach, describe, expect, jest, test} from '@jest/globals';
+
+jest.unstable_mockModule('../../../persistence.js', () => ({
+  readAllPersistedSessions: jest.fn(async () => []),
+  removePersistedSession: jest.fn(async () => {}),
+}));
+
+jest.unstable_mockModule('../../../session-store.js', () => ({
+  getDriver: jest.fn(),
+  setSession: jest.fn(),
+  getPlatformName: jest.fn(),
+  isAndroidUiautomator2DriverSession: jest.fn(() => false),
+  isRemoteDriverSession: jest.fn(() => false),
+  isXCUITestDriverSession: jest.fn(() => false),
+  PLATFORM: {ios: 'iOS', android: 'Android'},
+}));
+
+jest.unstable_mockModule('../../../command.js', () => ({
+  execute: jest.fn(async () => {}),
+}));
+
+jest.unstable_mockModule('../../../logger.js', () => ({
+  default: {debug: () => {}, info: () => {}, warn: () => {}, error: () => {}},
+}));
+
+const {getDriver, getPlatformName, isRemoteDriverSession, isXCUITestDriverSession, PLATFORM} =
+  await import('../../../session-store.js');
+const {execute} = await import('../../../command.js');
+
+const mockGetDriver = getDriver as jest.MockedFunction<typeof getDriver>;
+const mockGetPlatformName = getPlatformName as jest.MockedFunction<typeof getPlatformName>;
+const mockIsRemoteDriverSession = isRemoteDriverSession as jest.MockedFunction<typeof isRemoteDriverSession>;
+const mockIsXCUITestDriverSession = isXCUITestDriverSession as jest.MockedFunction<typeof isXCUITestDriverSession>;
+const mockExecute = execute as jest.MockedFunction<typeof execute>;
+
+const mockServer = {addTool: jest.fn()} as any;
+
+async function getToolExecute() {
+  const {default: mobileDeviceControl} = await import('../../../tools/session/device-control.js');
+  mobileDeviceControl(mockServer);
+  return (mockServer.addTool as jest.MockedFunction<any>).mock.calls.at(-1)?.[0];
+}
+
+function textFromResult(result: {content: Array<{type: string; text?: string}>}): string | undefined {
+  const block = result.content[0];
+  return block && 'text' in block ? block.text : undefined;
+}
+
+describe('appium_mobile_device_control shake', () => {
+  beforeEach(() => {
+    mockGetDriver.mockReset();
+    mockGetPlatformName.mockReset();
+    mockIsRemoteDriverSession.mockReset();
+    mockIsXCUITestDriverSession.mockReset();
+    mockExecute.mockReset();
+    mockIsRemoteDriverSession.mockReturnValue(false);
+    mockIsXCUITestDriverSession.mockReturnValue(false);
+  });
+
+  test('remote iOS sessions use mobile: shake', async () => {
+    const driver = {sessionId: 'remote-ios'};
+    mockGetDriver.mockReturnValue(driver as any);
+    mockGetPlatformName.mockReturnValue(PLATFORM.ios);
+    mockIsRemoteDriverSession.mockReturnValue(true);
+
+    const tool = await getToolExecute();
+    const result = await tool.execute({action: 'shake'}, undefined);
+
+    expect(result.isError).toBeFalsy();
+    expect(textFromResult(result)).toBe('Shake action performed.');
+    expect(mockExecute).toHaveBeenCalledWith(driver as never, 'mobile: shake', {});
+  });
+
+  test('embedded XCUITest sessions call mobileShake', async () => {
+    const mobileShake = jest.fn(async () => {});
+    const driver = {mobileShake};
+    mockGetDriver.mockReturnValue(driver as any);
+    mockGetPlatformName.mockReturnValue(PLATFORM.ios);
+    mockIsXCUITestDriverSession.mockReturnValue(true);
+
+    const tool = await getToolExecute();
+    const result = await tool.execute({action: 'shake'}, undefined);
+
+    expect(result.isError).toBeFalsy();
+    expect(mobileShake).toHaveBeenCalledTimes(1);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  test('non-iOS platforms return a platform mismatch', async () => {
+    mockGetDriver.mockReturnValue({sessionId: 'remote-android'} as any);
+    mockGetPlatformName.mockReturnValue(PLATFORM.android);
+    mockIsRemoteDriverSession.mockReturnValue(true);
+
+    const tool = await getToolExecute();
+    const result = await tool.execute({action: 'shake'}, undefined);
+
+    expect(result.isError).toBe(true);
+    expect(textFromResult(result)).toBe("action=shake is iOS-only. Current session platform is 'Android'.");
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/session/device-control.ts
+++ b/src/tools/session/device-control.ts
@@ -90,10 +90,19 @@ async function handleUnlock(driver: DriverInstance): Promise<ContentResult> {
 }
 
 async function handleShake(driver: DriverInstance): Promise<ContentResult> {
-  if (!isXCUITestDriverSession(driver)) {
-    return platformMismatch('shake', 'iOS', getPlatformName(driver));
+  const platform = getPlatformName(driver);
+  if (platform !== PLATFORM.ios) {
+    return platformMismatch('shake', 'iOS', platform);
   }
-  await (driver as any).mobileShake();
+
+  if (isXCUITestDriverSession(driver)) {
+    await driver.mobileShake();
+  } else if (isRemoteDriverSession(driver)) {
+    await execute(driver, 'mobile: shake', {});
+  } else {
+    return errorResult('Unsupported iOS driver for shake');
+  }
+
   return textResult('Shake action performed.');
 }
 


### PR DESCRIPTION
On a remote iOS session, `action=shake` fails with:

```
action=shake is iOS-only. Current session platform is 'iOS'.
```

`handleShake` treated anything that is not an in-process XCUITest driver as the wrong platform. Remote attach/create uses a WebDriver client, so shake never ran.

Fix: check platform first, then call `mobileShake()` for embedded XCUITest and `mobile: shake` for remote. Android still gets the real platform mismatch.

## Tests
- [x] remote iOS uses `mobile: shake`
- [x] embedded XCUITest still calls `mobileShake()`
- [x] Android returns the platform mismatch