### PR TITLE
fix(command): re-throw swallowed remote errors for orientation and back

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -420,7 +420,9 @@ export async function getOrientation(driver: DriverInstance): Promise<'LANDSCAPE
   } else if (isXCUITestDriverSession(driver)) {
     return (await driver.proxyCommand('/orientation', 'GET')) as 'LANDSCAPE' | 'PORTRAIT';
   }
-  return (await driver.getOrientation()) as 'LANDSCAPE' | 'PORTRAIT';
+  const result = await driver.getOrientation();
+  throwIfSwallowedRemoteError(result);
+  return result as 'LANDSCAPE' | 'PORTRAIT';
 }
 
 /**
@@ -435,7 +437,8 @@ export async function setOrientation(driver: DriverInstance, orientation: 'LANDS
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.proxyCommand('/orientation', 'POST', {orientation});
   }
-  return await driver.setOrientation(orientation);
+  const result = await driver.setOrientation(orientation);
+  throwIfSwallowedRemoteError(result);
 }
 
 /**
@@ -540,7 +543,8 @@ export async function back(driver: DriverInstance): Promise<void> {
   } else if (isXCUITestDriverSession(driver)) {
     return await driver.back();
   }
-  return await (driver as Client).back();
+  const result = await (driver as Client).back();
+  throwIfSwallowedRemoteError(result);
 }
 
 interface SimctlExecResponse {

--- a/src/tests/command.test.ts
+++ b/src/tests/command.test.ts
@@ -25,6 +25,9 @@ const {
   getWindowSize,
   performActions,
   queryAppState,
+  getOrientation,
+  setOrientation,
+  back,
 } = await import('../command.js');
 
 // What the remote client resolves with when it swallows a WebDriver error.
@@ -234,5 +237,28 @@ describe('remote command wrappers: re-throw swallowed WebDriver errors', () => {
     await expect(
       getWindowSize({getWindowRect: jest.fn(async () => ({x: 0, y: 0, width: 320, height: 640}))} as never),
     ).resolves.toEqual({width: 320, height: 640});
+  });
+
+  test('getOrientation re-throws swallowed error values', async () => {
+    await expect(getOrientation({getOrientation: jest.fn(async () => NO_SUCH_ELEMENT_VALUE)} as never)).rejects.toThrow(
+      /could not be located/i,
+    );
+    await expect(getOrientation({getOrientation: jest.fn(async () => 'PORTRAIT')} as never)).resolves.toBe('PORTRAIT');
+  });
+
+  test('setOrientation re-throws swallowed error values', async () => {
+    await expect(
+      setOrientation({setOrientation: jest.fn(async () => NO_SUCH_ELEMENT_VALUE)} as never, 'LANDSCAPE'),
+    ).rejects.toThrow(/could not be located/i);
+    await expect(
+      setOrientation({setOrientation: jest.fn(async () => undefined)} as never, 'LANDSCAPE'),
+    ).resolves.toBeUndefined();
+  });
+
+  test('back re-throws swallowed error values', async () => {
+    await expect(back({back: jest.fn(async () => NO_SUCH_ELEMENT_VALUE)} as never)).rejects.toThrow(
+      /could not be located/i,
+    );
+    await expect(back({back: jest.fn(async () => undefined)} as never)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
Follow-up to #497.. a few remote wrappers in command.ts were still returning swallowed WebDriver error objects as success.

The important one is setOrientation, It drops the return value, so a remote failure still comes back as a successful rotation getOrientation and back get the same guard so the pair stays consistent.

## Tests
- command.test.ts (23 tests) --> passed